### PR TITLE
Edit entries on review stage

### DIFF
--- a/backend/lib/richard_burton_web/controllers/publication_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/publication_controller.ex
@@ -44,6 +44,18 @@ defmodule RichardBurtonWeb.PublicationController do
     end
   end
 
+  def validate(conn, %{"_json" => publications}) do
+    result =
+      publications
+      |> Publication.Codec.nest()
+      |> Enum.map(&validate_publication/1)
+      |> Publication.Codec.flatten()
+
+    conn
+    |> put_status(:ok)
+    |> json(result)
+  end
+
   defp validate_publication(p) do
     case Publication.validate(p) do
       {:ok, ^p} -> %{publication: p, errors: nil}

--- a/backend/lib/richard_burton_web/router.ex
+++ b/backend/lib/richard_burton_web/router.ex
@@ -6,7 +6,7 @@ defmodule RichardBurtonWeb.Router do
   end
 
   pipeline :validate do
-    plug(:accepts, ["text/csv"])
+    plug(:accepts, ["json", "text/csv"])
   end
 
   scope "/api", RichardBurtonWeb do

--- a/backend/test/richard_burton_web/controllers/publication_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/publication_controller_test.exs
@@ -78,6 +78,88 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
     end
   end
 
+  describe "POST /publications/validate when sending valid json" do
+    @correct_input_1 %{
+      "title" => "Iraçéma the Honey-Lips: A Legend of Brazil",
+      "year" => "1886",
+      "country" => "GB",
+      "publisher" => "Bickers & Son",
+      "authors" => "Isabel Burton",
+      "original_authors" => "José de Alencar",
+      "original_title" => "Iracema"
+    }
+    @correct_input_2 %{
+      "title" => "Ubirajara: A Legend of the Tupy Indians",
+      "year" => "1922",
+      "country" => "US",
+      "publisher" => "Ronald Massey",
+      "authors" => "J. T. W. Sadler",
+      "original_authors" => "José de Alencar",
+      "original_title" => "Ubirajara"
+    }
+    @correct_input_3 %{
+      "title" => "",
+      "year" => "AAAA",
+      "country" => "GB",
+      "publisher" => "Bickers & Son",
+      "authors" => "",
+      "original_authors" => "José de Alencar",
+      "original_title" => "Iracema"
+    }
+    @correct_input_4 %{
+      "title" => "Ubirajara: A Legend of the Tupy Indians",
+      "year" => "",
+      "country" => "",
+      "publisher" => "",
+      "authors" => "J. T. W. Sadler",
+      "original_authors" => "",
+      "original_title" => ""
+    }
+
+    @input [
+      @correct_input_1,
+      @correct_input_2,
+      @correct_input_3,
+      @correct_input_4
+    ]
+
+    @output [
+      %{
+        "publication" => @correct_input_1,
+        "errors" => nil
+      },
+      %{
+        "publication" => @correct_input_2,
+        "errors" => nil
+      },
+      %{
+        "publication" => @correct_input_3,
+        "errors" => %{
+          "year" => "integer",
+          "title" => "required",
+          "authors" => "required"
+        }
+      },
+      %{
+        "publication" => @correct_input_4,
+        "errors" => %{
+          "year" => "required",
+          "country" => "required",
+          "publisher" => "required",
+          "original_authors" => "required",
+          "original_title" => "required"
+        }
+      }
+    ]
+
+    test "returns 200 a list of maps with the publications an their corresponding errors", meta do
+      assert @output ==
+               meta.conn
+               |> post(publication_path(meta.conn, :validate), %{"_json" => @input})
+               |> json_response(200)
+    end
+  end
+
   describe "POST /publications/validate when sending correct csv" do
     @output [
       %{

--- a/frontend/components/PublicationIndex.tsx
+++ b/frontend/components/PublicationIndex.tsx
@@ -67,16 +67,20 @@ const SignalColumn: FC<SignalColumnProps> = ({ publicationId }) => {
   );
 };
 
-type DataColumnProps = {
-  attribute: PublicationKey;
+type DataInputProps = {
   publicationId: PublicationId;
-  editable: boolean;
+  attribute: PublicationKey;
+  data: string | number;
 };
 
-type DataInputProps = { data: string | number };
-
-const DataInput: FC<DataInputProps> = ({ data }) => {
+const DataInput: FC<DataInputProps> = ({
+  publicationId,
+  attribute,
+  data,
+}) => {
   const [value, setValue] = useState(data);
+
+  const override = Publication.STORE.ATTRIBUTES.useOverride();
 
   return (
     <input
@@ -86,9 +90,15 @@ const DataInput: FC<DataInputProps> = ({ data }) => {
       )}
       value={value}
       onChange={(e) => setValue(e.target.value)}
-      onBlur={() => setValue(data)}
+      onBlur={() => override(publicationId, attribute, value)}
     />
   );
+};
+
+type DataColumnProps = {
+  attribute: PublicationKey;
+  publicationId: PublicationId;
+  editable: boolean;
 };
 
 const DataColumn: FC<DataColumnProps> = ({

--- a/frontend/components/PublicationIndex.tsx
+++ b/frontend/components/PublicationIndex.tsx
@@ -104,7 +104,7 @@ const DataInput: FC<DataInputProps> = ({
   }, [data, publicationId, validate, setValue]);
 
   const handleBlur = () => {
-    if (value.current) {
+    if (data !== value.current) {
       override(publicationId, attribute, value.current);
       validate([publicationId]);
     }

--- a/frontend/components/PublicationIndex.tsx
+++ b/frontend/components/PublicationIndex.tsx
@@ -21,7 +21,6 @@ import {
   useIsSelectionEmpty,
   useSelectionEvent,
 } from "react-selection-manager";
-import { isElement } from "lodash";
 
 const COUNTRIES: Record<string, string> = {
   BR: "Brazil",

--- a/frontend/components/PublicationIndex.tsx
+++ b/frontend/components/PublicationIndex.tsx
@@ -9,6 +9,7 @@ import {
   MouseEvent,
   MouseEventHandler,
   PropsWithChildren,
+  useEffect,
   useState,
 } from "react";
 import ErrorTooltip from "./ErrorTooltip";
@@ -79,6 +80,8 @@ const DataInput: FC<DataInputProps> = ({
   data,
 }) => {
   const [value, setValue] = useState(data);
+
+  useEffect(() => setValue(data), [data]);
 
   const override = Publication.STORE.ATTRIBUTES.useOverride();
 

--- a/frontend/components/PublicationIndex.tsx
+++ b/frontend/components/PublicationIndex.tsx
@@ -14,14 +14,11 @@ import {
 } from "react";
 import ErrorTooltip from "./ErrorTooltip";
 import {
-  useClearSelection,
   useIsSelected,
   useIsSelectionEmpty,
   useSelectionEvent,
 } from "react-selection-manager";
 import { isElement } from "lodash";
-
-type NativeMouseEvent = globalThis.MouseEvent;
 
 const COUNTRIES: Record<string, string> = {
   BR: "Brazil",
@@ -212,7 +209,6 @@ const PublicationIndex: FC<Props> = ({ editable = false }) => {
 
   const onSelect = useSelectionEvent();
   const isSelectionEmpty = useIsSelectionEmpty();
-  const clearSelection = useClearSelection();
 
   const toggleSelection = (id: number) => (event: MouseEvent) =>
     onSelect({
@@ -222,21 +218,6 @@ const PublicationIndex: FC<Props> = ({ editable = false }) => {
       metaKey: event.metaKey,
       orderedIds: ids,
     });
-
-  useEffect(() => {
-    const handle = (event: NativeMouseEvent) => {
-      const target = event.target as HTMLElement;
-
-      if (isElement(target) && !target.matches('[data-selectable="true"]')) {
-        clearSelection();
-      }
-    };
-
-    document.addEventListener("click", handle);
-    return () => {
-      document.removeEventListener("click", handle);
-    };
-  }, [clearSelection]);
 
   return (
     <table

--- a/frontend/components/PublicationIndex.tsx
+++ b/frontend/components/PublicationIndex.tsx
@@ -4,7 +4,13 @@ import {
   PublicationId,
   PublicationKey,
 } from "modules/publications";
-import { FC, MouseEvent, MouseEventHandler, PropsWithChildren } from "react";
+import {
+  FC,
+  MouseEvent,
+  MouseEventHandler,
+  PropsWithChildren,
+  useState,
+} from "react";
 import ErrorTooltip from "./ErrorTooltip";
 import {
   useIsSelected,
@@ -34,7 +40,7 @@ const Column: FC<ColumnProps> = ({ className, children, publicationId }) => {
     <td
       className={classNames(
         className,
-        "max-w-xs px-2 py-1 truncate justify",
+        "max-w-xs px-2 py-1 justify",
         isValid ? "group-hover:bg-indigo-100" : "group-hover:bg-red-100",
         { "bg-amber-100": isSelected }
       )}
@@ -67,6 +73,24 @@ type DataColumnProps = {
   editable: boolean;
 };
 
+type DataInputProps = { data: string | number };
+
+const DataInput: FC<DataInputProps> = ({ data }) => {
+  const [value, setValue] = useState(data);
+
+  return (
+    <input
+      className={classNames(
+        "px-2 py-1",
+        "bg-transparent focus:bg-white/50 focus:shadow rounded outline-none"
+      )}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={() => setValue(data)}
+    />
+  );
+};
+
 const DataColumn: FC<DataColumnProps> = ({
   attribute,
   publicationId,
@@ -78,6 +102,13 @@ const DataColumn: FC<DataColumnProps> = ({
   const value = useValue(publicationId, attribute);
   const error = useErrorDescription(publicationId, attribute);
   const isVisible = useIsVisible(attribute);
+  const className = classNames(
+    "px-2 py-1 truncate",
+    error &&
+      "border rounded border-dotted border-red-300 hover:bg-red-300 hover:text-white "
+  );
+
+  const content = attribute === "country" ? COUNTRIES[value] : value;
 
   return isVisible ? (
     <Column publicationId={publicationId}>
@@ -87,15 +118,11 @@ const DataColumn: FC<DataColumnProps> = ({
         disabled={!editable}
         boundary="main"
       >
-        <div
-          className={classNames(
-            "px-2 py-1 truncate",
-            error &&
-              "border rounded border-dotted border-red-300 hover:bg-red-300 hover:text-white "
-          )}
-        >
-          {attribute === "country" ? COUNTRIES[value] : value}
-        </div>
+        {editable ? (
+          <DataInput data={content} />
+        ) : (
+          <div className={className}>{content}</div>
+        )}
       </ErrorTooltip>
     </Column>
   ) : null;

--- a/frontend/components/PublicationIndex.tsx
+++ b/frontend/components/PublicationIndex.tsx
@@ -72,12 +72,14 @@ type DataInputProps = {
   publicationId: PublicationId;
   attribute: PublicationKey;
   data: string | number;
+  hasError: boolean;
 };
 
 const DataInput: FC<DataInputProps> = ({
   publicationId,
   attribute,
   data,
+  hasError,
 }) => {
   const [value, setValue] = useState(data);
 
@@ -88,8 +90,10 @@ const DataInput: FC<DataInputProps> = ({
   return (
     <input
       className={classNames(
-        "px-2 py-1",
-        "bg-transparent focus:bg-white/50 focus:shadow rounded outline-none"
+        "px-2 py-1 rounded outline-none bg-transparent",
+        hasError
+          ? "focus:bg-red-400/80 bg-red-300/40 focus:text-white shadow-sm"
+          : "focus:bg-white/50 focus:shadow-sm"
       )}
       value={value}
       onChange={(e) => setValue(e.target.value)}
@@ -115,11 +119,6 @@ const DataColumn: FC<DataColumnProps> = ({
   const value = useValue(publicationId, attribute);
   const error = useErrorDescription(publicationId, attribute);
   const isVisible = useIsVisible(attribute);
-  const className = classNames(
-    "px-2 py-1 truncate",
-    error &&
-      "border rounded border-dotted border-red-300 hover:bg-red-300 hover:text-white "
-  );
 
   const content = attribute === "country" ? COUNTRIES[value] : value;
 
@@ -132,9 +131,14 @@ const DataColumn: FC<DataColumnProps> = ({
         boundary="main"
       >
         {editable ? (
-          <DataInput data={content} />
+          <DataInput
+            publicationId={publicationId}
+            attribute={attribute}
+            data={content}
+            hasError={Boolean(error)}
+          />
         ) : (
-          <div className={className}>{content}</div>
+          <div className="px-2 py-1 truncate">{content}</div>
         )}
       </ErrorTooltip>
     </Column>

--- a/frontend/components/PublicationIndex.tsx
+++ b/frontend/components/PublicationIndex.tsx
@@ -72,10 +72,11 @@ const DataColumn: FC<DataColumnProps> = ({
   publicationId,
   editable,
 }) => {
-  const { useIsVisible, useValue, useError } = Publication.STORE.ATTRIBUTES;
+  const { useIsVisible, useValue, useErrorDescription } =
+    Publication.STORE.ATTRIBUTES;
 
   const value = useValue(publicationId, attribute);
-  const error = useError(publicationId, attribute);
+  const error = useErrorDescription(publicationId, attribute);
   const isVisible = useIsVisible(attribute);
 
   return isVisible ? (
@@ -107,10 +108,10 @@ type RowProps = {
 };
 
 const Row: FC<RowProps> = ({ publicationId, editable, onClick }) => {
-  const { useIsValid, useError } = Publication.STORE;
+  const { useIsValid, useErrorDescription } = Publication.STORE;
 
   const isValid = useIsValid(publicationId);
-  const error = useError(publicationId);
+  const error = useErrorDescription(publicationId);
 
   return (
     <ErrorTooltip

--- a/frontend/components/PublicationIndex.tsx
+++ b/frontend/components/PublicationIndex.tsx
@@ -88,6 +88,14 @@ const DataInput: FC<DataInputProps> = ({
   useEffect(() => setValue(data), [data]);
 
   const override = Publication.STORE.ATTRIBUTES.useOverride();
+  const validate = Publication.REMOTE.useValidate();
+
+  const handleBlur = () => {
+    override(publicationId, attribute, value);
+    if (data !== value) {
+      validate([publicationId]);
+    }
+  };
 
   return (
     <input
@@ -99,7 +107,7 @@ const DataInput: FC<DataInputProps> = ({
       )}
       value={value}
       onChange={(e) => setValue(e.target.value)}
-      onBlur={() => override(publicationId, attribute, value)}
+      onBlur={handleBlur}
     />
   );
 };

--- a/frontend/components/PublicationToolbar.tsx
+++ b/frontend/components/PublicationToolbar.tsx
@@ -2,7 +2,6 @@ import { ChangeEvent, FC, useEffect, useState } from "react";
 import { API } from "app";
 import { useRecoilCallback } from "recoil";
 import { useNotifyError } from "./Errors";
-import { range } from "lodash";
 import axios from "axios";
 import Button from "./Button";
 import Router from "next/router";
@@ -28,11 +27,19 @@ const ToolbarHeading: FC<{ label: string }> = ({ label }) => (
 );
 
 const PublicationEdit: FC = () => {
-  const { useDeletedCount, useSetDeleted, useResetDeleted } = Publication.STORE;
+  const {
+    useDeletedCount,
+    useOverriddenCount,
+    useSetDeleted,
+    useResetDeleted,
+    useResetOverridden,
+  } = Publication.STORE;
 
   const setDeleted = useSetDeleted();
   const resetDeleted = useResetDeleted();
+  const resetOverridden = useResetOverridden();
   const deletedCount = useDeletedCount();
+  const overriddenCount = useOverriddenCount();
 
   const selectionSize = useSelectionSize();
   const clearSelection = useClearSelection();
@@ -47,11 +54,14 @@ const PublicationEdit: FC = () => {
 
   const reset = () => {
     resetDeleted();
+    resetOverridden();
     clearSelection();
   };
 
   const isSelectionEmpty = selectionSize === 0;
   const isDeletionSetEmpty = deletedCount === 0;
+  const isOverrideSetEmpty = overriddenCount === 0;
+  const isResetEnabled = !isDeletionSetEmpty || !isOverrideSetEmpty;
 
   return (
     <section className="flex flex-col grow">
@@ -64,16 +74,16 @@ const PublicationEdit: FC = () => {
             onClick={deleteSelected}
           />
         )}
-        {isSelectionEmpty && isDeletionSetEmpty && (
-          <div className="flex items-center justify-center grow">
-            <p className="self-center m-3 text-sm text-center text-gray-400">
-              Select publications by clicking on them to start editing
-            </p>
-          </div>
-        )}
+
+        <div className="flex items-center justify-center grow">
+          <p className="self-center m-3.5 text-sm text-center text-gray-400">
+            Select publications to delete them, or click on the columns to start
+            editing
+          </p>
+        </div>
       </div>
 
-      {!isDeletionSetEmpty && (
+      {isResetEnabled && (
         <footer className="mt-auto">
           <Button type="outline" label="Reset" onClick={reset} />
         </footer>

--- a/frontend/components/PublicationToolbar.tsx
+++ b/frontend/components/PublicationToolbar.tsx
@@ -6,9 +6,7 @@ import {
   useEffect,
   useState,
 } from "react";
-import { useRecoilCallback } from "recoil";
-import { useNotifyError, _ERRORS, _notify } from "./Errors";
-import axios from "axios";
+import { _ERRORS, _notify } from "./Errors";
 import Button from "./Button";
 import Router from "next/router";
 import Toggle from "./Toggle";

--- a/frontend/components/PublicationToolbar.tsx
+++ b/frontend/components/PublicationToolbar.tsx
@@ -133,12 +133,9 @@ const PublicationUpload: FC = () => {
             Omit<PublicationEntry, "id">[]
           >("publications/validate", data);
 
-          const ids = range(0, parsed.length);
-
           setPublications(
-            ids,
             parsed.map(({ publication, errors }, index) => ({
-              id: ids[index],
+              id: index,
               publication,
               errors,
             }))
@@ -195,9 +192,7 @@ const PublicationToolbar: FC<Props> = ({
     ({ snapshot }) =>
       async () => {
         try {
-          const publications = Publication.STORE.from(snapshot)
-            .getAllVisible()
-            .map(({ publication }) => publication);
+          const publications = Publication.STORE.from(snapshot).getAllVisible();
 
           await API.post("publications/bulk", publications);
 

--- a/frontend/listeners/ClearSelection.tsx
+++ b/frontend/listeners/ClearSelection.tsx
@@ -1,0 +1,25 @@
+import { isElement } from "lodash";
+import { FC, useEffect } from "react";
+import { useClearSelection } from "react-selection-manager";
+
+const ClearSelection: FC = () => {
+  const clearSelection = useClearSelection();
+  useEffect(() => {
+    const handle = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+
+      if (isElement(target) && !target.matches('[data-selectable="true"]')) {
+        clearSelection();
+      }
+    };
+
+    document.addEventListener("click", handle);
+    return () => {
+      document.removeEventListener("click", handle);
+    };
+  }, [clearSelection]);
+
+  return null;
+};
+
+export default ClearSelection;

--- a/frontend/modules/publications.ts
+++ b/frontend/modules/publications.ts
@@ -48,15 +48,15 @@ const PUBLICATION_ERROR = selectorFamily<string, PublicationId>({
   },
 });
 
-const DELETED_PUBLICATIONS = atomFamily<boolean, PublicationId>({
-  key: "deleted-publications",
+const IS_PUBLICATION_DELETED = atomFamily<boolean, PublicationId>({
+  key: "is-publication-deleted",
   default: false,
 });
 
 const DELETED_PUBLICATIONS_IDS = selector<PublicationId[]>({
   key: "deleted-publications-ids",
   get({ get }) {
-    return get(PUBLICATION_IDS).filter((id) => get(DELETED_PUBLICATIONS(id)));
+    return get(PUBLICATION_IDS).filter((id) => get(IS_PUBLICATION_DELETED(id)));
   },
 });
 
@@ -70,7 +70,9 @@ const DELETED_PUBLICATION_COUNT = selector<number>({
 const VISIBLE_PUBLICATION_IDS = selector<PublicationId[]>({
   key: "visible-publications-ids",
   get({ get }) {
-    return get(PUBLICATION_IDS).filter((id) => !get(DELETED_PUBLICATIONS(id)));
+    return get(PUBLICATION_IDS).filter(
+      (id) => !get(IS_PUBLICATION_DELETED(id))
+    );
   },
 });
 
@@ -81,8 +83,8 @@ const VISIBLE_PUBLICATION_COUNT = selector<number>({
   },
 });
 
-const VALID_PUBLICATIONS = selectorFamily<boolean, PublicationId>({
-  key: "valid-publications",
+const IS_PUBLICATION_VALID = selectorFamily<boolean, PublicationId>({
+  key: "is-publication-valid",
   get(id) {
     return function ({ get }) {
       return !Boolean(get(PUBLICATIONS(id)).errors);
@@ -94,8 +96,8 @@ const VALID_PUBLICATIONS_IDS = selector<number[]>({
   key: "valid-publication-ids",
   get({ get }) {
     return get(PUBLICATION_IDS)
-      .filter((id) => !get(DELETED_PUBLICATIONS(id)))
-      .filter((id) => get(VALID_PUBLICATIONS(id)));
+      .filter((id) => !get(IS_PUBLICATION_DELETED(id)))
+      .filter((id) => get(IS_PUBLICATION_VALID(id)));
   },
 });
 
@@ -239,7 +241,7 @@ const Publication: PublicationModule = {
       return useRecoilCallback(
         ({ set }) =>
           (ids, isDeleted = true) => {
-            ids.forEach((id) => set(DELETED_PUBLICATIONS(id), isDeleted));
+            ids.forEach((id) => set(IS_PUBLICATION_DELETED(id), isDeleted));
           },
         []
       );
@@ -251,7 +253,7 @@ const Publication: PublicationModule = {
             const ids = snapshot.getLoadable(PUBLICATION_IDS).valueOrThrow();
             ids.forEach((id) => {
               reset(PUBLICATIONS(id));
-              reset(DELETED_PUBLICATIONS(id));
+              reset(IS_PUBLICATION_DELETED(id));
             });
             reset(PUBLICATION_IDS);
           },
@@ -266,14 +268,14 @@ const Publication: PublicationModule = {
               .getLoadable(DELETED_PUBLICATIONS_IDS)
               .valueOrThrow()
               .forEach((id) => {
-                reset(DELETED_PUBLICATIONS(id));
+                reset(IS_PUBLICATION_DELETED(id));
               });
           },
         []
       );
     },
     useIsValid(id) {
-      return useRecoilValue(VALID_PUBLICATIONS(id));
+      return useRecoilValue(IS_PUBLICATION_VALID(id));
     },
 
     useVisibleCount() {
@@ -300,7 +302,7 @@ const Publication: PublicationModule = {
         return getVisibleIds().map(getValue);
       },
       isDeleted(id) {
-        return snapshot.getLoadable(DELETED_PUBLICATIONS(id)).valueOrThrow();
+        return snapshot.getLoadable(IS_PUBLICATION_DELETED(id)).valueOrThrow();
       },
     }),
 

--- a/frontend/modules/publications.ts
+++ b/frontend/modules/publications.ts
@@ -39,8 +39,8 @@ const PUBLICATIONS = atomFamily<PublicationEntry, PublicationId>({
   default: undefined,
 });
 
-const PUBLICATION_ERROR = selectorFamily<string, PublicationId>({
-  key: "publication-error",
+const PUBLICATION_ERROR_DESCRIPTION = selectorFamily<string, PublicationId>({
+  key: "publication-error-description",
   get(id) {
     return function ({ get }) {
       return Publication.describe(get(PUBLICATIONS(id)).errors);
@@ -138,11 +138,11 @@ const PUBLICATION_ATTRIBUTE = selectorFamily<
   },
 });
 
-const PUBLICATION_ATTRIBUTE_ERROR = selectorFamily<
+const PUBLICATION_ATTRIBUTE_ERROR_DESCRIPTION = selectorFamily<
   string,
   CompositeAttributeId
 >({
-  key: "publication-error",
+  key: "publication-attribute-error-description",
   get(compositeId) {
     return function ({ get }) {
       const [id, key] = compositeId.split(".") as [string, PublicationKey];
@@ -165,7 +165,7 @@ interface PublicationModule {
   STORE: {
     useVisibleIds(): PublicationId[];
     useValue(id: PublicationId): PublicationEntry;
-    useError(id: PublicationId): string;
+    useErrorDescription(id: PublicationId): string;
     useSetAll(): (ids: PublicationId[], entries: PublicationEntry[]) => void;
     useSetDeleted(): (ids: PublicationId[], isDeleted?: boolean) => void;
     useResetAll(): Resetter;
@@ -191,7 +191,7 @@ interface PublicationModule {
         id: PublicationId,
         key: K
       ): Publication[K];
-      useError(id: PublicationId, key: PublicationKey): string;
+      useErrorDescription(id: PublicationId, key: PublicationKey): string;
     };
   };
 
@@ -224,8 +224,8 @@ const Publication: PublicationModule = {
     useValue(id) {
       return useRecoilValue(PUBLICATIONS(id));
     },
-    useError(id) {
-      return useRecoilValue(PUBLICATION_ERROR(id));
+    useErrorDescription(id) {
+      return useRecoilValue(PUBLICATION_ERROR_DESCRIPTION(id));
     },
     useSetAll() {
       return useRecoilCallback(
@@ -333,9 +333,11 @@ const Publication: PublicationModule = {
           PUBLICATION_ATTRIBUTE(compositeId)
         ) as Publication[K];
       },
-      useError(id, key) {
+      useErrorDescription(id, key) {
         const compositeId: CompositeAttributeId = `${id}.${key}`;
-        return useRecoilValue(PUBLICATION_ATTRIBUTE_ERROR(compositeId));
+        return useRecoilValue(
+          PUBLICATION_ATTRIBUTE_ERROR_DESCRIPTION(compositeId)
+        );
       },
     },
   },

--- a/frontend/modules/publications.ts
+++ b/frontend/modules/publications.ts
@@ -322,6 +322,7 @@ const Publication: PublicationModule = {
             ids.forEach((id) => {
               reset(PUBLICATIONS(id));
               reset(PUBLICATION_OVERRIDES(id));
+              reset(PUBLICATION_ERRORS(id));
               reset(IS_PUBLICATION_DELETED(id));
             });
             reset(PUBLICATION_IDS);

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,10 +1,10 @@
 import "styles/globals.css";
 import type { AppProps } from "next/app";
-import { FC, useCallback } from "react";
-import axios, { Axios, AxiosInstance } from "axios";
+import { FC } from "react";
+import axios, { AxiosInstance } from "axios";
 import axiosCaseConverter from "axios-case-converter";
-import { RecoilRoot, useRecoilCallback } from "recoil";
-import Errors, { useNotifyError } from "components/Errors";
+import { RecoilRoot } from "recoil";
+import Errors from "components/Errors";
 import ClearSelection from "listeners/ClearSelection";
 
 const http = axiosCaseConverter(

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,17 +1,42 @@
 import "styles/globals.css";
 import type { AppProps } from "next/app";
-import { FC } from "react";
-import axios from "axios";
+import { FC, useCallback } from "react";
+import axios, { Axios, AxiosInstance } from "axios";
 import axiosCaseConverter from "axios-case-converter";
-import { RecoilRoot } from "recoil";
-import Errors from "components/Errors";
+import { RecoilRoot, useRecoilCallback } from "recoil";
+import Errors, { useNotifyError } from "components/Errors";
 import ClearSelection from "listeners/ClearSelection";
 
-const API = axiosCaseConverter(
+const http = axiosCaseConverter(
   axios.create({
     baseURL: process.env.NEXT_PUBLIC_API_URL,
   })
 );
+
+function request<T = void>(
+  cb: (http: AxiosInstance) => Promise<T>
+): Promise<T> {
+  return new Promise(async (resolve, reject) => {
+    try {
+      const result = await cb(http);
+      resolve(result);
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response) {
+          if (error.response.status === 409) {
+            reject("conflict");
+          } else {
+            reject(error.response?.data);
+          }
+        } else {
+          reject(error.message);
+        }
+      } else {
+        reject(error);
+      }
+    }
+  });
+}
 
 const App: FC<AppProps> = ({ Component, pageProps }) => {
   return (
@@ -23,5 +48,5 @@ const App: FC<AppProps> = ({ Component, pageProps }) => {
   );
 };
 
-export { API };
 export default App;
+export { request };

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -5,6 +5,7 @@ import axios from "axios";
 import axiosCaseConverter from "axios-case-converter";
 import { RecoilRoot } from "recoil";
 import Errors from "components/Errors";
+import ClearSelection from "listeners/ClearSelection";
 
 const API = axiosCaseConverter(
   axios.create({
@@ -16,6 +17,7 @@ const App: FC<AppProps> = ({ Component, pageProps }) => {
   return (
     <RecoilRoot>
       <Errors />
+      <ClearSelection />
       <Component {...pageProps} />
     </RecoilRoot>
   );

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,40 +1,17 @@
 import { NextPage } from "next";
-import { API } from "app";
 import { Publication } from "modules/publications";
 import PublicationIndex from "components/PublicationIndex";
 import PublicationToolbar from "components/PublicationToolbar";
 import Header from "components/Header";
 import Layout from "components/Layout";
 import { useEffect } from "react";
-import { useNotifyError } from "components/Errors";
-import axios from "axios";
-import { range } from "lodash";
 
 const Home: NextPage = () => {
-  const notifyError = useNotifyError();
-  const setPublications = Publication.STORE.useSetAll();
+  const index = Publication.REMOTE.useIndex();
 
   useEffect(() => {
-    API.get<Publication[]>("publications")
-      .then(({ data }) => {
-        setPublications(
-          data.map((publication, index) => ({
-            id: index,
-            publication,
-            errors: null,
-          }))
-        );
-      })
-      .catch(({ error }) => {
-        if (axios.isAxiosError(error)) {
-          const { response, message } = error;
-          const descriptiveError =
-            response && Publication.describe(response.data as string);
-
-          notifyError(descriptiveError || message);
-        }
-      });
-  }, [notifyError, setPublications]);
+    index();
+  }, [index]);
 
   return (
     <Layout

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -17,11 +17,9 @@ const Home: NextPage = () => {
   useEffect(() => {
     API.get<Publication[]>("publications")
       .then(({ data }) => {
-        const ids = range(0, data.length);
         setPublications(
-          ids,
           data.map((publication, index) => ({
-            id: ids[index],
+            id: index,
             publication,
             errors: null,
           }))


### PR DESCRIPTION
Closes #22 
Closes #39 
Closes #44 

Implementes logical edition of publications on review stage. As deletions, editions are kept in a separate storage so they can be reset anytime. Columns of `PublicationIndex` now render an input when `editable` is turned on. Overrides trigger automatic row validations. 

In summary:

- Now Publication data and errors are stored in separate 
- A new atom family is defined to store overridden attributes
- Visible publications now merge the actual publications with the overrides, giving priority to the later
- Implements on-click-outside row selection clearing so it doesn't interfere with the inputs
- Refactor the endpoint api to avoid repetition of error handling
- Trigger server-side validations on blur and when data changes for external reasons, like resetting the overrides