### PR TITLE
Refactor data structures

### DIFF
--- a/backend/lib/mix/tasks/load_data.ex
+++ b/backend/lib/mix/tasks/load_data.ex
@@ -12,10 +12,14 @@ defmodule Mix.Tasks.Rb.LoadData do
     File.cwd!()
     |> Path.join('data.csv')
     |> Publication.Codec.from_csv()
-    |> Publication.Codec.nest()
     |> case do
-      {:ok, publications} -> Enum.map(publications, &Publication.insert/1)
-      {:error, error} -> IO.puts("Operation failed with error #{error}")
+      {:ok, publications} ->
+        publications
+        |> Publication.Codec.nest()
+        |> Enum.map(&Publication.insert/1)
+
+      {:error, error} ->
+        IO.puts("Operation failed with error #{error}")
     end
   end
 end

--- a/backend/lib/mix/tasks/load_data.ex
+++ b/backend/lib/mix/tasks/load_data.ex
@@ -12,6 +12,7 @@ defmodule Mix.Tasks.Rb.LoadData do
     File.cwd!()
     |> Path.join('data.csv')
     |> Publication.Codec.from_csv()
+    |> Publication.Codec.nest()
     |> case do
       {:ok, publications} -> Enum.map(publications, &Publication.insert/1)
       {:error, error} -> IO.puts("Operation failed with error #{error}")

--- a/backend/lib/richard_burton/author.ex
+++ b/backend/lib/richard_burton/author.ex
@@ -45,14 +45,6 @@ defmodule RichardBurton.Author do
     |> Repo.maybe_insert!([:name])
   end
 
-  def to_map(author = %Author{}) do
-    Map.take(author, @external_attributes)
-  end
-
-  def to_map(author) when is_map(author) do
-    author
-  end
-
   def all do
     Repo.all(Author)
   end
@@ -62,7 +54,6 @@ defmodule RichardBurton.Author do
       changeset
       |> get_change(:authors)
       |> Enum.map(&apply_changes/1)
-      |> Enum.map(&Author.to_map/1)
       |> Enum.map(&Author.maybe_insert!/1)
 
     put_assoc(changeset, :authors, authors)
@@ -72,7 +63,6 @@ defmodule RichardBurton.Author do
 
   def fingerprint(authors) when is_list(authors) do
     authors
-    |> Enum.map(&Author.to_map/1)
     |> Enum.map_join(&Map.get(&1, :name))
     |> Util.create_fingerprint()
   end

--- a/backend/lib/richard_burton/author.ex
+++ b/backend/lib/richard_burton/author.ex
@@ -63,7 +63,9 @@ defmodule RichardBurton.Author do
 
   def fingerprint(authors) when is_list(authors) do
     authors
-    |> Enum.map_join(fn %Author{name: name} -> name end)
+    |> Enum.map(fn %Author{name: name} -> name end)
+    |> Enum.sort()
+    |> Enum.join()
     |> Util.create_fingerprint()
   end
 

--- a/backend/lib/richard_burton/author.ex
+++ b/backend/lib/richard_burton/author.ex
@@ -63,7 +63,7 @@ defmodule RichardBurton.Author do
 
   def fingerprint(authors) when is_list(authors) do
     authors
-    |> Enum.map_join(&Map.get(&1, :name))
+    |> Enum.map_join(fn %Author{name: name} -> name end)
     |> Util.create_fingerprint()
   end
 

--- a/backend/lib/richard_burton/author.ex
+++ b/backend/lib/richard_burton/author.ex
@@ -24,6 +24,14 @@ defmodule RichardBurton.Author do
   end
 
   @doc false
+  def changeset(author, attrs \\ %{})
+
+  @doc false
+  def changeset(author, attrs = %Author{}) do
+    changeset(author, Map.from_struct(attrs))
+  end
+
+  @doc false
   def changeset(author, attrs) do
     author
     |> cast(attrs, [:name])

--- a/backend/lib/richard_burton/author.ex
+++ b/backend/lib/richard_burton/author.ex
@@ -31,8 +31,6 @@ defmodule RichardBurton.Author do
     |> unique_constraint([:name])
   end
 
-  @spec maybe_insert!(:invalid | %{optional(:__struct__) => none, optional(atom | binary) => any}) ::
-          any
   def maybe_insert!(attrs) do
     %__MODULE__{}
     |> changeset(attrs)

--- a/backend/lib/richard_burton/codec.ex
+++ b/backend/lib/richard_burton/codec.ex
@@ -29,6 +29,7 @@ defmodule RichardBurton.Codec do
         iex> RichardBurton.Codec.flatten(%{a: 1, b: [2, 3, %{a: 1, b: 2}], c: %{a: 1, b: 2, c: 3}})
         %{ "a" => 1, "b" => [2, 3, %{a: 1, b: 2}], "c_a" => 1, "c_b"=> 2, "c_c"=> 3}
   """
+
   def flatten(map) when is_map(map) do
     map
     |> Util.stringify_keys()

--- a/backend/lib/richard_burton/codec.ex
+++ b/backend/lib/richard_burton/codec.ex
@@ -1,4 +1,6 @@
 defmodule RichardBurton.Codec do
+  alias RichardBurton.Util
+
   @moduledoc """
   Utilities for serialization and deserialization
   """
@@ -51,5 +53,69 @@ defmodule RichardBurton.Codec do
 
   defp compose_keys(key1, key2) when is_binary(key1) and is_binary(key2) do
     "#{key1}_#{key2}"
+  end
+
+  @doc ~S"""
+    Automatically nests a flat map.
+    Keys are grouped by their Longest Common Prefix (LCP) to define nesting points.
+    LCP is calculated considering atomic words separated by underscore:
+
+      `aBC` and `aDE do not have a common prefix
+      `a_BC` and `a_DE` have "a" as common prefix
+      `a_b_BC` and `a_b_DE` have "a_b" as common prefix
+
+    Returns the nested map with string keys.
+
+    ## Examples
+
+        iex> RichardBurton.Codec.nest(%{})
+        %{}
+
+        iex> RichardBurton.Codec.nest(%{a: 1, b: 2, c: 3})
+        %{"a" => 1, "b" => 2, "c" => 3}
+
+        iex> RichardBurton.Codec.nest(%{a: 1, b_a: 1, b_b: 2, b_c: 3})
+        %{"a" => 1, "b" => %{"a" => 1, "b" => 2, "c" => 3}}
+
+        iex> RichardBurton.Codec.nest(%{a: 1, b_a: 1, b_b: 2, b_c_c: 3})
+        %{"a" => 1, "b" => %{"a" => 1, "b" => 2, "c_c" => 3}}
+
+        iex> RichardBurton.Codec.nest(%{a: 1, b_a: 1, b_b: 2, b_c_c_c: 3})
+        %{"a" => 1, "b" => %{"a" => 1, "b" => 2, "c_c_c" => 3}}
+
+        iex> RichardBurton.Codec.nest(%{a: 1, b_a: 1, b_b: 2, b_c_c: 3, b_c_d: 4})
+        %{"a" => 1, "b" => %{"a" => 1, "b" => 2, "c" => %{"c" => 3, "d" => 4}}}
+  """
+  def nest(map) do
+    map
+    |> Util.stringify_keys()
+    |> Enum.map(fn {k, v} -> {String.split(k, "_"), v} end)
+    |> Enum.reduce(%{}, fn {path, v}, acc -> put_path(acc, path, v) end)
+    |> Map.new(&coalesce_keys/1)
+  end
+
+  defp put_path(map, [key], value) do
+    Map.put(map, key, value)
+  end
+
+  defp put_path(map, [key | rest], value) do
+    Map.put(map, key, put_path(map[key] || %{}, rest, value))
+  end
+
+  defp coalesce_keys({key, map}) when is_map(map) do
+    case(coalesce_keys(map)) do
+      {inner_key, v} -> {compose_keys(key, inner_key), v}
+      v -> {key, v}
+    end
+  end
+
+  defp coalesce_keys({key, value}), do: {key, value}
+
+  defp coalesce_keys(map) when is_map(map) do
+    case Map.to_list(map) do
+      [{k, m}] when is_map(m) -> coalesce_keys({k, m})
+      [{k, v}] -> {k, v}
+      _ -> Map.new(map, &coalesce_keys/1)
+    end
   end
 end

--- a/backend/lib/richard_burton/codec.ex
+++ b/backend/lib/richard_burton/codec.ex
@@ -29,11 +29,10 @@ defmodule RichardBurton.Codec do
         iex> RichardBurton.Codec.flatten(%{a: 1, b: [2, 3, %{a: 1, b: 2}], c: %{a: 1, b: 2, c: 3}})
         %{ a: 1, b: [2, 3, %{a: 1, b: 2}], c_a: 1, c_b: 2, c_c: 3}
   """
-  def flatten(map, post \\ &Function.identity/1) when is_map(map) and is_function(post) do
+  def flatten(map) when is_map(map) do
     map
     |> Map.to_list()
     |> Enum.reduce([], &do_flatten/2)
-    |> Enum.map(&post.(&1))
     |> Map.new()
   end
 

--- a/backend/lib/richard_burton/codec.ex
+++ b/backend/lib/richard_burton/codec.ex
@@ -86,13 +86,15 @@ defmodule RichardBurton.Codec do
     |> Map.new(&coalesce_keys/1)
   end
 
-  defp put_path(map, [key], value) do
+  defp put_path(map, [key], value) when is_map(map) do
     Map.put(map, key, value)
   end
 
-  defp put_path(map, [key | rest], value) do
+  defp put_path(map, [key | rest], value) when is_map(map) do
     Map.put(map, key, put_path(map[key] || %{}, rest, value))
   end
+
+  defp put_path(not_map, _, _) when not is_map(not_map), do: not_map
 
   defp coalesce_keys({key, map}) when is_map(map) do
     case(coalesce_keys(map)) do

--- a/backend/lib/richard_burton/flat_publication.ex
+++ b/backend/lib/richard_burton/flat_publication.ex
@@ -9,6 +9,7 @@ defmodule RichardBurton.FlatPublication do
   alias RichardBurton.FlatPublication
   alias RichardBurton.Publication
   alias RichardBurton.Repo
+  alias RichardBurton.TranslatedBook
   alias RichardBurton.Validation
 
   @external_attributes [
@@ -36,15 +37,13 @@ defmodule RichardBurton.FlatPublication do
 
   @doc false
   def changeset(flat_publication, attrs) do
-    translated_book_fingerprint =
-      %Publication{}
-      |> Publication.changeset(Publication.Codec.nest(attrs))
-      |> get_field(:translated_book_fingerprint)
+    %Publication{}
+    |> Publication.changeset(Publication.Codec.nest(attrs))
 
     flat_publication
     |> cast(attrs, @external_attributes)
     |> validate_required(@external_attributes)
-    |> put_change(:translated_book_fingerprint, translated_book_fingerprint)
+    |> TranslatedBook.link_fingerprint()
   end
 
   def validate(attrs) do

--- a/backend/lib/richard_burton/flat_publication.ex
+++ b/backend/lib/richard_burton/flat_publication.ex
@@ -1,10 +1,10 @@
-defmodule RichardBurton.Publication.Index.FlatPublication do
+defmodule RichardBurton.FlatPublication do
   @moduledoc """
   Schema for publications
   """
   use Ecto.Schema
 
-  alias RichardBurton.Publication.Index.FlatPublication
+  alias RichardBurton.FlatPublication
 
   @external_attributes [
     :title,

--- a/backend/lib/richard_burton/flat_publication.ex
+++ b/backend/lib/richard_burton/flat_publication.ex
@@ -76,12 +76,4 @@ defmodule RichardBurton.FlatPublication do
       :ok
     end
   end
-
-  def to_map(ps) when is_list(ps) do
-    Enum.map(ps, &FlatPublication.to_map/1)
-  end
-
-  def to_map(p) do
-    Map.take(p, @external_attributes)
-  end
 end

--- a/backend/lib/richard_burton/original_book.ex
+++ b/backend/lib/richard_burton/original_book.ex
@@ -54,14 +54,6 @@ defmodule RichardBurton.OriginalBook do
     |> Repo.maybe_insert!([:authors_fingerprint, :title])
   end
 
-  def to_map(original_book = %OriginalBook{}) do
-    authors = Enum.map(original_book.authors, &Author.to_map/1)
-
-    original_book
-    |> Map.take(@external_attributes)
-    |> Map.put(:authors, authors)
-  end
-
   def all() do
     OriginalBook |> Repo.all() |> preload
   end
@@ -75,7 +67,6 @@ defmodule RichardBurton.OriginalBook do
       changeset
       |> get_change(:original_book)
       |> apply_changes()
-      |> OriginalBook.to_map()
       |> OriginalBook.maybe_insert!()
 
     put_assoc(changeset, :original_book, original_book)

--- a/backend/lib/richard_burton/original_book.ex
+++ b/backend/lib/richard_burton/original_book.ex
@@ -33,7 +33,10 @@ defmodule RichardBurton.OriginalBook do
     |> validate_required([:title])
     |> validate_length(:authors, min: 1)
     |> Author.link_fingerprint()
-    |> unique_constraint([:authors_fingerprint, :title])
+    |> unique_constraint(
+      [:authors_fingerprint, :title],
+      name: "original_books_composite_key"
+    )
   end
 
   def maybe_insert!(attrs) do

--- a/backend/lib/richard_burton/original_book.ex
+++ b/backend/lib/richard_burton/original_book.ex
@@ -26,7 +26,15 @@ defmodule RichardBurton.OriginalBook do
   end
 
   @doc false
-  def changeset(original_book, attrs \\ %{}) do
+  def changeset(original_book, attrs \\ %{})
+
+  @doc false
+  def changeset(original_book, attrs = %OriginalBook{}) do
+    changeset(original_book, Map.from_struct(attrs))
+  end
+
+  @doc false
+  def changeset(original_book, attrs) do
     original_book
     |> cast(attrs, [:title])
     |> cast_assoc(:authors, required: true)

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -91,12 +91,4 @@ defmodule RichardBurton.Publication do
         Repo.rollback({attrs, errors})
     end
   end
-
-  def to_map(publication) do
-    translated_book = TranslatedBook.to_map(publication.translated_book)
-
-    publication
-    |> Map.take(@external_attributes)
-    |> Map.put(:translated_book, translated_book)
-  end
 end

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -20,6 +20,7 @@ defmodule RichardBurton.Publication do
     field(:publisher, :string)
     field(:title, :string)
     field(:year, :integer)
+    field(:translated_book_fingerprint, :string)
 
     belongs_to(:translated_book, TranslatedBook)
 
@@ -30,9 +31,13 @@ defmodule RichardBurton.Publication do
   def changeset(publication, attrs \\ %{}) do
     publication
     |> cast(attrs, [:title, :year, :country, :publisher])
-    |> validate_required([:title, :year, :country, :publisher])
     |> cast_assoc(:translated_book, required: true)
-    |> unique_constraint([:title, :year, :country, :publisher])
+    |> validate_required([:title, :year, :country, :publisher])
+    |> TranslatedBook.link_fingerprint()
+    |> unique_constraint(
+      [:title, :year, :country, :publisher, :translated_book_fingerprint],
+      name: "publications_composite_key"
+    )
   end
 
   def all do

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -28,7 +28,15 @@ defmodule RichardBurton.Publication do
   end
 
   @doc false
-  def changeset(publication, attrs \\ %{}) do
+  def changeset(publication, attrs \\ %{})
+
+  @doc false
+  def changeset(publication, attrs = %Publication{}) do
+    changeset(publication, Map.from_struct(attrs))
+  end
+
+  @doc false
+  def changeset(publication, attrs) do
     publication
     |> cast(attrs, [:title, :year, :country, :publisher])
     |> cast_assoc(:translated_book, required: true)

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -95,7 +95,7 @@ defmodule RichardBurton.Publication.Codec do
   defp nest_entry({key, value}),
     do: {key, value}
 
-  defp nest_authors(authors) when is_binary(authors) do
+  def nest_authors(authors) when is_binary(authors) do
     Enum.map(String.split(authors, ","), &%{"name" => String.trim(&1)})
   end
 

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -6,7 +6,7 @@ defmodule RichardBurton.Publication.Codec do
   alias RichardBurton.Codec
   alias RichardBurton.Util
   alias RichardBurton.Publication
-  alias RichardBurton.Publication.Index.FlatPublication
+  alias RichardBurton.FlatPublication
 
   @empty_flat_attrs %{
     "title" => "",

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -34,7 +34,6 @@ defmodule RichardBurton.Publication.Codec do
         |> File.stream!()
         |> CSV.decode!(separator: ?;, headers: @csv_headers)
         |> Enum.map(&Util.deep_merge_maps(@empty_flat_attrs, &1))
-        |> nest
 
       {:ok, publications}
     rescue
@@ -53,6 +52,13 @@ defmodule RichardBurton.Publication.Codec do
     flat_publications
     |> CSV.encode(separator: ?;, delimiter: "\n", headers: true)
     |> Enum.to_list()
+  end
+
+  def from_csv!(path) do
+    case from_csv(path) do
+      {:ok, publications} -> publications
+      {:error, error} -> throw(error)
+    end
   end
 
   def nest(flat_publication_like_map) when is_map(flat_publication_like_map) do

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -51,6 +51,12 @@ defmodule RichardBurton.Publication.Codec do
 
   def to_csv(flat_publications) do
     flat_publications
+    |> Enum.map(fn
+      struct = %FlatPublication{} -> Map.from_struct(struct)
+      map when is_map(map) -> map
+    end)
+    |> Enum.map(&Util.stringify_keys/1)
+    |> Enum.map(&Map.take(&1, @csv_headers))
     |> CSV.encode(separator: ?;, delimiter: "\n", headers: true)
     |> Enum.to_list()
   end

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -133,6 +133,8 @@ defmodule RichardBurton.Publication.Codec do
     Enum.map_join(authors, ", ", &(Map.get(&1, "name") || Map.get(&1, :name)))
   end
 
+  defp flatten_authors(authors), do: authors
+
   defp rename_key({"translated_book_authors", v}), do: {"authors", v}
   defp rename_key({"translated_book_original_book_title", v}), do: {"original_title", v}
   defp rename_key({"translated_book_original_book_authors", v}), do: {"original_authors", v}

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -6,6 +6,7 @@ defmodule RichardBurton.Publication.Codec do
   alias RichardBurton.Codec
   alias RichardBurton.Util
   alias RichardBurton.Publication
+  alias RichardBurton.Publication.Index.FlatPublication
 
   @empty_flat_attrs %{
     "title" => "",
@@ -61,8 +62,16 @@ defmodule RichardBurton.Publication.Codec do
     end
   end
 
+  def nest(p = %FlatPublication{}) do
+    p
+    |> FlatPublication.to_map()
+    |> nest
+  end
+
   def nest(flat_publication_like_map) when is_map(flat_publication_like_map) do
-    flat_publication_like_map |> Map.new(&(&1 |> nest_entry |> rename_key)) |> Codec.nest()
+    flat_publication_like_map
+    |> Map.new(&(&1 |> Util.stringify_keys() |> nest_entry |> rename_key))
+    |> Codec.nest()
   end
 
   def nest(flat_publication_like_maps) when is_list(flat_publication_like_maps) do

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -172,13 +172,11 @@ defmodule RichardBurton.Publication.Codec do
   end
 
   defp flatten_errors(errors) do
-    Codec.flatten(errors)
+    errors
+    |> Codec.flatten()
     |> Map.new(&(&1 |> rename_key |> flatten_error))
   end
 
-  defp rename_key({:translated_book_authors, v}), do: {:authors, v}
-  defp rename_key({:translated_book_original_book_title, v}), do: {:original_title, v}
-  defp rename_key({:translated_book_original_book_authors, v}), do: {:original_authors, v}
   defp rename_key({"translated_book_authors", v}), do: {"authors", v}
   defp rename_key({"translated_book_original_book_title", v}), do: {"original_title", v}
   defp rename_key({"translated_book_original_book_authors", v}), do: {"original_authors", v}
@@ -195,20 +193,8 @@ defmodule RichardBurton.Publication.Codec do
   defp flatten_value({"original_authors", value}),
     do: {"original_authors", flatten_authors(value)}
 
-  defp flatten_value({:authors, value}),
-    do: {:authors, flatten_authors(value)}
-
-  defp flatten_value({:original_authors, value}),
-    do: {:original_authors, flatten_authors(value)}
-
   defp flatten_value({key, value}),
     do: {key, value}
-
-  defp flatten_error({:authors, error}),
-    do: {:authors, flatten_authors_error(error)}
-
-  defp flatten_error({:original_authors, error}),
-    do: {:original_authors, flatten_authors_error(error)}
 
   defp flatten_error({"authors", error}),
     do: {"authors", flatten_authors_error(error)}

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -88,7 +88,7 @@ defmodule RichardBurton.Publication.Codec do
           }
         }
       ) do
-    Codec.flatten(p, &(&1 |> rename_key |> flatten_value))
+    Codec.flatten(p) |> Map.new(&(&1 |> rename_key |> flatten_value))
   end
 
   def flatten(p = %Publication{}) do
@@ -112,7 +112,7 @@ defmodule RichardBurton.Publication.Codec do
           }
         }
       ) do
-    Codec.flatten(p, &(&1 |> rename_key |> flatten_value |> Util.stringify_keys()))
+    Codec.flatten(p) |> Map.new(&(&1 |> rename_key |> flatten_value |> Util.stringify_keys()))
   end
 
   def flatten(%{publication: publication, errors: nil}) do
@@ -172,7 +172,8 @@ defmodule RichardBurton.Publication.Codec do
   end
 
   defp flatten_errors(errors) do
-    Codec.flatten(errors, &(&1 |> rename_key |> flatten_error |> Util.stringify_keys()))
+    Codec.flatten(errors)
+    |> Map.new(&(&1 |> rename_key |> flatten_error |> Util.stringify_keys()))
   end
 
   defp rename_key({:translated_book_authors, v}), do: {:authors, v}

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -112,7 +112,7 @@ defmodule RichardBurton.Publication.Codec do
           }
         }
       ) do
-    Codec.flatten(p) |> Map.new(&(&1 |> rename_key |> flatten_value |> Util.stringify_keys()))
+    Codec.flatten(p) |> Map.new(&(&1 |> rename_key |> flatten_value))
   end
 
   def flatten(%{publication: publication, errors: nil}) do
@@ -173,7 +173,7 @@ defmodule RichardBurton.Publication.Codec do
 
   defp flatten_errors(errors) do
     Codec.flatten(errors)
-    |> Map.new(&(&1 |> rename_key |> flatten_error |> Util.stringify_keys()))
+    |> Map.new(&(&1 |> rename_key |> flatten_error))
   end
 
   defp rename_key({:translated_book_authors, v}), do: {:authors, v}

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -122,16 +122,16 @@ defmodule RichardBurton.Publication.Codec do
   end
 
   def flatten(publication_like_map) when is_map(publication_like_map) do
-    publication_like_map |> Codec.flatten() |> Map.new(&(&1 |> rename_key |> flatten_value))
+    publication_like_map |> Codec.flatten() |> Map.new(&(&1 |> rename_key |> flatten_entry))
   end
 
-  defp flatten_value({"authors", value}),
+  defp flatten_entry({"authors", value}),
     do: {"authors", flatten_authors(value)}
 
-  defp flatten_value({"original_authors", value}),
+  defp flatten_entry({"original_authors", value}),
     do: {"original_authors", flatten_authors(value)}
 
-  defp flatten_value({key, value}),
+  defp flatten_entry({key, value}),
     do: {key, value}
 
   defp flatten_authors(authors) when is_list(authors) do

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -79,10 +79,7 @@ defmodule RichardBurton.Publication.Index do
           )
           |> maybe_select(attributes)
 
-        results =
-          query
-          |> Repo.all()
-          |> FlatPublication.to_map()
+        results = Repo.all(query)
 
         {:ok, results, keywords}
     end

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -5,7 +5,7 @@ defmodule RichardBurton.Publication.Index do
 
   import Ecto.Query
 
-  alias RichardBurton.Publication.Index.FlatPublication
+  alias RichardBurton.FlatPublication
   alias RichardBurton.Publication.Index.SearchDocument
   alias RichardBurton.Publication.Index.SearchKeyword
   alias RichardBurton.Repo

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -19,7 +19,6 @@ defmodule RichardBurton.Publication.Index do
       from(fp in FlatPublication)
       |> maybe_select(attributes)
       |> Repo.all()
-      |> FlatPublication.to_map()
 
     {:ok, results}
   end

--- a/backend/lib/richard_burton/translated_book.ex
+++ b/backend/lib/richard_burton/translated_book.ex
@@ -6,10 +6,11 @@ defmodule RichardBurton.TranslatedBook do
   import Ecto.Changeset
 
   alias RichardBurton.Author
-  alias RichardBurton.Repo
   alias RichardBurton.OriginalBook
-  alias RichardBurton.TranslatedBook
   alias RichardBurton.Publication
+  alias RichardBurton.Repo
+  alias RichardBurton.TranslatedBook
+  alias RichardBurton.Util
 
   @external_attributes [:authors, :original_book]
 
@@ -82,4 +83,24 @@ defmodule RichardBurton.TranslatedBook do
   end
 
   def link(changeset = %{valid?: false}), do: changeset
+
+  def fingerprint(%TranslatedBook{
+        original_book_fingerprint: original_book_fingerprint,
+        authors_fingerprint: authors_fingerprint
+      }) do
+    [original_book_fingerprint, authors_fingerprint]
+    |> Enum.join()
+    |> Util.create_fingerprint()
+  end
+
+  def link_fingerprint(changeset = %Ecto.Changeset{valid?: true}) do
+    translated_book_fingerprint =
+      changeset
+      |> get_field(:translated_book)
+      |> fingerprint
+
+    put_change(changeset, :translated_book_fingerprint, translated_book_fingerprint)
+  end
+
+  def link_fingerprint(changeset = %Ecto.Changeset{valid?: false}), do: changeset
 end

--- a/backend/lib/richard_burton/translated_book.ex
+++ b/backend/lib/richard_burton/translated_book.ex
@@ -16,6 +16,7 @@ defmodule RichardBurton.TranslatedBook do
   @derive {Jason.Encoder, only: @external_attributes}
   schema "translated_books" do
     field(:authors_fingerprint, :string)
+    field(:original_book_fingerprint, :string)
 
     has_many(:publications, Publication)
 
@@ -33,8 +34,12 @@ defmodule RichardBurton.TranslatedBook do
     |> cast_assoc(:authors, required: true)
     |> cast_assoc(:original_book, required: true)
     |> validate_length(:authors, min: 1)
+    |> OriginalBook.link_fingerprint()
     |> Author.link_fingerprint()
-    |> unique_constraint([:authors_fingerprint, :original_book_id])
+    |> unique_constraint(
+      [:authors_fingerprint, :original_book_fingerprint],
+      name: "translated_books_composite_key"
+    )
   end
 
   def maybe_insert!(attrs) do

--- a/backend/lib/richard_burton/translated_book.ex
+++ b/backend/lib/richard_burton/translated_book.ex
@@ -69,22 +69,11 @@ defmodule RichardBurton.TranslatedBook do
     Repo.preload(data, [:authors, original_book: [:authors]])
   end
 
-  def to_map(translated_book) do
-    original_book = OriginalBook.to_map(translated_book.original_book)
-    authors = Enum.map(translated_book.authors, &Author.to_map/1)
-
-    translated_book
-    |> Map.take(@external_attributes)
-    |> Map.put(:original_book, original_book)
-    |> Map.put(:authors, authors)
-  end
-
   def link(changeset = %{valid?: true}) do
     translated_book =
       changeset
       |> get_change(:translated_book)
       |> apply_changes()
-      |> TranslatedBook.to_map()
       |> TranslatedBook.maybe_insert!()
 
     put_assoc(changeset, :translated_book, translated_book)

--- a/backend/lib/richard_burton/translated_book.ex
+++ b/backend/lib/richard_burton/translated_book.ex
@@ -29,7 +29,15 @@ defmodule RichardBurton.TranslatedBook do
   end
 
   @doc false
-  def changeset(translated_book, attrs \\ %{}) do
+  def changeset(translated_book, attrs \\ %{})
+
+  @doc false
+  def changeset(translated_book, attrs = %TranslatedBook{}) do
+    changeset(translated_book, Map.from_struct(attrs))
+  end
+
+  @doc false
+  def changeset(translated_book, attrs) do
     translated_book
     |> cast(attrs, [])
     |> cast_assoc(:authors, required: true)

--- a/backend/lib/richard_burton/util.ex
+++ b/backend/lib/richard_burton/util.ex
@@ -25,7 +25,7 @@ defmodule RichardBurton.Util do
 
   @doc ~S"""
     Given an enumerable with atom keys, return the enumerable with string keys instead.
-    Works for keyword lists, key-value tuples and maps.
+    Works for keyword lists, key-value tuples, maps and structs.
     When an ordinary list is given, it stringify the keys of its elements.
     Does not traverse structures other than ordinary lists.
 
@@ -76,8 +76,9 @@ defmodule RichardBurton.Util do
         iex> RichardBurton.Util.stringify_keys(%{key: {:key, "value"}})
         %{"key" => {:key, "value"}}
   """
-  def stringify_keys(list) when is_list(list), do: Enum.map(list, &stringify_keys/1)
-  def stringify_keys(map) when is_map(map), do: Map.new(map, &stringify_keys/1)
+  def stringify_keys(s) when is_struct(s), do: stringify_keys(Map.from_struct(s))
+  def stringify_keys(l) when is_list(l), do: Enum.map(l, &stringify_keys/1)
+  def stringify_keys(m) when is_map(m), do: Map.new(m, &stringify_keys/1)
   def stringify_keys({key, value}) when is_atom(key), do: {Atom.to_string(key), value}
   def stringify_keys({key, value}) when is_binary(key), do: {key, value}
 end

--- a/backend/lib/richard_burton/validation.ex
+++ b/backend/lib/richard_burton/validation.ex
@@ -5,7 +5,6 @@ defmodule RichardBurton.Validation do
 
   alias RichardBurton.Repo
 
-  @spec validate(%{:valid? => boolean, optional(any) => any}, any) :: :ok | {:error, any}
   def validate(changeset, link_assocs) do
     case validate_transaction(changeset, link_assocs) do
       {:error, :ok} -> :ok

--- a/backend/lib/richard_burton_web/controllers/publication_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/publication_controller.ex
@@ -1,6 +1,7 @@
 defmodule RichardBurtonWeb.PublicationController do
   use RichardBurtonWeb, :controller
 
+  alias RichardBurton.FlatPublication
   alias RichardBurton.Publication
 
   def index(conn, %{"search" => query}) do
@@ -72,11 +73,7 @@ defmodule RichardBurtonWeb.PublicationController do
   def validate(conn, %{"csv" => %Plug.Upload{path: path}}) do
     case Publication.Codec.from_csv(path) do
       {:ok, publications} ->
-        result =
-          publications
-          |> Publication.Codec.nest()
-          |> Enum.map(&validate_publication/1)
-          |> Publication.Codec.flatten()
+        result = Enum.map(publications, &validate_publication/1)
 
         conn
         |> put_status(:ok)
@@ -88,11 +85,7 @@ defmodule RichardBurtonWeb.PublicationController do
   end
 
   def validate(conn, %{"_json" => publications}) do
-    result =
-      publications
-      |> Publication.Codec.nest()
-      |> Enum.map(&validate_publication/1)
-      |> Publication.Codec.flatten()
+    result = Enum.map(publications, &validate_publication/1)
 
     conn
     |> put_status(:ok)
@@ -100,7 +93,7 @@ defmodule RichardBurtonWeb.PublicationController do
   end
 
   defp validate_publication(p) do
-    case Publication.validate(p) do
+    case FlatPublication.validate(p) do
       :ok -> %{publication: p, errors: nil}
       {:error, errors} -> %{publication: p, errors: errors}
     end

--- a/backend/lib/richard_burton_web/controllers/publication_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/publication_controller.ex
@@ -74,6 +74,7 @@ defmodule RichardBurtonWeb.PublicationController do
       {:ok, publications} ->
         result =
           publications
+          |> Publication.Codec.nest()
           |> Enum.map(&validate_publication/1)
           |> Publication.Codec.flatten()
 

--- a/backend/priv/repo/migrations/20230206165256_add_original_book_fingerprint_to_translated_book.exs
+++ b/backend/priv/repo/migrations/20230206165256_add_original_book_fingerprint_to_translated_book.exs
@@ -1,0 +1,40 @@
+defmodule RichardBurton.Repo.Migrations.AddOriginalBookFingerprintToTranslatedBook do
+  use Ecto.Migration
+
+  def change do
+    alter table("translated_books") do
+      add(:original_book_fingerprint, :string)
+    end
+
+    execute(
+      "--Up
+      UPDATE translated_books
+      SET original_book_fingerprint = (
+        SELECT
+          encode(sha256(decode(concat(original_books.title, original_books.authors_fingerprint), 'escape')), 'hex') AS fingerprint
+        FROM
+          original_books
+        WHERE
+          translated_books.original_book_id = original_books.id
+      )
+      ",
+      "--Down
+      "
+    )
+
+    execute(
+      "--Up
+      ALTER TABLE translated_books ALTER COLUMN original_book_fingerprint SET NOT NULL;
+      ",
+      "--Down
+      ALTER TABLE translated_books ALTER COLUMN original_book_fingerprint DROP NOT NULL;
+      "
+    )
+
+    drop(unique_index(:translated_books, [:authors_fingerprint, :original_book_id]))
+
+    create(unique_index(:translated_books, [:authors_fingerprint, :original_book_fingerprint]),
+      name: "translated_books_composite_key"
+    )
+  end
+end

--- a/backend/priv/repo/migrations/20230206165256_add_original_book_fingerprint_to_translated_book.exs
+++ b/backend/priv/repo/migrations/20230206165256_add_original_book_fingerprint_to_translated_book.exs
@@ -33,8 +33,12 @@ defmodule RichardBurton.Repo.Migrations.AddOriginalBookFingerprintToTranslatedBo
 
     drop(unique_index(:translated_books, [:authors_fingerprint, :original_book_id]))
 
-    create(unique_index(:translated_books, [:authors_fingerprint, :original_book_fingerprint]),
-      name: "translated_books_composite_key"
+    create(
+      unique_index(
+        :translated_books,
+        [:authors_fingerprint, :original_book_fingerprint],
+        name: "translated_books_composite_key"
+      )
     )
   end
 end

--- a/backend/priv/repo/migrations/20230206182249_add_translated_book_fingerprint_to_publication.exs
+++ b/backend/priv/repo/migrations/20230206182249_add_translated_book_fingerprint_to_publication.exs
@@ -1,0 +1,57 @@
+defmodule RichardBurton.Repo.Migrations.AddTranslatedBookFingerprintToPublication do
+  use Ecto.Migration
+
+  def change do
+    alter table("publications") do
+      add(:translated_book_fingerprint, :string)
+    end
+
+    execute(
+      "--Up
+      UPDATE publications
+      SET translated_book_fingerprint = (
+        SELECT
+          encode(sha256(decode(concat(translated_books.original_book_fingerprint, translated_books.authors_fingerprint), 'escape')), 'hex') AS fingerprint
+        FROM
+          translated_books
+        WHERE
+          publications.translated_book_id = translated_books.id
+      )
+      ",
+      "--Down
+      "
+    )
+
+    execute(
+      "--Up
+      ALTER TABLE publications ALTER COLUMN translated_book_fingerprint SET NOT NULL;
+      ",
+      "--Down
+      ALTER TABLE publications ALTER COLUMN translated_book_fingerprint DROP NOT NULL;
+      "
+    )
+
+    drop(
+      unique_index(:publications, [
+        :title,
+        :year,
+        :country,
+        :publisher
+      ])
+    )
+
+    create(
+      unique_index(
+        :publications,
+        [
+          :title,
+          :year,
+          :country,
+          :publisher,
+          :translated_book_fingerprint
+        ],
+        name: "publications_composite_key"
+      )
+    )
+  end
+end

--- a/backend/priv/repo/migrations/20230206184236_rename_original_books_composite_key.exs
+++ b/backend/priv/repo/migrations/20230206184236_rename_original_books_composite_key.exs
@@ -1,0 +1,20 @@
+defmodule RichardBurton.Repo.Migrations.RenameOriginalBooksCompositeKey do
+  use Ecto.Migration
+
+  def change do
+    drop(
+      unique_index(
+        :original_books,
+        [:authors_fingerprint, :title]
+      )
+    )
+
+    create(
+      unique_index(
+        :original_books,
+        [:title, :authors_fingerprint],
+        name: "original_books_composite_key"
+      )
+    )
+  end
+end

--- a/backend/priv/repo/migrations/20230206201045_add_translated_book_fingerprint_to_flat_publication.exs
+++ b/backend/priv/repo/migrations/20230206201045_add_translated_book_fingerprint_to_flat_publication.exs
@@ -1,0 +1,193 @@
+defmodule RichardBurton.Repo.Migrations.AddTranslatedBookFingerprintToFlatPublication do
+  use Ecto.Migration
+
+  def up do
+    execute("
+      CREATE OR REPLACE VIEW flat_publications AS
+      WITH
+      CTE_publications AS (
+        SELECT
+            publications.id AS id,
+            publications.title AS title,
+            publications.country AS country,
+            publications.year AS year,
+            publications.publisher AS publisher,
+            authors.name AS original_author,
+            translators.name AS translator,
+            original_books.title AS original_title,
+            publications.translated_book_fingerprint AS translated_book_fingerprint
+        FROM
+            translated_books
+        INNER JOIN
+            publications
+            ON publications.translated_book_id = translated_books.id
+        INNER JOIN
+            original_books
+            ON original_books.id = translated_books.original_book_id
+        INNER JOIN
+            original_book_authors
+            ON original_book_authors.original_book_id = original_books.id
+        INNER JOIN
+            authors
+            ON authors.id = original_book_authors.author_id
+        INNER JOIN
+            translated_book_authors
+            ON translated_book_authors.translated_book_id = translated_books.id
+        INNER JOIN
+            authors AS translators
+            ON translators.id = translated_book_authors.author_id
+      ),
+      CTE_authors AS (
+        SELECT id, original_author
+        FROM CTE_publications
+        GROUP BY id, original_author
+      ),
+      CTE_authors_distinct AS (
+        SELECT id, string_agg(original_author, ', ' ORDER BY original_author) AS original_authors
+        FROM CTE_authors
+        GROUP BY id
+      ),
+      CTE_translators AS (
+        SELECT id, translator
+        FROM CTE_publications
+        GROUP BY id, translator
+      ),
+      CTE_translators_distinct AS (
+        SELECT id, string_agg(translator, ', ' ORDER BY translator) AS translators
+        FROM CTE_translators
+        GROUP BY id
+      )
+      SELECT
+        CTE_publications.id AS id,
+        CTE_publications.title AS title,
+        CTE_publications.country AS country,
+        CTE_publications.year AS year,
+        CTE_publications.publisher AS publisher,
+        CTE_publications.original_title AS original_title,
+        CTE_authors_distinct.original_authors AS original_authors,
+        CTE_translators_distinct.translators AS authors,
+        CTE_publications.translated_book_fingerprint AS translated_book_fingerprint
+      FROM
+        CTE_publications
+      INNER JOIN
+        CTE_authors_distinct
+        ON CTE_publications.id = CTE_authors_distinct.id
+      INNER JOIN
+        CTE_translators_distinct
+        ON CTE_publications.id = CTE_translators_distinct.id
+      GROUP BY
+        CTE_publications.id,
+        CTE_publications.title,
+        CTE_publications.country,
+        CTE_publications.year,
+        CTE_publications.publisher,
+        CTE_publications.original_title,
+        CTE_authors_distinct.original_authors,
+        CTE_translators_distinct.translators,
+        CTE_publications.translated_book_fingerprint;
+      ")
+  end
+
+  def down do
+    execute("DROP VIEW flat_publications CASCADE")
+
+    execute("
+      CREATE VIEW flat_publications AS
+      WITH
+      CTE_publications AS (
+        SELECT
+            publications.id AS id,
+            publications.title AS title,
+            publications.country AS country,
+            publications.year AS year,
+            publications.publisher AS publisher,
+            authors.name AS original_author,
+            translators.name AS translator,
+            original_books.title AS original_title
+        FROM
+            translated_books
+        INNER JOIN
+            publications
+            ON publications.translated_book_id = translated_books.id
+        INNER JOIN
+            original_books
+            ON original_books.id = translated_books.original_book_id
+        INNER JOIN
+            original_book_authors
+            ON original_book_authors.original_book_id = original_books.id
+        INNER JOIN
+            authors
+            ON authors.id = original_book_authors.author_id
+        INNER JOIN
+            translated_book_authors
+            ON translated_book_authors.translated_book_id = translated_books.id
+        INNER JOIN
+            authors AS translators
+            ON translators.id = translated_book_authors.author_id
+      ),
+      CTE_authors AS (
+        SELECT id, original_author
+        FROM CTE_publications
+        GROUP BY id, original_author
+      ),
+      CTE_authors_distinct AS (
+        SELECT id, string_agg(original_author, ', ' ORDER BY original_author) AS original_authors
+        FROM CTE_authors
+        GROUP BY id
+      ),
+      CTE_translators AS (
+        SELECT id, translator
+        FROM CTE_publications
+        GROUP BY id, translator
+      ),
+      CTE_translators_distinct AS (
+        SELECT id, string_agg(translator, ', ' ORDER BY translator) AS translators
+        FROM CTE_translators
+        GROUP BY id
+      )
+      SELECT
+        CTE_publications.id AS id,
+        CTE_publications.title AS title,
+        CTE_publications.country AS country,
+        CTE_publications.year AS year,
+        CTE_publications.publisher AS publisher,
+        CTE_publications.original_title AS original_title,
+        CTE_authors_distinct.original_authors AS original_authors,
+        CTE_translators_distinct.translators AS authors
+      FROM
+        CTE_publications
+      INNER JOIN
+        CTE_authors_distinct
+        ON CTE_publications.id = CTE_authors_distinct.id
+      INNER JOIN
+        CTE_translators_distinct
+        ON CTE_publications.id = CTE_translators_distinct.id
+      GROUP BY
+        CTE_publications.id,
+        CTE_publications.title,
+        CTE_publications.country,
+        CTE_publications.year,
+        CTE_publications.publisher,
+        CTE_publications.original_title,
+        CTE_authors_distinct.original_authors,
+        CTE_translators_distinct.translators;
+      ")
+
+    execute("
+      CREATE MATERIALIZED VIEW search_documents AS
+      SELECT
+        id,
+        to_tsvector('simple'::regconfig, title)                ||
+        to_tsvector('simple'::regconfig, country)              ||
+        to_tsvector('simple'::regconfig, publisher)            ||
+        to_tsvector('simple'::regconfig, year::text)           ||
+        to_tsvector('simple'::regconfig, authors)              ||
+        to_tsvector('simple'::regconfig, original_title)       ||
+        to_tsvector('simple'::regconfig, original_authors)     AS document
+      FROM
+        flat_publications
+      ")
+
+    execute("CREATE INDEX search_index ON search_documents USING gin(document);")
+  end
+end

--- a/backend/priv/repo/migrations/20230208144440_recalculate_authors_fingerprint_sorting_names.exs
+++ b/backend/priv/repo/migrations/20230208144440_recalculate_authors_fingerprint_sorting_names.exs
@@ -1,0 +1,75 @@
+defmodule RichardBurton.Repo.Migrations.RecalculateAuthorsFingerprintSortingNames do
+  use Ecto.Migration
+
+  def up do
+    execute("
+      UPDATE original_books
+      SET authors_fingerprint = (
+        SELECT
+          encode(sha256(decode(string_agg(authors.name, '' ORDER BY authors.name), 'escape')), 'hex') AS fingerprint
+        FROM
+          original_book_authors,
+          authors
+        WHERE
+          original_book_authors.author_id = authors.id
+        AND
+          original_book_authors.original_book_id = original_books.id
+        GROUP BY
+          authors.name
+        ORDER BY
+          authors.name
+      )
+      ")
+
+    execute("
+      UPDATE translated_books
+      SET authors_fingerprint = (
+        SELECT
+          encode(sha256(decode(string_agg(authors.name, '' ORDER BY authors.name), 'escape')), 'hex') AS fingerprint
+        FROM
+          translated_book_authors,
+          authors
+        WHERE
+          translated_book_authors.author_id = authors.id
+        AND
+          translated_book_authors.translated_book_id = translated_books.id
+        GROUP BY
+          authors.name
+        ORDER BY
+          authors.name
+      )
+      ")
+  end
+
+  def down do
+    execute("
+      UPDATE original_books
+      SET authors_fingerprint = (
+        SELECT
+          encode(sha256(decode(string_agg(authors.name, ''), 'escape')), 'hex') AS fingerprint
+        FROM
+          original_book_authors,
+          authors
+        WHERE
+          original_book_authors.author_id = authors.id
+        AND
+          original_book_authors.original_book_id = original_books.id
+      )
+      ")
+
+    execute("
+      UPDATE translated_books
+      SET authors_fingerprint = (
+        SELECT
+          encode(sha256(decode(string_agg(authors.name, ''), 'escape')), 'hex') AS fingerprint
+        FROM
+          translated_book_authors,
+          authors
+        WHERE
+          translated_book_authors.author_id = authors.id
+        AND
+          translated_book_authors.translated_book_id = translated_books.id
+      )
+      ")
+  end
+end

--- a/backend/test/richard_burton/author_test.exs
+++ b/backend/test/richard_burton/author_test.exs
@@ -89,6 +89,13 @@ defmodule RichardBurton.AuthorTest do
 
       assert Author.fingerprint(authors1) == Author.fingerprint(authors2)
     end
+
+    test "given two lists of authors with the same and different order, generates the same fingerprints" do
+      authors1 = [%Author{name: "Isabel Burton"}, %Author{name: "Richard Burton"}]
+      authors2 = [%Author{name: "Richard Burton"}, %Author{name: "Isabel Burton"}]
+
+      assert Author.fingerprint(authors1) == Author.fingerprint(authors2)
+    end
   end
 
   describe "link/1" do

--- a/backend/test/richard_burton/author_test.exs
+++ b/backend/test/richard_burton/author_test.exs
@@ -75,17 +75,6 @@ defmodule RichardBurton.AuthorTest do
     end
   end
 
-  describe "to_map/1" do
-    test "returns the selected attributes as a map with atom keys" do
-      result =
-        changeset(%{"name" => "Richard Burton"})
-        |> apply_changes()
-        |> Author.to_map()
-
-      assert %{name: "Richard Burton"} == result
-    end
-  end
-
   describe "fingerprint/1" do
     test "given two different lists of authors, generates different fingerprints" do
       authors1 = [%Author{name: "Richard Burton"}, %Author{name: "Isabel Burton"}]

--- a/backend/test/richard_burton/codec_test.exs
+++ b/backend/test/richard_burton/codec_test.exs
@@ -30,18 +30,18 @@ defmodule RichardBurton.CodecTest do
       }
 
       output = %{
-        string: "hey",
-        number: 1,
-        list: [1, 2, 3],
-        tuple: {:error, nil},
-        parent_map_string: "bla",
-        parent_map_number: 2,
-        parent_map_list: ["1", "2", "3"],
-        parent_map_tuple: {:ok, 1},
-        parent_map_nil_: nil,
-        parent_map_another_map_string: "bye",
-        parent_map_another_map_number: 42,
-        nil_: nil
+        "string" => "hey",
+        "number" => 1,
+        "list" => [1, 2, 3],
+        "tuple" => {:error, nil},
+        "parent_map_string" => "bla",
+        "parent_map_number" => 2,
+        "parent_map_list" => ["1", "2", "3"],
+        "parent_map_tuple" => {:ok, 1},
+        "parent_map_nil_" => nil,
+        "parent_map_another_map_string" => "bye",
+        "parent_map_another_map_number" => 42,
+        "nil_" => nil
       }
 
       assert output == Codec.flatten(input)

--- a/backend/test/richard_burton/codec_test.exs
+++ b/backend/test/richard_burton/codec_test.exs
@@ -11,36 +11,36 @@ defmodule RichardBurton.CodecTest do
   describe "flatten/1" do
     test "flattens a nested map" do
       input = %{
-        a_string: "hey",
-        a_number: 1,
-        a_list: [1, 2, 3],
-        a_tuple: {:error, nil},
+        string: "hey",
+        number: 1,
+        list: [1, 2, 3],
+        tuple: {:error, nil},
         parent_map: %{
-          a_string: "bla",
-          a_number: 2,
-          a_list: ["1", "2", "3"],
-          a_tuple: {:ok, 1},
+          string: "bla",
+          number: 2,
+          list: ["1", "2", "3"],
+          tuple: {:ok, 1},
           nil_: nil,
           another_map: %{
-            a_string: "bye",
-            a_number: 42
+            string: "bye",
+            number: 42
           }
         },
         nil_: nil
       }
 
       output = %{
-        a_string: "hey",
-        a_number: 1,
-        a_list: [1, 2, 3],
-        a_tuple: {:error, nil},
-        parent_map_a_string: "bla",
-        parent_map_a_number: 2,
-        parent_map_a_list: ["1", "2", "3"],
-        parent_map_a_tuple: {:ok, 1},
+        string: "hey",
+        number: 1,
+        list: [1, 2, 3],
+        tuple: {:error, nil},
+        parent_map_string: "bla",
+        parent_map_number: 2,
+        parent_map_list: ["1", "2", "3"],
+        parent_map_tuple: {:ok, 1},
         parent_map_nil_: nil,
-        parent_map_another_map_a_string: "bye",
-        parent_map_another_map_a_number: 42,
+        parent_map_another_map_string: "bye",
+        parent_map_another_map_number: 42,
         nil_: nil
       }
 
@@ -91,6 +91,46 @@ defmodule RichardBurton.CodecTest do
       }
 
       assert output == Codec.flatten(input, fn {k, v} -> {Atom.to_string(k), v} end)
+    end
+  end
+
+  describe "nest/1" do
+    test "nests a flat map" do
+      input = %{
+        string: "hey",
+        number: 1,
+        list: [1, 2, 3],
+        tuple: {:error, nil},
+        parent_map_string: "bla",
+        parent_map_number: 2,
+        parent_map_list: ["1", "2", "3"],
+        parent_map_tuple: {:ok, 1},
+        parent_map_nil_: nil,
+        parent_map_another_map_string: "bye",
+        parent_map_another_map_number: 42,
+        nil_: nil
+      }
+
+      output = %{
+        "string" => "hey",
+        "number" => 1,
+        "list" => [1, 2, 3],
+        "tuple" => {:error, nil},
+        "parent_map" => %{
+          "string" => "bla",
+          "number" => 2,
+          "list" => ["1", "2", "3"],
+          "tuple" => {:ok, 1},
+          "nil_" => nil,
+          "another_map" => %{
+            "string" => "bye",
+            "number" => 42
+          }
+        },
+        "nil_" => nil
+      }
+
+      assert output == Codec.nest(input)
     end
   end
 end

--- a/backend/test/richard_burton/codec_test.exs
+++ b/backend/test/richard_burton/codec_test.exs
@@ -72,26 +72,6 @@ defmodule RichardBurton.CodecTest do
 
       assert output == Codec.flatten(input)
     end
-
-    test "modifies keys of the resulting flat map" do
-      input = %{
-        a_string: "hey",
-        a_number: 1,
-        a_list: [1, 2, 3],
-        a_tuple: {:error, nil},
-        nil_: nil
-      }
-
-      output = %{
-        "a_string" => "hey",
-        "a_number" => 1,
-        "a_list" => [1, 2, 3],
-        "a_tuple" => {:error, nil},
-        "nil_" => nil
-      }
-
-      assert output == Codec.flatten(input, fn {k, v} -> {Atom.to_string(k), v} end)
-    end
   end
 
   describe "nest/1" do

--- a/backend/test/richard_burton/flat_publication_test.exs
+++ b/backend/test/richard_burton/flat_publication_test.exs
@@ -1,0 +1,181 @@
+defmodule RichardBurton.FlatPublicationTest do
+  @moduledoc """
+  Tests for the FlatPublication schema
+  """
+  use RichardBurton.DataCase
+
+  alias RichardBurton.FlatPublication
+  alias RichardBurton.Publication
+  alias RichardBurton.Util
+  alias RichardBurton.Validation
+
+  @valid_attrs %{
+    "title" => "Manuel de Moraes: A Chronicle of the Seventeenth Century",
+    "country" => "GB",
+    "year" => 1886,
+    "publisher" => "Bickers & Son",
+    "authors" => "Richard Burton, Isabel Burton",
+    "original_authors" => "J. M. Pereira da Silva",
+    "original_title" => "Manuel de Moraes: crônica do século XVII"
+  }
+
+  @skeleton_attrs %{
+    translated_book: %{
+      authors: nil,
+      original_book: %{
+        authors: nil,
+        title: nil
+      }
+    }
+  }
+
+  @empty_attrs %{}
+
+  @empty_attrs_error_map %{
+    title: :required,
+    country: :required,
+    year: :required,
+    publisher: :required,
+    authors: :required,
+    original_authors: :required,
+    original_title: :required
+  }
+
+  defp changeset(attrs = %{}) do
+    FlatPublication.changeset(%FlatPublication{}, attrs)
+  end
+
+  defp change_valid(attrs = %{}) do
+    changeset(Util.deep_merge_maps(@valid_attrs, attrs))
+  end
+
+  defp insert(attrs) do
+    %Publication{} |> Publication.changeset(Publication.Codec.nest(attrs)) |> Repo.insert()
+  end
+
+  describe "changeset/2" do
+    test "when valid attributes are provided, is valid" do
+      assert changeset(@valid_attrs).valid?
+    end
+
+    test "when title is blank, is invalid" do
+      refute change_valid(%{"title" => ""}).valid?
+    end
+
+    test "when title is nil, is invalid" do
+      refute change_valid(%{"title" => nil}).valid?
+    end
+
+    test "when country is blank, is invalid" do
+      refute change_valid(%{"country" => ""}).valid?
+    end
+
+    test "when country is nil, is invalid" do
+      refute change_valid(%{"country" => nil}).valid?
+    end
+
+    test "when publisher is blank, is invalid" do
+      refute change_valid(%{"publisher" => ""}).valid?
+    end
+
+    test "when publisher is nil, is invalid" do
+      refute change_valid(%{"publisher" => nil}).valid?
+    end
+
+    test "when year is nil, is invalid" do
+      refute change_valid(%{"year" => nil}).valid?
+    end
+
+    test "when year is not numeric, is invalid" do
+      refute change_valid(%{"year" => "abc"}).valid?
+    end
+
+    test "when year is a numeric string, is invalid" do
+      assert change_valid(%{"year" => "2000"}).valid?
+    end
+
+    test "when year is a number, is invalid" do
+      assert change_valid(%{"year" => 2000}).valid?
+    end
+
+    test "when a publication with the provided attributes already exists, is invalid" do
+      {:ok, _} = insert(@valid_attrs)
+      {:error, changeset} = insert(@valid_attrs)
+
+      refute changeset.valid?
+      assert :conflict == Validation.get_errors(changeset)
+    end
+  end
+
+  describe "validate/1" do
+    import FlatPublication, only: [validate: 1]
+
+    test "when validating valid publications, returns :ok" do
+      # Insert a dummy publication to make sure the test passes on a non-empty database
+      insert(Map.put(@valid_attrs, "title", "New title"))
+      assert :ok == validate(@valid_attrs)
+    end
+
+    test "when validating a duplicate publication, returns {:error, :conflict}" do
+      insert(@valid_attrs)
+      assert {:error, :conflict} == validate(@valid_attrs)
+    end
+
+    test "when validating an empty publication, returns an error map with :required errors" do
+      assert {:error, @empty_attrs_error_map} == validate(@empty_attrs)
+    end
+
+    test "when a single field is invalid, returns the corresponding error map" do
+      assert {:error, %{year: :integer}} = validate(Map.put(@valid_attrs, "year", "A"))
+    end
+
+    test "generates results analog to those of Publication.validate/1 on valid attrs" do
+      expected =
+        @valid_attrs
+        |> Publication.Codec.nest()
+        |> Publication.validate()
+
+      assert FlatPublication.validate(@valid_attrs) == expected
+    end
+
+    test "generates results analog to those of Publication.validate/1 on empty attrs" do
+      {:error, expected} =
+        @skeleton_attrs
+        |> Publication.Codec.nest()
+        |> Publication.validate()
+
+      expected = {:error, Publication.Codec.flatten(expected)}
+
+      {:error, actual} = FlatPublication.validate(@empty_attrs)
+
+      actual = {:error, Util.stringify_keys(actual)}
+
+      assert actual == expected
+    end
+
+    test "generates results analog to those of Publication.validate/1 on duplicate attrs" do
+      insert(@valid_attrs)
+
+      expected =
+        @valid_attrs
+        |> Publication.Codec.nest()
+        |> Publication.validate()
+
+      assert expected == FlatPublication.validate(@valid_attrs)
+    end
+
+    test "generates results analog to those of Publication.validate/1 on attrs with invalid types" do
+      attrs =
+        @valid_attrs
+        |> Map.put("year", "AAAA")
+        |> Map.put("title", 1234)
+
+      expected =
+        attrs
+        |> Publication.Codec.nest()
+        |> Publication.validate()
+
+      assert expected == FlatPublication.validate(attrs)
+    end
+  end
+end

--- a/backend/test/richard_burton/original_book_test.exs
+++ b/backend/test/richard_burton/original_book_test.exs
@@ -19,14 +19,6 @@ defmodule RichardBurton.OriginalBookTest do
     ]
   }
 
-  @valid_attrs_atom_keys %{
-    title: "Manuel de Moraes: crônica do século XVII",
-    authors: [
-      %{name: "J. M. Pereira da Silva"},
-      %{name: "Machado de Assis"}
-    ]
-  }
-
   defp changeset(attrs = %{}) do
     OriginalBook.changeset(%OriginalBook{}, attrs)
   end
@@ -130,14 +122,6 @@ defmodule RichardBurton.OriginalBookTest do
       authors_fingerprint2 = Ecto.Changeset.get_field(changeset2, :authors_fingerprint)
 
       refute authors_fingerprint1 == authors_fingerprint2
-    end
-  end
-
-  describe "to_map/1" do
-    test "returns the selected attributes as a map with atom keys" do
-      {:ok, original_book} = insert(@valid_attrs)
-
-      assert @valid_attrs_atom_keys == OriginalBook.to_map(original_book)
     end
   end
 

--- a/backend/test/richard_burton/publication_codec_test.exs
+++ b/backend/test/richard_burton/publication_codec_test.exs
@@ -6,6 +6,7 @@ defmodule RichardBurton.Publication.CodecTest do
   use RichardBurton.DataCase
 
   alias RichardBurton.Publication
+  alias RichardBurton.Publication.Index.FlatPublication
   alias RichardBurton.TranslatedBook
   alias RichardBurton.OriginalBook
 
@@ -318,6 +319,102 @@ defmodule RichardBurton.Publication.CodecTest do
       ]
 
       assert output == Publication.Codec.flatten(input)
+    end
+  end
+
+  describe "nest/1 on flat publications" do
+    @output %{
+      "title" => "Iraçéma the Honey-Lips: A Legend of Brazil",
+      "year" => "1886",
+      "country" => "GB",
+      "publisher" => "Bickers & Son",
+      "translated_book" => %{
+        "authors" => [
+          %{"name" => "Isabel Burton"}
+        ],
+        "original_book" => %{
+          "authors" => [
+            %{"name" => "José de Alencar"}
+          ],
+          "title" => "Iracema"
+        }
+      }
+    }
+
+    test "on a nested publication-like with string keys, returns the flattened representation with string keys" do
+      input = %{
+        "title" => "Iraçéma the Honey-Lips: A Legend of Brazil",
+        "year" => "1886",
+        "country" => "GB",
+        "publisher" => "Bickers & Son",
+        "authors" => "Isabel Burton",
+        "original_authors" => "José de Alencar",
+        "original_title" => "Iracema"
+      }
+
+      assert @output == Publication.Codec.nest(input)
+    end
+
+    test "on a nested publication-like with atom keys, returns the flattened representation with string keys" do
+      input = %{
+        title: "Iraçéma the Honey-Lips: A Legend of Brazil",
+        year: "1886",
+        country: "GB",
+        publisher: "Bickers & Son",
+        authors: "Isabel Burton",
+        original_authors: "José de Alencar",
+        original_title: "Iracema"
+      }
+
+      assert @output == Publication.Codec.nest(input)
+    end
+
+    test "on a Publication struct, returns the flattened representation with string keys" do
+      input = %FlatPublication{
+        title: "Iraçéma the Honey-Lips: A Legend of Brazil",
+        year: "1886",
+        country: "GB",
+        publisher: "Bickers & Son",
+        authors: "Isabel Burton",
+        original_authors: "José de Alencar",
+        original_title: "Iracema"
+      }
+
+      assert @output == Publication.Codec.nest(input)
+    end
+
+    test "on a list, returns the flattened representation of its items, with string keys" do
+      input = [
+        %{
+          "title" => "Iraçéma the Honey-Lips: A Legend of Brazil",
+          "year" => "1886",
+          "country" => "GB",
+          "publisher" => "Bickers & Son",
+          "authors" => "Isabel Burton",
+          "original_authors" => "José de Alencar",
+          "original_title" => "Iracema"
+        },
+        %{
+          title: "Iraçéma the Honey-Lips: A Legend of Brazil",
+          year: "1886",
+          country: "GB",
+          publisher: "Bickers & Son",
+          authors: "Isabel Burton",
+          original_authors: "José de Alencar",
+          original_title: "Iracema"
+        },
+        %FlatPublication{
+          title: "Iraçéma the Honey-Lips: A Legend of Brazil",
+          year: "1886",
+          country: "GB",
+          publisher: "Bickers & Son",
+          authors: "Isabel Burton",
+          original_authors: "José de Alencar",
+          original_title: "Iracema"
+        }
+      ]
+
+      assert [@output, @output, @output] == Publication.Codec.nest(input)
     end
   end
 end

--- a/backend/test/richard_burton/publication_codec_test.exs
+++ b/backend/test/richard_burton/publication_codec_test.exs
@@ -360,8 +360,8 @@ defmodule RichardBurton.Publication.CodecTest do
 
       output = [
         %{
-          publication: @output_publication,
-          errors: %{
+          "publication" => @output_publication,
+          "errors" => %{
             "year" => "required",
             "country" => "required",
             "publisher" => "required",
@@ -370,12 +370,12 @@ defmodule RichardBurton.Publication.CodecTest do
           }
         },
         %{
-          publication: @output_publication,
-          errors: nil
+          "publication" => @output_publication,
+          "errors" => nil
         },
         %{
-          publication: @output_publication,
-          errors: :conflict
+          "publication" => @output_publication,
+          "errors" => :conflict
         }
       ]
 

--- a/backend/test/richard_burton/publication_codec_test.exs
+++ b/backend/test/richard_burton/publication_codec_test.exs
@@ -5,6 +5,7 @@ defmodule RichardBurton.Publication.CodecTest do
 
   use RichardBurton.DataCase
 
+  alias RichardBurton.Author
   alias RichardBurton.Publication
   alias RichardBurton.FlatPublication
   alias RichardBurton.TranslatedBook
@@ -169,11 +170,11 @@ defmodule RichardBurton.Publication.CodecTest do
         publisher: "Bickers & Son",
         translated_book: %TranslatedBook{
           authors: [
-            %{name: "Isabel Burton"}
+            %Author{name: "Isabel Burton"}
           ],
           original_book: %OriginalBook{
             authors: [
-              %{name: "José de Alencar"}
+              %Author{name: "José de Alencar"}
             ],
             title: "Iracema"
           }
@@ -226,11 +227,11 @@ defmodule RichardBurton.Publication.CodecTest do
           publisher: "Bickers & Son",
           translated_book: %TranslatedBook{
             authors: [
-              %{name: "Isabel Burton"}
+              %Author{name: "Isabel Burton"}
             ],
             original_book: %OriginalBook{
               authors: [
-                %{name: "José de Alencar"}
+                %Author{name: "José de Alencar"}
               ],
               title: "Iracema"
             }
@@ -341,6 +342,30 @@ defmodule RichardBurton.Publication.CodecTest do
       }
     }
 
+    @output_struct %Publication{
+      title: "Iraçéma the Honey-Lips: A Legend of Brazil",
+      year: 1886,
+      country: "GB",
+      publisher: "Bickers & Son",
+      translated_book: %TranslatedBook{
+        authors: [
+          %Author{name: "Isabel Burton"}
+        ],
+        authors_fingerprint: "3D9BE0F48628685291383A430443DE4D864E69660C376B17EE9E7501BE5BB2D8",
+        original_book: %OriginalBook{
+          title: "Iracema",
+          authors: [
+            %Author{name: "José de Alencar"}
+          ],
+          authors_fingerprint: "65931E62E55E5151BD2F625E9D3CBD821B6D4B6CE0B6F600BAFB9D49E2F338CB"
+        },
+        original_book_fingerprint:
+          "F9846F5EAF84555CE8AA7D20C8C89BEAB11C1466A2A79B0700050FEAC784226B"
+      },
+      translated_book_fingerprint:
+        "954F4C8E5EB33960B733BADB84134970AF5D970879260138C8C214B66DDBEF1F"
+    }
+
     test "on a nested publication-like with string keys, returns the flattened representation with string keys" do
       input = %{
         "title" => "Iraçéma the Honey-Lips: A Legend of Brazil",
@@ -380,7 +405,7 @@ defmodule RichardBurton.Publication.CodecTest do
         original_title: "Iracema"
       }
 
-      assert @output == Publication.Codec.nest(input)
+      assert @output_struct == Publication.Codec.nest(input)
     end
 
     test "on a list, returns the flattened representation of its items, with string keys" do
@@ -414,7 +439,7 @@ defmodule RichardBurton.Publication.CodecTest do
         }
       ]
 
-      assert [@output, @output, @output] == Publication.Codec.nest(input)
+      assert [@output, @output, @output_struct] == Publication.Codec.nest(input)
     end
   end
 end

--- a/backend/test/richard_burton/publication_codec_test.exs
+++ b/backend/test/richard_burton/publication_codec_test.exs
@@ -118,6 +118,18 @@ defmodule RichardBurton.Publication.CodecTest do
       "original_title" => "Iracema"
     }
 
+    @output_struct %FlatPublication{
+      title: "Iraçéma the Honey-Lips: A Legend of Brazil",
+      year: 1886,
+      country: "GB",
+      publisher: "Bickers & Son",
+      authors: "Isabel Burton",
+      original_authors: "José de Alencar",
+      original_title: "Iracema",
+      translated_book_fingerprint:
+        "954F4C8E5EB33960B733BADB84134970AF5D970879260138C8C214B66DDBEF1F"
+    }
+
     test "on a nested publication-like with string keys, returns the flattened representation with string keys" do
       input = %{
         "title" => "Iraçéma the Honey-Lips: A Legend of Brazil",
@@ -181,7 +193,7 @@ defmodule RichardBurton.Publication.CodecTest do
         }
       }
 
-      assert @output == Publication.Codec.flatten(input)
+      assert @output_struct == Publication.Codec.flatten(input)
     end
 
     test "on a list, returns the flattened representation of its items, with string keys" do
@@ -239,7 +251,7 @@ defmodule RichardBurton.Publication.CodecTest do
         }
       ]
 
-      assert [@output, @output, @output] == Publication.Codec.flatten(input)
+      assert [@output, @output, @output_struct] == Publication.Codec.flatten(input)
     end
   end
 

--- a/backend/test/richard_burton/publication_codec_test.exs
+++ b/backend/test/richard_burton/publication_codec_test.exs
@@ -10,82 +10,49 @@ defmodule RichardBurton.Publication.CodecTest do
   alias RichardBurton.OriginalBook
 
   describe "from_csv/1 when the provided csv is correct" do
-    test "returns a list of publication-like maps" do
+    test "returns a list of flattened publications" do
       input = "test/fixtures/data_correct_with_errors.csv"
 
-      publications = [
+      output = [
         %{
+          "authors" => "Isabel Burton, Richard Burton",
+          "country" => "GB",
+          "original_authors" => "José de Alencar",
+          "original_title" => "Iracema",
+          "publisher" => "Bickers & Son",
           "title" => "Iraçéma the Honey-Lips: A Legend of Brazil",
-          "year" => "1886",
-          "country" => "GB",
-          "publisher" => "Bickers & Son",
-          "translated_book" => %{
-            "authors" => [
-              %{"name" => "Isabel Burton"},
-              %{"name" => "Richard Burton"}
-            ],
-            "original_book" => %{
-              "authors" => [
-                %{"name" => "José de Alencar"}
-              ],
-              "title" => "Iracema"
-            }
-          }
+          "year" => "1886"
         },
         %{
-          "title" => "Ubirajara: A Legend of the Tupy Indians",
-          "year" => "1922",
+          "authors" => "J. T. W. Sadler",
           "country" => "US",
+          "original_authors" => "José de Alencar",
+          "original_title" => "Ubirajara",
           "publisher" => "Ronald Massey",
-          "translated_book" => %{
-            "authors" => [
-              %{"name" => "J. T. W. Sadler"}
-            ],
-            "original_book" => %{
-              "authors" => [
-                %{"name" => "José de Alencar"}
-              ],
-              "title" => "Ubirajara"
-            }
-          }
-        },
-        %{
-          "title" => "",
-          "year" => "AAAA",
-          "country" => "GB",
-          "publisher" => "Bickers & Son",
-          "translated_book" => %{
-            "authors" => [
-              %{"name" => ""}
-            ],
-            "original_book" => %{
-              "authors" => [
-                %{"name" => "José de Alencar"}
-              ],
-              "title" => "Iracema"
-            }
-          }
-        },
-        %{
           "title" => "Ubirajara: A Legend of the Tupy Indians",
-          "year" => "",
+          "year" => "1922"
+        },
+        %{
+          "authors" => "",
+          "country" => "GB",
+          "original_authors" => "José de Alencar",
+          "original_title" => "Iracema",
+          "publisher" => "Bickers & Son",
+          "title" => "",
+          "year" => "AAAA"
+        },
+        %{
+          "authors" => "J. T. W. Sadler",
           "country" => "",
+          "original_authors" => "",
+          "original_title" => "",
           "publisher" => "",
-          "translated_book" => %{
-            "authors" => [
-              %{"name" => "J. T. W. Sadler"}
-            ],
-            "original_book" => %{
-              "authors" => [
-                %{"name" => ""}
-              ],
-              "title" => ""
-            }
-          }
+          "title" => "Ubirajara: A Legend of the Tupy Indians",
+          "year" => ""
         }
       ]
 
-      assert {:ok, publications} == Publication.Codec.from_csv(input)
+      assert {:ok, output} == Publication.Codec.from_csv(input)
     end
   end
 
@@ -95,61 +62,32 @@ defmodule RichardBurton.Publication.CodecTest do
 
       output = [
         %{
-          "title" => "Iraçéma the Honey-Lips: A Legend of Brazil",
-          "year" => "1886",
+          "authors" => "Isabel Burton",
           "country" => "GB",
+          "original_authors" => "José de Alencar",
+          "original_title" => "Iracema",
           "publisher" => "",
-          "translated_book" => %{
-            "authors" => [
-              %{"name" => "Isabel Burton"}
-            ],
-            "original_book" => %{
-              "authors" => [
-                %{"name" => "José de Alencar"}
-              ],
-              "title" => "Iracema"
-            }
-          }
+          "title" => "Iraçéma the Honey-Lips: A Legend of Brazil",
+          "year" => "1886"
         },
         %{
-          "title" => "J. T. W. Sadler",
-          "year" => "GB",
+          "authors" => "Ronald Massey",
           "country" => "Ubirajara",
+          "original_authors" => "",
+          "original_title" => "Ubirajara: A Legend of the Tupy Indians",
           "publisher" => "",
-          "translated_book" => %{
-            "authors" => [
-              %{"name" => "Ronald Massey"}
-            ],
-            "original_book" => %{
-              "authors" => [
-                %{"name" => ""}
-              ],
-              "title" => "Ubirajara: A Legend of the Tupy Indians"
-            }
-          }
+          "title" => "J. T. W. Sadler",
+          "year" => "GB"
         },
         %{
-          "title" => "",
-          "year" => "",
+          "authors" => "",
           "country" => "",
+          "original_authors" =>
+            "José de Alencar,1886,GB,Iracema,Iraçéma the Honey-Lips: A Legend of Brazil,Isabel Burton,Bickers & Son",
+          "original_title" => "",
           "publisher" => "",
-          "translated_book" => %{
-            "authors" => [
-              %{"name" => ""}
-            ],
-            "original_book" => %{
-              "authors" => [
-                %{"name" => "José de Alencar"},
-                %{"name" => "1886"},
-                %{"name" => "GB"},
-                %{"name" => "Iracema"},
-                %{"name" => "Iraçéma the Honey-Lips: A Legend of Brazil"},
-                %{"name" => "Isabel Burton"},
-                %{"name" => "Bickers & Son"}
-              ],
-              "title" => ""
-            }
-          }
+          "title" => "",
+          "year" => ""
         }
       ]
 

--- a/backend/test/richard_burton/publication_codec_test.exs
+++ b/backend/test/richard_burton/publication_codec_test.exs
@@ -6,7 +6,7 @@ defmodule RichardBurton.Publication.CodecTest do
   use RichardBurton.DataCase
 
   alias RichardBurton.Publication
-  alias RichardBurton.Publication.Index.FlatPublication
+  alias RichardBurton.FlatPublication
   alias RichardBurton.TranslatedBook
   alias RichardBurton.OriginalBook
 

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -6,15 +6,167 @@ defmodule RichardBurton.Publication.IndexTest do
   use RichardBurton.DataCase
 
   alias RichardBurton.Publication
+  alias RichardBurton.Publication.Index.FlatPublication
   alias RichardBurton.Util
 
+  @publications [
+    %FlatPublication{
+      authors: "Arthur Brakel",
+      country: "CA",
+      original_authors: "Cyro dos Anjos",
+      original_title: "O amanuense Belmiro",
+      publisher: "Fairleigh Dickinson University Press",
+      title: "Diary of a Civil Servant",
+      year: 1986
+    },
+    %FlatPublication{
+      authors: "Arthur Brakel",
+      country: "GB",
+      original_authors: "Cyro dos Anjos",
+      original_title: "O amanuense Belmiro",
+      publisher: "Associated University Presses",
+      title: "Diary of a Civil Servant",
+      year: 1988
+    },
+    %FlatPublication{
+      authors: "Dorothy Scott Loos",
+      country: "US",
+      original_authors: "Rachel de Queiroz",
+      original_title: "Dora Doralina",
+      publisher: "Dutton",
+      title: "Dora Doralina",
+      year: 1984
+    },
+    %FlatPublication{
+      authors: "E. Percy Ellis",
+      country: "BR",
+      original_authors: "Machado de Assis",
+      original_title: "Memórias póstumas de Brás Cubas",
+      publisher: "Instituto Nacional do Livro",
+      title: "Posthumous Reminiscences of Brás Cubas",
+      year: 1955
+    },
+    %FlatPublication{
+      authors: "Fred P. Ellison",
+      country: "US",
+      original_authors: "Rachel de Queiroz",
+      original_title: "As três Marias",
+      publisher: "University of Texas Press",
+      title: "The Three Marias",
+      year: 1963
+    },
+    %FlatPublication{
+      authors: "Gregory Rabassa",
+      country: "US",
+      original_authors: "Machado de Assis",
+      original_title: "Memórias póstumas de Brás Cubas",
+      publisher: "Oxford University Press",
+      title: "Posthumous Memoirs of Bras Cubas",
+      year: 1997
+    },
+    %FlatPublication{
+      authors: "Jean Neel Karnoff",
+      country: "GB",
+      original_authors: "Erico Verissimo",
+      original_title: "Olhai os lírios do campo",
+      publisher: "Greenwood",
+      title: "Consider the Lilies of the Field",
+      year: 1969
+    },
+    %FlatPublication{
+      authors: "L. C. Kaplan",
+      country: "US",
+      original_authors: "Graciliano Ramos",
+      original_title: "Angústia",
+      publisher: "Alfred A. Knopf",
+      title: "Anguish",
+      year: 1946
+    },
+    %FlatPublication{
+      authors: "Linton Lemos Barrett",
+      country: "GB",
+      original_authors: "Erico Verissimo",
+      original_title: "O tempo e o vento",
+      publisher: "Arco Publications",
+      title: "Time and the Wind",
+      year: 1954
+    },
+    %FlatPublication{
+      authors: "Linton Lemos Barrett",
+      country: "GB",
+      original_authors: "Erico Verissimo",
+      original_title: "Noite",
+      publisher: "Arco Publications",
+      title: "Night",
+      year: 1956
+    },
+    %FlatPublication{
+      authors: "Linton Lemos Barrett",
+      country: "US",
+      original_authors: "Erico Verissimo",
+      original_title: "O tempo e o vento",
+      publisher: "Macmillan",
+      title: "Time and the Wind",
+      year: 1951
+    },
+    %FlatPublication{
+      authors: "Linton Lemos Barrett",
+      country: "US",
+      original_authors: "Erico Verissimo",
+      original_title: "Noite",
+      publisher: "Macmillan",
+      title: "Night",
+      year: 1956
+    },
+    %FlatPublication{
+      authors: "Linton Lemos Barrett, Marie Barrett",
+      country: "US",
+      original_authors: "Erico Verissimo",
+      original_title: "O senhor embaixador",
+      publisher: "Macmillan",
+      title: "His Excellency, the Ambassador",
+      year: 1967
+    },
+    %FlatPublication{
+      authors: "Margaret Richardson Hollingsworth",
+      country: "US",
+      original_authors: "Mário de Andrade",
+      original_title: "Amar verbo intransitivo",
+      publisher: "MacCaulay",
+      title: "Fraulein",
+      year: 1933
+    },
+    %FlatPublication{
+      authors: "Thomas Colchie",
+      country: "US",
+      original_authors: "Graciliano Ramos",
+      original_title: "Memórias do cárcere",
+      publisher: "Evans",
+      title: "Jail Prison Memoirs",
+      year: 1974
+    },
+    %FlatPublication{
+      authors: "William L. Grossman",
+      country: "GB",
+      original_authors: "Machado de Assis",
+      original_title: "Memórias póstumas de Brás Cubas",
+      publisher: "W.H. Allen",
+      title: "Epitaph of a Small Winner",
+      year: 1953
+    },
+    %FlatPublication{
+      authors: "William L. Grossman",
+      country: "US",
+      original_authors: "Machado de Assis",
+      original_title: "Memórias póstumas de Brás Cubas",
+      publisher: "Noonday Press",
+      title: "Epitaph of a Small Winner",
+      year: 1952
+    }
+  ]
+
   setup(_context) do
-    publications = Publication.Codec.from_csv!("test/fixtures/data_index.csv")
-
-    publications
-    |> Publication.Codec.nest()
-    |> Enum.map(&Publication.insert/1)
-
+    @publications |> Publication.Codec.nest() |> Enum.map(&Publication.insert/1)
     []
   end
 
@@ -90,14 +242,12 @@ defmodule RichardBurton.Publication.IndexTest do
 
   describe "all/0" do
     test "returns all publications flattened" do
-      {:ok, actual} = Publication.Index.all()
+      {:ok, output} = Publication.Index.all()
 
-      expected =
-        Publication.all()
-        |> Publication.preload()
-        |> Publication.Codec.flatten()
+      actual = output |> Enum.map(&%{&1 | __meta__: nil, id: nil}) |> Enum.sort()
+      expected = @publications |> Enum.map(&%{&1 | __meta__: nil}) |> Enum.sort()
 
-      assert Enum.sort(Util.stringify_keys(actual)) == Enum.sort(expected)
+      assert expected == actual
     end
   end
 

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -208,7 +208,7 @@ defmodule RichardBurton.Publication.IndexTest do
 
     Enum.each(publications, fn p ->
       assert Enum.any?(expected_values, fn {key, value} ->
-               String.contains?(inspect(p[key]), value)
+               String.contains?(inspect(Map.fetch(p, key)), value)
              end),
              """
              Expected publication

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -268,6 +268,7 @@ defmodule RichardBurton.Publication.IndexTest do
         Publication.all()
         |> Publication.preload()
         |> Publication.Codec.flatten()
+        |> Util.stringify_keys()
         |> select_attrs(Enum.map(attributes, &Atom.to_string/1))
 
       assert Enum.sort(Util.stringify_keys(actual)) == Enum.sort(expected)

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -9,8 +9,12 @@ defmodule RichardBurton.Publication.IndexTest do
   alias RichardBurton.Util
 
   setup(_context) do
-    {:ok, publications} = Publication.Codec.from_csv("test/fixtures/data_index.csv")
-    Enum.map(publications, &Publication.insert/1)
+    publications = Publication.Codec.from_csv!("test/fixtures/data_index.csv")
+
+    publications
+    |> Publication.Codec.nest()
+    |> Enum.map(&Publication.insert/1)
+
     []
   end
 

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -5,8 +5,8 @@ defmodule RichardBurton.Publication.IndexTest do
 
   use RichardBurton.DataCase
 
+  alias RichardBurton.FlatPublication
   alias RichardBurton.Publication
-  alias RichardBurton.Publication.Index.FlatPublication
   alias RichardBurton.Util
 
   @publications [

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -244,7 +244,11 @@ defmodule RichardBurton.Publication.IndexTest do
     test "returns all publications flattened" do
       {:ok, output} = Publication.Index.all()
 
-      actual = output |> Enum.map(&%{&1 | __meta__: nil, id: nil}) |> Enum.sort()
+      actual =
+        output
+        |> Enum.map(&%{&1 | __meta__: nil, id: nil, translated_book_fingerprint: nil})
+        |> Enum.sort()
+
       expected = @publications |> Enum.map(&%{&1 | __meta__: nil}) |> Enum.sort()
 
       assert expected == actual

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -166,7 +166,10 @@ defmodule RichardBurton.Publication.IndexTest do
   ]
 
   setup(_context) do
-    @publications |> Publication.Codec.nest() |> Enum.map(&Publication.insert/1)
+    @publications
+    |> Publication.Codec.nest()
+    |> Enum.map(&Publication.insert/1)
+
     []
   end
 

--- a/backend/test/richard_burton/publication_test.exs
+++ b/backend/test/richard_burton/publication_test.exs
@@ -29,25 +29,6 @@ defmodule RichardBurton.PublicationTest do
     }
   }
 
-  @valid_attrs_atom_keys %{
-    title: "Manuel de Moraes: A Chronicle of the Seventeenth Century",
-    country: "GB",
-    year: 1886,
-    publisher: "Bickers & Son",
-    translated_book: %{
-      authors: [
-        %{name: "Richard Burton"},
-        %{name: "Isabel Burton"}
-      ],
-      original_book: %{
-        authors: [
-          %{name: "J. M. Pereira da Silva"}
-        ],
-        title: "Manuel de Moraes: crônica do século XVII"
-      }
-    }
-  }
-
   @empty_attrs %{}
   @skeleton_attrs %{translated_book: %{original_book: %{}}}
 
@@ -254,14 +235,6 @@ defmodule RichardBurton.PublicationTest do
       assert {@skeleton_attrs, @skeleton_attrs_error_map} == description
 
       assert [] == Publication.all()
-    end
-  end
-
-  describe "to_map/1" do
-    test "returns the selected attributes as a map with atom keys" do
-      {:ok, publication} = insert(@valid_attrs)
-      publication = Publication.preload(publication)
-      assert @valid_attrs_atom_keys == Publication.to_map(publication)
     end
   end
 end

--- a/backend/test/richard_burton/translated_book_test.exs
+++ b/backend/test/richard_burton/translated_book_test.exs
@@ -25,19 +25,6 @@ defmodule RichardBurton.TranslatedBookTest do
     }
   }
 
-  @valid_attrs_atom_keys %{
-    authors: [
-      %{name: "Richard Burton"},
-      %{name: "Isabel Burton"}
-    ],
-    original_book: %{
-      title: "Manuel de Moraes: crônica do século XVII",
-      authors: [
-        %{name: "J. M. Pereira da Silva"}
-      ]
-    }
-  }
-
   defp changeset(attrs = %{}) do
     TranslatedBook.changeset(%TranslatedBook{}, attrs)
   end
@@ -147,14 +134,6 @@ defmodule RichardBurton.TranslatedBookTest do
 
       assert pre_existent_book == translated_book
       assert [translated_book] == TranslatedBook.all()
-    end
-  end
-
-  describe "to_map/1" do
-    test "returns the selected attributes as a map with atom keys" do
-      {:ok, translated_book} = insert(@valid_attrs)
-
-      assert @valid_attrs_atom_keys == TranslatedBook.to_map(translated_book)
     end
   end
 


### PR DESCRIPTION
Closes #66 

Huge refactor on data structures and transforms

- Introduces a generic `Codec.nest/1` function, so `Publication.Codec.nest/1` only cares about publication specifics
- Make `Codec` and `Publication.Codec` almost always return maps with string keys, exception is `Publication.Codec` returning a `Publication` when nesting a `FlatPublication` and a `FlatPublication` when flattening a `Publication`
- Removes `to_map` functions on schemas
- Prepares the ground so `Publication` and `FlatPublication` are the preferred data structures to be used internally, instead of attribute maps. The latter should only exist in de/serialization layers.
- Enhances identity by adding `original_book_fingerprint` to `TranslatedBook` and `translated_book_fingerprint` to `Publication`
- Implements validation logic on `FlatPublication`, so we don't need to `nest -> validate -> flatten` when handling requests to `publications/validate`
- Refactors (and recalculates) authors fingerprint so it's agnostic to ordering