### PR TITLE
Enhance error reporting

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -39,12 +39,15 @@ function request<T = void>(
           if (error.response.status === 409) {
             reject("conflict");
           } else {
-            const detail = (error.response?.data as any).errors?.detail;
-
-            if (detail) {
-              reject(detail);
+            if (error.response.data) {
+              const detail = (error.response?.data as any).errors?.detail;
+              if (detail) {
+                reject(detail);
+              } else {
+                reject(error.response?.data);
+              }
             } else {
-              reject(error.response?.data);
+              reject(error.message);
             }
           }
         } else if (error.request) {

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -34,12 +34,26 @@ function request<T = void>(
     } catch (error) {
       if (axios.isAxiosError(error)) {
         if (error.response) {
+          // The request was made and the server responded with a status code
+          // that falls out of the range of 2xx
           if (error.response.status === 409) {
             reject("conflict");
           } else {
-            reject((error.response?.data as any).errors?.detail);
+            const detail = (error.response?.data as any).errors?.detail;
+
+            if (detail) {
+              reject(detail);
+            } else {
+              reject(error.response?.data);
+            }
           }
+        } else if (error.request) {
+          // The request was made but no response was received
+          // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+          // http.ClientRequest in node.js
+          reject(error.message);
         } else {
+          // Something happened in setting up the request that triggered an Error
           reject(error.message);
         }
       } else {


### PR DESCRIPTION
Adds comment on request wrapper to better understand error cases, for posterity. Right now is a bit redundant.

Also makes it work for cases where the server returns an error string instead of an object.