### PR TITLE
[Feature] Edit publication form

### DIFF
--- a/frontend/components/ContactModal.tsx
+++ b/frontend/components/ContactModal.tsx
@@ -92,14 +92,12 @@ const ContactForm: FC = () => {
           disabled={loading}
         />
         <Button type="submit" label="Send" loading={loading} />
-        {
-          // <ReCAPTCHA
-          //   ref={recaptchaRef}
-          //   size="invisible"
-          //   sitekey={GOOGLE_RECAPTCHA_SITEKEY}
-          //   hidden
-          // />
-        }
+        <ReCAPTCHA
+          ref={recaptchaRef}
+          size="invisible"
+          sitekey={GOOGLE_RECAPTCHA_SITEKEY}
+          hidden
+        />
       </footer>
     </form>
   );

--- a/frontend/components/ContactModal.tsx
+++ b/frontend/components/ContactModal.tsx
@@ -92,12 +92,14 @@ const ContactForm: FC = () => {
           disabled={loading}
         />
         <Button type="submit" label="Send" loading={loading} />
-        <ReCAPTCHA
-          ref={recaptchaRef}
-          size="invisible"
-          sitekey={GOOGLE_RECAPTCHA_SITEKEY}
-          hidden
-        />
+        {
+          // <ReCAPTCHA
+          //   ref={recaptchaRef}
+          //   size="invisible"
+          //   sitekey={GOOGLE_RECAPTCHA_SITEKEY}
+          //   hidden
+          // />
+        }
       </footer>
     </form>
   );

--- a/frontend/components/MenuProvider.tsx
+++ b/frontend/components/MenuProvider.tsx
@@ -31,7 +31,7 @@ type Props<OptionType extends Option | string> = {
   setIsOpen: (value: boolean) => void;
   setActiveIndex: (value: number | null) => void;
   onSelect: (option: OptionType) => void;
-  rootRef: RefObject<HTMLElement> | null;
+  rootRef?: RefObject<HTMLElement> | null;
 };
 
 const MenuProvider = <OptionType extends Option | string>({

--- a/frontend/components/MenuProvider.tsx
+++ b/frontend/components/MenuProvider.tsx
@@ -13,6 +13,7 @@ import {
   cloneElement,
   MutableRefObject,
   ReactElement,
+  RefObject,
   useMemo,
   useRef,
 } from "react";
@@ -30,6 +31,7 @@ type Props<OptionType extends Option | string> = {
   setIsOpen: (value: boolean) => void;
   setActiveIndex: (value: number | null) => void;
   onSelect: (option: OptionType) => void;
+  rootRef: RefObject<HTMLElement> | null;
 };
 
 const MenuProvider = <OptionType extends Option | string>({
@@ -40,6 +42,7 @@ const MenuProvider = <OptionType extends Option | string>({
   setIsOpen,
   setActiveIndex,
   onSelect,
+  rootRef,
 }: Props<OptionType>) => {
   const listRef = useRef<(HTMLLIElement | null)[]>([]);
 
@@ -90,8 +93,8 @@ const MenuProvider = <OptionType extends Option | string>({
           ...children.props,
         }),
       )}
-      <FloatingPortal>
-        {isOpen && (
+      {isOpen && (
+        <FloatingPortal root={rootRef}>
           <FloatingFocusManager
             context={context}
             initialFocus={-1}
@@ -124,8 +127,8 @@ const MenuProvider = <OptionType extends Option | string>({
               ))}
             </Menu>
           </FloatingFocusManager>
-        )}
-      </FloatingPortal>
+        </FloatingPortal>
+      )}
     </>
   );
 };

--- a/frontend/components/Multicombobox.tsx
+++ b/frontend/components/Multicombobox.tsx
@@ -109,39 +109,43 @@ export default function Multicombobox<ItemType extends string | Item>({
   }
 
   const inputRef = useRef<HTMLInputElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
 
   return (
-    <MenuProvider<ItemType>
-      options={options}
-      isOpen={isOpen}
-      activeIndex={activeIndex}
-      setIsOpen={setIsOpen}
-      setActiveIndex={setActiveIndex}
-      onSelect={handleOptionSelect}
-    >
-      <TextInput
-        {...props}
-        ref={forwardedRef}
-        inputRef={inputRef}
-        value={inputValue}
-        error={error}
-        placeholder={value.length === 0 ? placeholder : "Add another"}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        aria-autocomplete="list"
-        data-multiselect-input="true"
-        left={
-          <>
-            {value.map((item, index) => (
-              <Pill
-                key={`${item}-${index}`}
-                label={isString(item) ? item : item.label}
-                onRemove={() => unselect(index)}
-              />
-            ))}
-          </>
-        }
-      />
-    </MenuProvider>
+    <div ref={parentRef}>
+      <MenuProvider<ItemType>
+        options={options}
+        isOpen={isOpen}
+        activeIndex={activeIndex}
+        setIsOpen={setIsOpen}
+        setActiveIndex={setActiveIndex}
+        onSelect={handleOptionSelect}
+        rootRef={parentRef}
+      >
+        <TextInput
+          {...props}
+          ref={forwardedRef}
+          inputRef={inputRef}
+          value={inputValue}
+          error={error}
+          placeholder={value.length === 0 ? placeholder : "Add another"}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          aria-autocomplete="list"
+          data-multiselect-input="true"
+          left={
+            <>
+              {value.map((item, index) => (
+                <Pill
+                  key={`${item}-${index}`}
+                  label={isString(item) ? item : item.label}
+                  onRemove={() => unselect(index)}
+                />
+              ))}
+            </>
+          }
+        />
+      </MenuProvider>
+    </div>
   );
 }

--- a/frontend/components/Pill.tsx
+++ b/frontend/components/Pill.tsx
@@ -12,6 +12,7 @@ const Pill: FC<Props> = ({ label, onRemove }) => {
     <span className="flex items-center space-x-1 shrink-0 px-1 py-0.5 border border-indigo-600 text-indigo-600 rounded">
       <span>{label}</span>
       <button
+        type="button"
         className={c(
           "inline-flex items-center justify-center transition-colors rounded-full",
           "hover:bg-indigo-500 hover:text-white",

--- a/frontend/components/PublicationEditModal.tsx
+++ b/frontend/components/PublicationEditModal.tsx
@@ -1,0 +1,91 @@
+import { useRouter } from "next/router";
+import { Publication, PublicationId } from "modules/publication";
+import { Article } from "./Article";
+import { Modal, useURLQueryModal } from "./Modal";
+import Button from "./Button";
+import DataInput from "./DataInput";
+
+const PUBLICATION_EDIT_MODAL_KEY = "edit";
+const usePublicationEditModal = () =>
+  useURLQueryModal(PUBLICATION_EDIT_MODAL_KEY);
+
+const { usePublication } = Publication.STORE;
+
+interface PublicationEditFormProps {
+  publicationId: PublicationId;
+  publication: Publication;
+  onClose: () => void;
+}
+
+const PublicationEditForm = ({
+  publicationId,
+  publication,
+  onClose,
+}: PublicationEditFormProps) => {
+  return (
+    <form className="p-2 flex flex-col gap-1">
+      {Publication.ATTRIBUTES.map((attrName) => (
+        <div key={attrName}>
+          <DataInput
+            rowId={publicationId}
+            colId={attrName}
+            value={publication[attrName]}
+            error=""
+          />
+        </div>
+      ))}
+      <div className="p-2 flex flex-row justify-between">
+        <Button
+          variant="secondary"
+          width="fixed"
+          onClick={onClose}
+          label="Cancel"
+        />
+        <Button variant="primary" width="fixed" type="submit" label="Submit" />
+      </div>
+    </form>
+  );
+};
+
+const PublicationEditModal = () => {
+  const { isOpen, close } = usePublicationEditModal();
+  const { query } = useRouter();
+  const rawPublicationId = query["publication"];
+  const publicationId =
+    rawPublicationId !== undefined
+      ? parseInt(rawPublicationId as string)
+      : undefined;
+
+  const publication = usePublication(publicationId as number);
+
+  const handleClose = () => close();
+
+  return (
+    <Modal isOpen={isOpen} onClose={close}>
+      <Article
+        heading={<>Edit Publication</>}
+        content={
+          publication ? (
+            <PublicationEditForm
+              publicationId={publicationId as number}
+              publication={publication as Publication}
+              onClose={handleClose}
+            />
+          ) : (
+            <div className="flex flex-col items-center">
+              <p className="p-4">Publication not found</p>
+              <Button
+                variant="secondary"
+                width="fixed"
+                onClick={handleClose}
+                label="Close"
+              />
+            </div>
+          )
+        }
+      />
+    </Modal>
+  );
+};
+
+export { PublicationEditModal, usePublicationEditModal };

--- a/frontend/components/PublicationEditModal.tsx
+++ b/frontend/components/PublicationEditModal.tsx
@@ -1,44 +1,79 @@
-import { useState } from "react";
+/**
+ * TODO:
+ * - autocomplete no funciona en PublicationInput y si funciona
+ *   en TablePublicationInput. Puede ser que se muestre atras del modal.
+ */
+import { useState, FormEvent } from "react";
 import { useRouter } from "next/router";
-import { Publication, PublicationId } from "modules/publication";
+import { http } from "app";
+import { isAxiosError } from "axios";
+import { Publication } from "modules/publication";
 import { Article } from "./Article";
 import { Modal, useURLQueryModal } from "./Modal";
 import Button from "./Button";
 import PublicationInput from "./PublicationInput";
+import { useNotify } from "./Notifications";
 
 const PUBLICATION_EDIT_MODAL_KEY = "edit";
+
 const usePublicationEditModal = () =>
   useURLQueryModal(PUBLICATION_EDIT_MODAL_KEY);
 
-const { usePublication } = Publication.STORE;
+const { usePublication, useSetPublication } = Publication.STORE;
 
 interface PublicationEditFormProps {
-  publicationId: PublicationId;
+  rowId: number;
   publication: Publication;
   onClose: () => void;
 }
 
 const PublicationEditForm = ({
-  publicationId,
+  rowId,
   publication: originalPublication,
   onClose,
 }: PublicationEditFormProps) => {
   const [publication, setPublication] = useState(originalPublication);
+  const [errors, setErrors] = useState({} as Record<keyof Publication, string>);
+  const [loading, setLoading] = useState(false);
+
+  const setStorePublication = useSetPublication();
+  const notify = useNotify();
 
   const handleChange = (key: string) => (value: string) => {
     setPublication({ ...originalPublication, [key]: value });
   };
 
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      setLoading(true);
+      const res = await http.put(`/publications/${publication.id}`, publication);
+
+      if (res.status == 200) {
+        setStorePublication(rowId, publication);
+        onClose();
+      }
+    } catch(err) {
+      if (isAxiosError(err) && err.response && err.response.status === 400) {
+        setErrors(err.response.data.errors);
+      } else {
+        notify({ message: "Publication edition failed", level: "error" });
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <form className="p-2 flex flex-col space-y-6">
+    <form className="p-2 flex flex-col space-y-6" onSubmit={handleSubmit}>
       {Publication.ATTRIBUTES.map((attribute) => (
         <PublicationInput
+          key={attribute}
           label={Publication.ATTRIBUTE_LABELS[attribute]}
-          publicationId={publicationId}
           attribute={attribute}
           value={publication[attribute]}
           onChange={handleChange(attribute)}
-          error=""
+          error={errors[attribute]}
           autoValidated
         />
       ))}
@@ -49,7 +84,7 @@ const PublicationEditForm = ({
           onClick={onClose}
           label="Cancel"
         />
-        <Button variant="primary" width="fixed" type="submit" label="Submit" />
+        <Button variant="primary" width="fixed" type="submit" label="Submit" loading={loading} />
       </div>
     </form>
   );
@@ -75,7 +110,7 @@ const PublicationEditModal = () => {
         content={
           publication ? (
             <PublicationEditForm
-              publicationId={publicationId as number}
+              rowId={publicationId as number}
               publication={publication as Publication}
               onClose={handleClose}
             />

--- a/frontend/components/PublicationEditModal.tsx
+++ b/frontend/components/PublicationEditModal.tsx
@@ -1,10 +1,3 @@
-/**
- * TODO: Problemas en los multiselect:
- * - Clickear en la cruz de las Pills de los multiselect
- *   a veces submitea el modal de editar.
- * - Clickear en la cruz de las Pills se borran opciones
- *   en varios multiselects (a veces).
- */
 import { useState, FormEvent } from "react";
 import { useRouter } from "next/router";
 import { http } from "app";
@@ -42,7 +35,7 @@ const PublicationEditForm = ({
   const notify = useNotify();
 
   const handleChange = (key: string) => (value: string) => {
-    setPublication({ ...originalPublication, [key]: value });
+    setPublication({ ...publication, [key]: value });
   };
 
   const handleSubmit = async (event: FormEvent) => {
@@ -115,7 +108,7 @@ const PublicationEditModal = () => {
   const handleClose = () => close();
 
   return (
-    <Modal isOpen={isOpen} onClose={close}>
+    <Modal isOpen={isOpen} onClose={handleClose}>
       <Article
         heading={<>Edit Publication</>}
         content={

--- a/frontend/components/PublicationEditModal.tsx
+++ b/frontend/components/PublicationEditModal.tsx
@@ -1,7 +1,9 @@
 /**
- * TODO:
- * - autocomplete no funciona en PublicationInput y si funciona
- *   en TablePublicationInput. Puede ser que se muestre atras del modal.
+ * TODO: Problemas en los multiselect:
+ * - Clickear en la cruz de las Pills de los multiselect
+ *   a veces submitea el modal de editar.
+ * - Clickear en la cruz de las Pills se borran opciones
+ *   en varios multiselects (a veces).
  */
 import { useState, FormEvent } from "react";
 import { useRouter } from "next/router";
@@ -47,13 +49,16 @@ const PublicationEditForm = ({
     event.preventDefault();
     try {
       setLoading(true);
-      const res = await http.put(`/publications/${publication.id}`, publication);
+      const res = await http.put(
+        `/publications/${publication.id}`,
+        publication,
+      );
 
       if (res.status == 200) {
         setStorePublication(rowId, publication);
         onClose();
       }
-    } catch(err) {
+    } catch (err) {
       if (isAxiosError(err) && err.response && err.response.status === 400) {
         setErrors(err.response.data.errors);
       } else {
@@ -84,7 +89,13 @@ const PublicationEditForm = ({
           onClick={onClose}
           label="Cancel"
         />
-        <Button variant="primary" width="fixed" type="submit" label="Submit" loading={loading} />
+        <Button
+          variant="primary"
+          width="fixed"
+          type="submit"
+          label="Submit"
+          loading={loading}
+        />
       </div>
     </form>
   );

--- a/frontend/components/PublicationEditModal.tsx
+++ b/frontend/components/PublicationEditModal.tsx
@@ -1,9 +1,10 @@
+import { useState } from "react";
 import { useRouter } from "next/router";
 import { Publication, PublicationId } from "modules/publication";
 import { Article } from "./Article";
 import { Modal, useURLQueryModal } from "./Modal";
 import Button from "./Button";
-import DataInput from "./DataInput";
+import PublicationInput from "./PublicationInput";
 
 const PUBLICATION_EDIT_MODAL_KEY = "edit";
 const usePublicationEditModal = () =>
@@ -19,22 +20,29 @@ interface PublicationEditFormProps {
 
 const PublicationEditForm = ({
   publicationId,
-  publication,
+  publication: originalPublication,
   onClose,
 }: PublicationEditFormProps) => {
+  const [publication, setPublication] = useState(originalPublication);
+
+  const handleChange = (key: string) => (value: string) => {
+    setPublication({ ...originalPublication, [key]: value });
+  };
+
   return (
-    <form className="p-2 flex flex-col gap-1">
-      {Publication.ATTRIBUTES.map((attrName) => (
-        <div key={attrName}>
-          <DataInput
-            rowId={publicationId}
-            colId={attrName}
-            value={publication[attrName]}
-            error=""
-          />
-        </div>
+    <form className="p-2 flex flex-col space-y-6">
+      {Publication.ATTRIBUTES.map((attribute) => (
+        <PublicationInput
+          label={Publication.ATTRIBUTE_LABELS[attribute]}
+          publicationId={publicationId}
+          attribute={attribute}
+          value={publication[attribute]}
+          onChange={handleChange(attribute)}
+          error=""
+          autoValidated
+        />
       ))}
-      <div className="p-2 flex flex-row justify-between">
+      <div className="mt-6 flex flex-row justify-between">
         <Button
           variant="secondary"
           width="fixed"

--- a/frontend/components/PublicationInput.tsx
+++ b/frontend/components/PublicationInput.tsx
@@ -1,0 +1,59 @@
+import {
+  Publication,
+  PublicationId,
+  PublicationKey,
+  PublicationKeyType,
+} from "modules/publication";
+import { FC, HTMLProps, Ref, forwardRef } from "react";
+import TextArrayDataInput from "./TextArrayDataInput";
+import TextDataInput from "./TextDataInput";
+import TextEnumArrayDataInput from "./TextEnumArrayDataInput";
+import TextEnumDataInput from "./TextEnumDataInput";
+import TextNumberDataInput from "./TextNumberDataInput";
+import Tooltip from "./Tooltip";
+
+const COMPONENTS_PER_TYPE: Record<PublicationKeyType, FC<Props>> = {
+  text: TextDataInput,
+  enum: TextEnumDataInput,
+  enumArray: TextEnumArrayDataInput,
+  number: TextNumberDataInput,
+  array: TextArrayDataInput,
+};
+
+type Props = Omit<HTMLProps<HTMLInputElement>, "onChange" | "ref"> & {
+  ref: Ref<HTMLElement>;
+  publicationId: PublicationId;
+  attribute: PublicationKey;
+  value: string;
+  error: string;
+  onChange?: (value: string) => void;
+  autoValidated?: boolean;
+};
+
+const PublicationInput = forwardRef<HTMLElement, Props>(
+  function DataInput(props, ref) {
+    const { attribute, value, error, onBlur, onChange } = props;
+
+    const type = Publication.ATTRIBUTE_TYPES[attribute];
+    const Component = COMPONENTS_PER_TYPE[type];
+    const placeholder = Publication.ATTRIBUTE_LABELS[attribute];
+
+    return (
+      <Tooltip error message={props.error}>
+        <Component
+          {...props}
+          {...Publication.define(attribute)}
+          ref={ref}
+          value={value}
+          onBlur={onBlur}
+          onChange={onChange}
+          placeholder={placeholder}
+          error={error}
+        />
+      </Tooltip>
+    );
+  },
+);
+
+export type { Props as PublicationInputProps };
+export default PublicationInput;

--- a/frontend/components/PublicationInput.tsx
+++ b/frontend/components/PublicationInput.tsx
@@ -1,6 +1,5 @@
 import {
   Publication,
-  PublicationId,
   PublicationKey,
   PublicationKeyType,
 } from "modules/publication";
@@ -22,7 +21,6 @@ const COMPONENTS_PER_TYPE: Record<PublicationKeyType, FC<Props>> = {
 
 type Props = Omit<HTMLProps<HTMLInputElement>, "onChange" | "ref"> & {
   ref: Ref<HTMLElement>;
-  publicationId: PublicationId;
   attribute: PublicationKey;
   value: string;
   error: string;
@@ -31,7 +29,7 @@ type Props = Omit<HTMLProps<HTMLInputElement>, "onChange" | "ref"> & {
 };
 
 const PublicationInput = forwardRef<HTMLElement, Props>(
-  function DataInput(props, ref) {
+  function PublicationInput(props, ref) {
     const { attribute, value, error, onBlur, onChange } = props;
 
     const type = Publication.ATTRIBUTE_TYPES[attribute];

--- a/frontend/components/PublicationModal.tsx
+++ b/frontend/components/PublicationModal.tsx
@@ -15,7 +15,7 @@ const usePublicationModal = () => useURLQueryModal(PUBLICATION_MODAL_KEY);
 const Param = z.string().regex(/^\d+$/).transform(Number).optional();
 type Param = z.infer<typeof Param>;
 const { useIsAuthenticated } = User;
-const { usePublicationEditId, usePublication } = Publication.STORE;
+const { usePublication } = Publication.STORE;
 
 const Searchable: FC<{ label: string; value?: string }> = ({
   value,

--- a/frontend/components/PublicationModal.tsx
+++ b/frontend/components/PublicationModal.tsx
@@ -1,21 +1,27 @@
 import { Publication, PublicationKey } from "modules/publication";
+import { User } from "modules/users";
 import Link from "next/link";
 import { FC } from "react";
 import { z } from "zod";
 import { Article } from "./Article";
 import { Modal, useURLQueryModal } from "./Modal";
+import { usePublicationEditModal } from "./PublicationEditModal";
 import Tooltip from "./Tooltip";
+import Button from "./Button";
 
 const PUBLICATION_MODAL_KEY = "publication";
+const usePublicationModal = () => useURLQueryModal(PUBLICATION_MODAL_KEY);
 
 const Param = z.string().regex(/^\d+$/).transform(Number).optional();
 type Param = z.infer<typeof Param>;
+const { useIsAuthenticated } = User;
+const { usePublicationEditId, usePublication } = Publication.STORE;
 
 const Searchable: FC<{ label: string; value?: string }> = ({
   value,
   label,
 }) => {
-  const { close } = useURLQueryModal(PUBLICATION_MODAL_KEY);
+  const { close } = usePublicationModal();
   return (
     <Link
       href={`/?search=${value || label}`}
@@ -87,22 +93,38 @@ const PublicationDescription: FC<{ publication: Publication }> = ({
 };
 
 const PublicationModal: FC = () => {
-  const { value, ...modal } = useURLQueryModal(PUBLICATION_MODAL_KEY);
+  const { value, ...modal } = usePublicationModal();
+  const editModal = usePublicationEditModal();
 
   const publicationId = Param.parse(value);
 
-  const publication = Publication.STORE.usePublication(publicationId);
+  const publication = usePublication(publicationId);
+
+  const isAuthenticated = useIsAuthenticated();
+
+  const handleEdit = () => {
+    editModal.open();
+  };
 
   return (
     <Modal isOpen={modal.isOpen} onClose={modal.close}>
       {publication && (
         <Article
           heading={<PublicationHeading publication={publication} />}
-          content={<PublicationDescription publication={publication} />}
+          content={
+            <>
+              <PublicationDescription publication={publication} />
+              {isAuthenticated && (
+                <div className="flex flex-row justify-center m-4">
+                  <Button onClick={handleEdit} label="Edit" width="fixed" />
+                </div>
+              )}
+            </>
+          }
         />
       )}
     </Modal>
   );
 };
 
-export { PUBLICATION_MODAL_KEY, PublicationModal };
+export { PUBLICATION_MODAL_KEY, PublicationModal, usePublicationModal };

--- a/frontend/components/PublicationReview.tsx
+++ b/frontend/components/PublicationReview.tsx
@@ -26,7 +26,7 @@ import {
   useIsSelectionEmpty,
   useSelectionEvent,
 } from "react-selection-manager";
-import DataInput from "./DataInput";
+import TablePublicationInput from "./TablePublicationInput";
 import Tooltip from "./Tooltip";
 
 const ExtendedColumn: typeof Column = (props) => {
@@ -81,7 +81,7 @@ const ExtendedSignalColumn: FC<{ rowId: RowId }> = ({ rowId }) => {
 
 const ExtendedContent: typeof Content = ({ rowId, colId, value, error }) => {
   return (
-    <DataInput
+    <TablePublicationInput
       rowId={rowId}
       colId={colId}
       value={value}
@@ -149,7 +149,7 @@ const SubmittableData: typeof Content = ({ rowId, colId, value, error }) => {
   );
 
   return (
-    <DataInput
+    <TablePublicationInput
       rowId={rowId}
       colId={colId}
       value={value}

--- a/frontend/components/TablePublicationInput.tsx
+++ b/frontend/components/TablePublicationInput.tsx
@@ -24,7 +24,7 @@ type Props = Omit<HTMLProps<HTMLInputElement>, "onChange" | "ref"> & {
 };
 
 const TablePublicationInput = forwardRef<HTMLElement, Props>(
-  function (props, ref) {
+  function TablePublicationInput(props, ref) {
     const {
       rowId,
       colId,
@@ -73,7 +73,6 @@ const TablePublicationInput = forwardRef<HTMLElement, Props>(
         ref={ref}
         value={value}
         attribute={colId}
-        publicationId={rowId}
         onChange={handleChange}
         onBlur={handleBlur}
         error={error}

--- a/frontend/components/TablePublicationInput.tsx
+++ b/frontend/components/TablePublicationInput.tsx
@@ -2,10 +2,8 @@ import {
   Publication,
   PublicationId,
   PublicationKey,
-  PublicationKeyType,
 } from "modules/publication";
 import {
-  FC,
   FocusEvent,
   HTMLProps,
   Ref,
@@ -13,20 +11,7 @@ import {
   useEffect,
   useState,
 } from "react";
-import TextArrayDataInput from "./TextArrayDataInput";
-import TextDataInput from "./TextDataInput";
-import TextEnumArrayDataInput from "./TextEnumArrayDataInput";
-import TextEnumDataInput from "./TextEnumDataInput";
-import TextNumberDataInput from "./TextNumberDataInput";
-import Tooltip from "./Tooltip";
-
-const COMPONENTS_PER_TYPE: Record<PublicationKeyType, FC<Props>> = {
-  text: TextDataInput,
-  enum: TextEnumDataInput,
-  enumArray: TextEnumArrayDataInput,
-  number: TextNumberDataInput,
-  array: TextArrayDataInput,
-};
+import PublicationInput from "./PublicationInput";
 
 type Props = Omit<HTMLProps<HTMLInputElement>, "onChange" | "ref"> & {
   ref: Ref<HTMLElement>;
@@ -38,22 +23,19 @@ type Props = Omit<HTMLProps<HTMLInputElement>, "onChange" | "ref"> & {
   autoValidated?: boolean;
 };
 
-const DataInput = forwardRef<HTMLElement, Props>(
-  function DataInput(props, ref) {
+const TablePublicationInput = forwardRef<HTMLElement, Props>(
+  function (props, ref) {
     const {
       rowId,
       colId,
       value: data,
       error,
-      autoValidated,
       onBlur,
+      autoValidated,
       onChange,
     } = props;
 
-    const type = Publication.ATTRIBUTE_TYPES[props.colId];
-    const Component = COMPONENTS_PER_TYPE[type];
-    const placeholder = Publication.ATTRIBUTE_LABELS[colId];
-
+    const type = Publication.ATTRIBUTE_TYPES[colId];
     const validate = Publication.REMOTE.useValidate();
     const override = Publication.STORE.ATTRIBUTES.useOverride();
     const [value, setValue] = useState(data);
@@ -67,10 +49,10 @@ const DataInput = forwardRef<HTMLElement, Props>(
     function handleChange(value: string) {
       setValue(value);
       override(rowId, colId, value);
+      onChange?.(value);
       if (type == "array" || type == "enum") {
         doValidate();
       }
-      onChange?.(value);
     }
 
     function handleBlur(event: FocusEvent<HTMLInputElement>) {
@@ -85,21 +67,20 @@ const DataInput = forwardRef<HTMLElement, Props>(
     }, [data, rowId, colId, value, setValue]);
 
     return (
-      <Tooltip error message={props.error}>
-        <Component
-          {...props}
-          {...Publication.define(colId)}
-          ref={ref}
-          value={value}
-          onBlur={handleBlur}
-          onChange={handleChange}
-          placeholder={placeholder}
-          error={error}
-        />
-      </Tooltip>
+      <PublicationInput
+        {...props}
+        {...Publication.define(colId)}
+        ref={ref}
+        value={value}
+        attribute={colId}
+        publicationId={rowId}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        error={error}
+        autoValidated={autoValidated}
+      />
     );
   },
 );
 
-export type { Props as DataInputProps };
-export default DataInput;
+export default TablePublicationInput;

--- a/frontend/components/TextArrayDataInput.tsx
+++ b/frontend/components/TextArrayDataInput.tsx
@@ -1,13 +1,13 @@
 import { Publication } from "modules/publication";
 import pDebounce from "p-debounce";
 import { FC, forwardRef, useCallback, useMemo } from "react";
-import { DataInputProps } from "./DataInput";
+import { PublicationInputProps } from "./PublicationInput";
 import Multicombobox from "./Multicombobox";
 
-export default forwardRef<HTMLDivElement, DataInputProps>(
+export default forwardRef<HTMLDivElement, PublicationInputProps>(
   function TextArrayDataInput(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    { colId, value, onChange, ...props },
+    { attribute, value, onChange, ...props },
     ref,
   ) {
     const items = useMemo(
@@ -22,10 +22,10 @@ export default forwardRef<HTMLDivElement, DataInputProps>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const getOptions = useCallback(
       pDebounce(
-        (search: string) => Publication.autocomplete(search, colId),
+        (search: string) => Publication.autocomplete(search, attribute),
         350,
       ),
-      [colId],
+      [attribute],
     );
 
     return (
@@ -38,4 +38,4 @@ export default forwardRef<HTMLDivElement, DataInputProps>(
       />
     );
   },
-) as FC<DataInputProps>;
+) as FC<PublicationInputProps>;

--- a/frontend/components/TextDataInput.tsx
+++ b/frontend/components/TextDataInput.tsx
@@ -1,9 +1,9 @@
 import { FC, forwardRef } from "react";
-import { DataInputProps } from "./DataInput";
+import { PublicationInputProps } from "./PublicationInput";
 import TextInput from "./TextInput";
 
-export default forwardRef<HTMLInputElement, DataInputProps>(
+export default forwardRef<HTMLInputElement, PublicationInputProps>(
   function TextDataInput(props, ref) {
     return <TextInput {...props} ref={ref} />;
   },
-) as FC<DataInputProps>;
+) as FC<PublicationInputProps>;

--- a/frontend/components/TextEnumArrayDataInput.tsx
+++ b/frontend/components/TextEnumArrayDataInput.tsx
@@ -24,8 +24,6 @@ export default forwardRef<HTMLDivElement, DataInputProps>(
       [value, toEnum],
     );
 
-    console.log({ value, items });
-
     function handleChange(value: Enum[]) {
       onChange?.(value.map(({ id }) => id).join(","));
     }

--- a/frontend/components/TextEnumArrayDataInput.tsx
+++ b/frontend/components/TextEnumArrayDataInput.tsx
@@ -1,22 +1,22 @@
 import { Publication } from "modules/publication";
 import pDebounce from "p-debounce";
 import { FC, forwardRef, useCallback, useMemo } from "react";
-import { DataInputProps } from "./DataInput";
+import { PublicationInputProps } from "./PublicationInput";
 import Multicombobox from "./Multicombobox";
 
 type Enum = { id: string; label: string };
 
-export default forwardRef<HTMLDivElement, DataInputProps>(
+export default forwardRef<HTMLDivElement, PublicationInputProps>(
   function TextEnumArrayDataInput(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    { colId, value, onChange, ...props },
+    { attribute, value, onChange, ...props },
     ref,
   ) {
     const toEnum = useCallback(
       (id: string): Enum => {
-        return { id, label: Publication.describeValue(id, colId) };
+        return { id, label: Publication.describeValue(id, attribute) };
       },
-      [colId],
+      [attribute],
     );
 
     const items = useMemo(
@@ -31,10 +31,10 @@ export default forwardRef<HTMLDivElement, DataInputProps>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const getOptions = useCallback(
       pDebounce(
-        (search: string) => Publication.autocomplete(search, colId),
+        (search: string) => Publication.autocomplete(search, attribute),
         350,
       ),
-      [colId],
+      [attribute],
     );
 
     return (
@@ -47,4 +47,4 @@ export default forwardRef<HTMLDivElement, DataInputProps>(
       />
     );
   },
-) as FC<DataInputProps>;
+) as FC<PublicationInputProps>;

--- a/frontend/components/TextEnumDataInput.tsx
+++ b/frontend/components/TextEnumDataInput.tsx
@@ -1,11 +1,11 @@
 import { Publication } from "modules/publication";
 import { FC, forwardRef, useCallback, useMemo } from "react";
-import { DataInputProps } from "./DataInput";
+import { PublicationInputProps } from "./PublicationInput";
 import Select, { SelectOption } from "./Select";
 import pDebounce from "p-debounce";
 
-export default forwardRef<HTMLInputElement, DataInputProps>(
-  function TextEnumDataInput({ colId, value, onChange, ...props }, ref) {
+export default forwardRef<HTMLInputElement, PublicationInputProps>(
+  function TextEnumDataInput({ attribute, value, onChange, ...props }, ref) {
     function handleChange(option: SelectOption) {
       onChange?.(option.id);
     }
@@ -13,18 +13,18 @@ export default forwardRef<HTMLInputElement, DataInputProps>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const getOptions = useCallback(
       pDebounce(
-        (search: string) => Publication.autocomplete(search, colId),
+        (search: string) => Publication.autocomplete(search, attribute),
         350,
       ),
-      [colId],
+      [attribute],
     );
 
     const selectedOption = useMemo(
       () =>
         value
-          ? { id: value, label: Publication.describeValue(value, colId) }
+          ? { id: value, label: Publication.describeValue(value, attribute) }
           : undefined,
-      [value, colId],
+      [value, attribute],
     );
 
     return (
@@ -37,4 +37,4 @@ export default forwardRef<HTMLInputElement, DataInputProps>(
       />
     );
   },
-) as FC<DataInputProps>;
+) as FC<PublicationInputProps>;

--- a/frontend/components/TextInput.tsx
+++ b/frontend/components/TextInput.tsx
@@ -62,10 +62,14 @@ export default forwardRef<HTMLDivElement, Props>(function TextInput(
           id={labelId}
           className={c(
             "absolute transition-all pointer-events-none",
-            "peer-placeholder-shown:text-gray-600 peer-placeholder-shown:text-sm text-xs peer-focus:text-xs text-indigo-600 peer-focus:text-indigo-600",
-            "peer-placeholder-shown:left-2 left-0 peer-focus:left-0 ",
-            "peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 -translate-y-full peer-focus:-translate-y-full top-0 peer-focus:top-0",
+            "text-xs peer-focus:text-xs text-indigo-600 peer-focus:text-indigo-600",
+            "left-0 peer-focus:left-0  -translate-y-full peer-focus:-translate-y-full top-0 peer-focus:top-0",
             "peer-error:text-red-600 peer-error:-translate-y-full peer-error:top-0 peer-error:left-0 peer-error:text-xs",
+            {
+              "peer-placeholder-shown:text-gray-600 peer-placeholder-shown:text-sm \
+               peer-placeholder-shown:left-2 peer-placeholder-shown:-translate-y-1/2 \
+               peer-placeholder-shown:top-1/2": !left,
+            },
           )}
         >
           {label} {error && <span id={errorId}>({error})</span>}
@@ -75,3 +79,5 @@ export default forwardRef<HTMLDivElement, Props>(function TextInput(
     </div>
   );
 });
+
+export type { Props as TextInputProps };

--- a/frontend/components/TextNumberDataInput.tsx
+++ b/frontend/components/TextNumberDataInput.tsx
@@ -1,9 +1,9 @@
 import { parseInt, toString } from "lodash";
 import { FC, forwardRef } from "react";
-import { DataInputProps } from "./DataInput";
+import { PublicationInputProps } from "./PublicationInput";
 import NumberInput from "./NumberInput";
 
-export default forwardRef<HTMLInputElement, DataInputProps>(
+export default forwardRef<HTMLInputElement, PublicationInputProps>(
   function TextNumberDataInput({ value, onChange, ...props }, ref) {
     function handleChange(value: number) {
       onChange?.(toString(value));
@@ -18,4 +18,4 @@ export default forwardRef<HTMLInputElement, DataInputProps>(
       />
     );
   },
-) as FC<DataInputProps>;
+) as FC<PublicationInputProps>;

--- a/frontend/modules/publication.ts
+++ b/frontend/modules/publication.ts
@@ -35,7 +35,14 @@ type Publication = {
 };
 
 type ValidationResult = { publication: Publication; errors: PublicationError };
-type PublicationKey = 'title' | 'countries' | 'year' | 'publishers' | 'authors' | 'originalTitle' | 'originalAuthors';
+type PublicationKey =
+  | "title"
+  | "countries"
+  | "year"
+  | "publishers"
+  | "authors"
+  | "originalTitle"
+  | "originalAuthors";
 type PublicationError = null | string | Record<PublicationKey, string>;
 type PublicationEntry = ValidationResult & { id: number };
 type PublicationId = number;

--- a/frontend/modules/publication.ts
+++ b/frontend/modules/publication.ts
@@ -24,6 +24,7 @@ import { COUNTRIES, Country } from "./country";
 import { Publisher } from "./publisher";
 
 type Publication = {
+  id: number | undefined;
   title: string;
   countries: string;
   year: string;
@@ -34,7 +35,7 @@ type Publication = {
 };
 
 type ValidationResult = { publication: Publication; errors: PublicationError };
-type PublicationKey = keyof Publication;
+type PublicationKey = 'title' | 'countries' | 'year' | 'publishers' | 'authors' | 'originalTitle' | 'originalAuthors';
 type PublicationError = null | string | Record<PublicationKey, string>;
 type PublicationEntry = ValidationResult & { id: number };
 type PublicationId = number;
@@ -291,6 +292,7 @@ interface PublicationModule {
     useError(id: PublicationId): PublicationError;
     useErrorDescription(id: PublicationId): string;
     useSetAll(): (entries: PublicationEntry[]) => void;
+    useSetPublication(): (id: PublicationId, pub: Publication) => void;
     useSetDeleted(): (ids: PublicationId[], isDeleted?: boolean) => void;
     useResetAll(): Resetter;
     useResetDeleted(): Resetter;
@@ -325,6 +327,7 @@ interface PublicationModule {
     };
 
     with: (params: Pick<CallbackInterface, "set">) => {
+      setPublication(id: PublicationId, publication: Publication): void;
       setPublications(entries: PublicationEntry[]): void;
       setErrors(entries: PublicationEntry[]): void;
       setFocusedRowId(id: PublicationId | undefined): void;
@@ -504,6 +507,13 @@ const Publication: PublicationModule = {
         [],
       );
     },
+    useSetPublication() {
+      return useRecoilCallback(
+        ({ set }) =>
+          (id: PublicationId, publication: Publication) =>
+            set(PUBLICATIONS(id), publication),
+      );
+    },
     useSetDeleted() {
       return useRecoilCallback(
         ({ set }) =>
@@ -631,6 +641,9 @@ const Publication: PublicationModule = {
     }),
 
     with: ({ set }) => ({
+      setPublication(id, publication) {
+        set(PUBLICATIONS(id), publication);
+      },
       setPublications(entries) {
         const ids = entries.map(({ id }) => id);
         set(PUBLICATION_IDS, ids);
@@ -902,6 +915,7 @@ const Publication: PublicationModule = {
 
   empty() {
     return {
+      id: undefined,
       authors: "",
       countries: "",
       originalAuthors: "",

--- a/frontend/modules/publication.ts
+++ b/frontend/modules/publication.ts
@@ -565,7 +565,6 @@ const Publication: PublicationModule = {
     useOverrideValue(id) {
       return useRecoilValue(PUBLICATION_OVERRIDES(id));
     },
-
     useIsValid(id) {
       return useRecoilValue(IS_PUBLICATION_VALID(id));
     },

--- a/frontend/modules/publication.ts
+++ b/frontend/modules/publication.ts
@@ -35,14 +35,7 @@ type Publication = {
 };
 
 type ValidationResult = { publication: Publication; errors: PublicationError };
-type PublicationKey =
-  | "title"
-  | "countries"
-  | "year"
-  | "publishers"
-  | "authors"
-  | "originalTitle"
-  | "originalAuthors";
+type PublicationKey = keyof Omit<Publication, "id">;
 type PublicationError = null | string | Record<PublicationKey, string>;
 type PublicationEntry = ValidationResult & { id: number };
 type PublicationId = number;

--- a/frontend/modules/users.ts
+++ b/frontend/modules/users.ts
@@ -30,7 +30,5 @@ const User: UserModule = {
   },
 };
 
-const useIsAuthenticated = () => {};
-
 export { User };
 export type { UserRole };

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -4,15 +4,15 @@ import { ContactModal } from "components/ContactModal";
 import { Counter } from "components/Counter";
 import Layout from "components/Layout";
 import { LearnMoreModal } from "components/LearnMoreModal";
-import { useURLQueryModal } from "components/Modal";
 import PublicationDownload from "components/PublicationDownload";
 import PublicationHiddenAttributes from "components/PublicationHiddenAttributes";
 import { PublicationIndexList } from "components/PublicationIndexList";
 import { PublicationIndexTable } from "components/PublicationIndexTable";
 import {
-  PUBLICATION_MODAL_KEY,
   PublicationModal,
+  usePublicationModal,
 } from "components/PublicationModal";
+import { PublicationEditModal } from "components/PublicationEditModal";
 import PublicationSearch from "components/PublicationSearch";
 import SignInButton from "components/SignInButton";
 import SignOutButton from "components/SignOutButton";
@@ -42,7 +42,7 @@ const Home: NextPage = () => {
     }
   }, [reset, index, search, isReady]);
 
-  const modal = useURLQueryModal(PUBLICATION_MODAL_KEY);
+  const modal = usePublicationModal();
 
   function handleRowClick(id: number) {
     return () => modal.open(`${id}`);
@@ -59,6 +59,7 @@ const Home: NextPage = () => {
             <PublicationIndexList onItemClick={handleRowClick} />
           </div>
           <PublicationModal />
+          <PublicationEditModal />
         </>
       }
       leftAside={<PublicationHiddenAttributes />}


### PR DESCRIPTION
- Add Edit publication form which is displayed as a modal (`<PublicationEditModal />`), accessed from the publication detail moda.
- Add `rootRef` to `<MenuProvider />` so we can show the menu in floating windows. This is used for inputs autocomplete.
- Add type to `<Pill />` button so it does not trigger a submit when rendered within a form.
- Refactor Inputs related to publication: split `<DataInput />` into `<PublicationInput />` which renders an input for a given publication field and `<PublicationTableInput />` which renders a publication input to be used in the bulk add table and handles some `Publication.STORE` actions.
- Remove label effect on `<TextInput />` when there are pills renderd to its left because label and pills where overlapping.

### Screenshot

![Captura de pantalla 2024-07-24 a la(s) 16 15 47](https://github.com/user-attachments/assets/7065d60e-4924-420c-80a5-9ca8b6c01d5a)
