### PR TITLE
Validate token expiry and refresh JWKS on rotation

### DIFF
--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -4,7 +4,10 @@ config :richard_burton,
   phx_consumer_url: "http://localhost:3000",
   google_client_id: nil,
   google_openid_config_url: nil,
-  google_oauth2_certs_url: nil
+  google_oauth2_certs_url: nil,
+  # The key store runs in all environments; under test it uses a no-op JWKS
+  # provider so it makes no network calls (auth itself is mocked via Mox).
+  jwks_provider: RichardBurton.Auth.JWKS.Stub
 
 # Configure your database
 #

--- a/backend/lib/richard_burton/application.ex
+++ b/backend/lib/richard_burton/application.ex
@@ -5,8 +5,6 @@ defmodule RichardBurton.Application do
 
   use Application
 
-  @environment Mix.env()
-
   @impl true
   def start(_type, _args) do
     children = [
@@ -17,9 +15,10 @@ defmodule RichardBurton.Application do
       # Start the PubSub system
       {Phoenix.PubSub, name: RichardBurton.PubSub},
       # Start the Endpoint (http/https)
-      RichardBurtonWeb.Endpoint
-      # Start a worker by calling: RichardBurton.Worker.start_link(arg)
-      # {RichardBurton.Worker, arg}
+      RichardBurtonWeb.Endpoint,
+      # Start the JWKS key store. Its provider is configured via :jwks_provider
+      # (Google in dev/prod; a stub under test, so no network calls are made).
+      RichardBurton.Auth.KeyStore
     ]
 
     # Set missing runtime config from Application env
@@ -44,11 +43,6 @@ defmodule RichardBurton.Application do
     |> Enum.reject(fn {_, key} -> is_nil(Application.get_env(:richard_burton, key)) end)
     |> Enum.map(fn {k1, k2} -> {k1, Application.get_env(:richard_burton, k2)} end)
     |> System.put_env()
-
-    if @environment !== :test do
-      # Initialize configuration for auth service
-      Application.put_env(:richard_burton, :auth_config, RichardBurton.Auth.init())
-    end
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/backend/lib/richard_burton/auth_claims.ex
+++ b/backend/lib/richard_burton/auth_claims.ex
@@ -1,0 +1,25 @@
+defmodule RichardBurton.Auth.Claims do
+  @moduledoc """
+  Validates the claims of an OIDC ID token: issuer, audience, subject and
+  expiry. Signature verification is performed separately (see
+  `RichardBurton.Auth.Google`); this module only checks the decoded claims.
+  """
+
+  @doc "Returns `{:ok, subject_id}` when every claim is valid, `:error` otherwise."
+  @spec validate(map(), String.t() | nil, String.t() | nil, integer()) ::
+          {:ok, String.t()} | :error
+  def validate(claims, issuer, audience, now \\ System.system_time(:second))
+
+  def validate(%{"iss" => iss, "aud" => aud, "sub" => sub, "exp" => exp}, issuer, audience, now)
+      when is_binary(sub) and sub != "" and is_integer(exp) do
+    cond do
+      is_nil(issuer) or iss != issuer -> :error
+      is_nil(audience) or aud != audience -> :error
+      # exp is a POSIX timestamp; reject tokens that have reached expiry.
+      exp <= now -> :error
+      true -> {:ok, sub}
+    end
+  end
+
+  def validate(_claims, _issuer, _audience, _now), do: :error
+end

--- a/backend/lib/richard_burton/auth_jwks.ex
+++ b/backend/lib/richard_burton/auth_jwks.ex
@@ -1,0 +1,10 @@
+defmodule RichardBurton.Auth.JWKS do
+  @moduledoc """
+  Behaviour for fetching a JSON Web Key Set (JWKS): the signing keys and issuer
+  used to verify ID tokens, plus the cache lifetime the provider advertises.
+  """
+
+  @type result :: %{issuer: String.t() | nil, keys: [map()], max_age: non_neg_integer()}
+
+  @callback fetch() :: {:ok, result()} | {:error, term()}
+end

--- a/backend/lib/richard_burton/auth_jwks_google.ex
+++ b/backend/lib/richard_burton/auth_jwks_google.ex
@@ -1,0 +1,61 @@
+defmodule RichardBurton.Auth.JWKS.Google do
+  @moduledoc """
+  `RichardBurton.Auth.JWKS` implementation that fetches from Google: the issuer
+  from Google's OpenID configuration and the signing keys from its OAuth2 certs
+  endpoint (respecting the certs' `Cache-Control: max-age`).
+  """
+  @behaviour RichardBurton.Auth.JWKS
+
+  # Fallback if the certs response carries no Cache-Control max-age.
+  @default_max_age 3600
+
+  @impl true
+  def fetch do
+    with {:ok, issuer} <- fetch_issuer(),
+         {:ok, keys, max_age} <- fetch_keys() do
+      {:ok, %{issuer: issuer, keys: keys, max_age: max_age}}
+    end
+  end
+
+  defp fetch_issuer do
+    with {:ok, url} <- env("GOOGLE_OPENID_CONFIG_URL"),
+         {:ok, %{status_code: 200, body: body}} <- HTTPoison.get(url),
+         {:ok, %{"issuer" => issuer}} <- Jason.decode(body) do
+      {:ok, issuer}
+    else
+      _ -> {:error, :openid_config_unavailable}
+    end
+  end
+
+  defp fetch_keys do
+    with {:ok, url} <- env("GOOGLE_OAUTH2_CERTS_URL"),
+         {:ok, %{status_code: 200, body: body, headers: headers}} <- HTTPoison.get(url),
+         {:ok, %{"keys" => keys}} <- Jason.decode(body) do
+      {:ok, keys, max_age(headers)}
+    else
+      _ -> {:error, :jwks_unavailable}
+    end
+  end
+
+  defp env(name) do
+    case System.get_env(name) do
+      value when value in [nil, ""] -> {:error, {:missing_env, name}}
+      value -> {:ok, value}
+    end
+  end
+
+  defp max_age(headers) do
+    headers
+    |> Enum.find_value(fn {k, v} -> if String.downcase(k) == "cache-control", do: v end)
+    |> parse_max_age()
+  end
+
+  defp parse_max_age(nil), do: @default_max_age
+
+  defp parse_max_age(cache_control) do
+    case Regex.run(~r/max-age=(\d+)/, cache_control) do
+      [_, seconds] -> String.to_integer(seconds)
+      _ -> @default_max_age
+    end
+  end
+end

--- a/backend/lib/richard_burton/auth_jwks_stub.ex
+++ b/backend/lib/richard_burton/auth_jwks_stub.ex
@@ -1,0 +1,13 @@
+defmodule RichardBurton.Auth.JWKS.Stub do
+  @moduledoc """
+  `RichardBurton.Auth.JWKS` implementation that fetches nothing.
+
+  Used under test (and in any environment where no identity provider is
+  configured) so the key store can run without making network calls. Any token
+  verification against it fails cleanly.
+  """
+  @behaviour RichardBurton.Auth.JWKS
+
+  @impl true
+  def fetch, do: {:ok, %{issuer: nil, keys: [], max_age: 0}}
+end

--- a/backend/lib/richard_burton/auth_key_store.ex
+++ b/backend/lib/richard_burton/auth_key_store.ex
@@ -1,0 +1,118 @@
+defmodule RichardBurton.Auth.KeyStore do
+  @moduledoc """
+  Caches a provider's JWKS signing keys and keeps them fresh so that key
+  rotation does not require restarting the server.
+
+  Provider-agnostic: it caches whatever any `RichardBurton.Auth.JWKS`
+  implementation returns. The implementation is configured via the `:jwks_provider`
+  application env and can be overridden per instance with the `:provider` option.
+
+  Keys are refreshed:
+
+    * on a schedule, honouring the `max-age` advertised by the provider; and
+    * lazily, whenever a token presents a `kid` that is not currently cached
+      (rate-limited by `:refresh_cooldown` to avoid hammering the
+      provider with bogus `kid`s).
+  """
+  use GenServer
+
+  @default_provider RichardBurton.Auth.JWKS.Google
+  @default_refresh_cooldown 60_000
+  @default_max_age 3600
+
+  # Client API
+
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "The issuer advertised by the provider, or nil if not fetched yet."
+  @spec issuer(GenServer.server()) :: String.t() | nil
+  def issuer(server \\ __MODULE__), do: GenServer.call(server, :issuer)
+
+  @doc """
+  Returns `{:ok, key}` for the cached key matching `kid`. On a cache miss, the
+  keys are refreshed once (rate-limited) before giving up with `:error`.
+  """
+  @spec fetch_key(GenServer.server(), String.t()) :: {:ok, map()} | :error
+  def fetch_key(server \\ __MODULE__, kid), do: GenServer.call(server, {:fetch_key, kid})
+
+  # Server
+
+  @impl true
+  def init(opts) do
+    state = %{
+      provider: Keyword.get(opts, :provider) || configured_provider(),
+      refresh_cooldown: Keyword.get(opts, :refresh_cooldown, @default_refresh_cooldown),
+      issuer: nil,
+      keys: [],
+      max_age: @default_max_age,
+      refreshed_at: nil
+    }
+
+    state = do_refresh(state)
+    schedule_next(state)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_call(:issuer, _from, state), do: {:reply, state.issuer, state}
+
+  def handle_call({:fetch_key, kid}, _from, state) do
+    case find_key(state, kid) do
+      nil ->
+        state = maybe_refresh(state)
+        {:reply, reply_for(find_key(state, kid)), state}
+
+      key ->
+        {:reply, {:ok, key}, state}
+    end
+  end
+
+  @impl true
+  def handle_info(:scheduled_refresh, state) do
+    state = do_refresh(state)
+    schedule_next(state)
+    {:noreply, state}
+  end
+
+  defp configured_provider do
+    Application.get_env(:richard_burton, :jwks_provider, @default_provider)
+  end
+
+  defp find_key(%{keys: keys}, kid), do: Enum.find(keys, &(&1["kid"] == kid))
+
+  defp reply_for(nil), do: :error
+  defp reply_for(key), do: {:ok, key}
+
+  defp maybe_refresh(state) do
+    if can_refresh?(state), do: do_refresh(state), else: state
+  end
+
+  defp can_refresh?(%{refreshed_at: nil}), do: true
+
+  defp can_refresh?(%{refreshed_at: last, refresh_cooldown: cd}), do: now_ms() - last >= cd
+
+  defp do_refresh(state) do
+    case state.provider.fetch() do
+      {:ok, %{issuer: issuer, keys: keys, max_age: max_age}} ->
+        %{state | issuer: issuer, keys: keys, max_age: max_age, refreshed_at: now_ms()}
+
+      {:ok, %{issuer: issuer, keys: keys}} ->
+        %{state | issuer: issuer, keys: keys, refreshed_at: now_ms()}
+
+      {:error, _reason} ->
+        # Keep the existing (possibly empty) cache; a later request retries.
+        %{state | refreshed_at: now_ms()}
+    end
+  end
+
+  defp schedule_next(%{max_age: max_age}) when is_integer(max_age) and max_age > 0 do
+    Process.send_after(self(), :scheduled_refresh, max_age * 1000)
+  end
+
+  defp schedule_next(_state), do: :ok
+
+  defp now_ms, do: System.monotonic_time(:millisecond)
+end

--- a/backend/lib/richard_burton/auth_service.ex
+++ b/backend/lib/richard_burton/auth_service.ex
@@ -1,19 +1,19 @@
 defmodule RichardBurton.Auth do
   @moduledoc """
-  Behaviour for authentication services
+  Authentication/authorization boundary. Delegates to the implementation
+  configured under `:auth_service` (default `RichardBurton.Auth.Google`, swapped
+  for a Mox mock in tests).
   """
 
-  @callback init() :: {Map.t(), List.t()}
   @callback verify(token :: String.t()) :: {:ok, String.t()} | :error
-  @callback authorize(subject_id :: String.t(), role :: Atom.t()) :: :ok | :error
+  @callback authorize(subject_id :: String.t(), role :: atom()) :: :ok | :error
 
-  @spec init() :: {Map.t(), List.t()}
-  def init, do: impl().init()
-
+  @doc "Authenticates an ID token, returning `{:ok, subject_id}` or `:error`."
   @spec verify(token :: String.t()) :: {:ok, String.t()} | :error
   def verify(token), do: impl().verify(token)
 
-  @spec authorize(subject_id :: String.t(), role :: Atom.t()) :: :ok | :error
+  @doc "Returns `:ok` if `subject_id` currently holds `role`, `:error` otherwise."
+  @spec authorize(subject_id :: String.t(), role :: atom()) :: :ok | :error
   def authorize(subject_id, role), do: impl().authorize(subject_id, role)
 
   defp impl, do: Application.get_env(:richard_burton, :auth_service, RichardBurton.Auth.Google)

--- a/backend/lib/richard_burton/auth_service_google.ex
+++ b/backend/lib/richard_burton/auth_service_google.ex
@@ -1,34 +1,36 @@
 defmodule RichardBurton.Auth.Google do
   @moduledoc """
-  Google idp implementation for RichardBurton.Auth behaviour
+  Google identity-provider implementation of the `RichardBurton.Auth` behaviour.
+
+  ID tokens are verified against Google's JWKS signing keys, which are cached
+  and refreshed by `RichardBurton.Auth.KeyStore` (using the
+  `RichardBurton.Auth.JWKS.Google` provider) so that key rotation does not
+  require a restart. The issuer, audience and expiry are all validated (see
+  `RichardBurton.Auth.Claims`).
   """
   @behaviour RichardBurton.Auth
 
+  alias RichardBurton.Auth.Claims
+  alias RichardBurton.Auth.KeyStore
   alias RichardBurton.User
-
-  @impl true
-  @spec init() :: {Map.t(), List.t()}
-  def init(), do: {get_config(), get_keys()}
 
   @impl true
   @spec verify(token :: String.t()) :: {:ok, String.t()} | :error
   def verify(token) do
-    case Application.get_env(:richard_burton, :auth_config) do
-      {%{"issuer" => issuer}, keys} ->
-        do_verify(
-          token,
-          issuer: issuer,
-          audience: get_audience(),
-          keys: keys
-        )
-
-      _ ->
-        throw("Auth configuration is not properly set")
+    with {:ok, %{"kid" => kid}} <- Joken.peek_header(token),
+         {:ok, key} <- KeyStore.fetch_key(kid),
+         {:ok, claims} <- verify_signature(token, key) do
+      Claims.validate(claims, KeyStore.issuer(), audience())
+    else
+      _ -> :error
     end
+  rescue
+    # A malformed token (bad header, unusable key, etc.) is just an auth failure.
+    _ -> :error
   end
 
   @impl true
-  @spec authorize(subject_id :: String.t(), role :: Atom.t()) :: :ok | :error
+  @spec authorize(subject_id :: String.t(), role :: atom()) :: :ok | :error
   def authorize(subject_id, role) do
     case User.get(subject_id) do
       %{role: ^role} -> :ok
@@ -36,51 +38,16 @@ defmodule RichardBurton.Auth.Google do
     end
   end
 
-  defp get_audience do
-    case System.get_env("GOOGLE_CLIENT_ID") do
-      nil -> throw("GOOGLE_CLIENT_ID environment variable is not set")
-      audience -> audience
-    end
-  end
+  # The signing algorithm is taken from the trusted JWKS key (not the token
+  # header), which avoids algorithm-confusion attacks.
+  defp verify_signature(token, key) do
+    signer = Joken.Signer.create(key["alg"], key)
 
-  defp do_verify(token, issuer: issuer, audience: audience, keys: keys) do
-    case Joken.verify(token, get_signer(token, keys)) do
-      {:ok, %{"iss" => ^issuer, "aud" => ^audience, "sub" => subject_id}} -> {:ok, subject_id}
+    case Joken.verify(token, signer) do
+      {:ok, claims} -> {:ok, claims}
       _ -> :error
     end
   end
 
-  defp get_signer(token, keys) do
-    {:ok, %{"kid" => kid}} = Joken.peek_header(token)
-    %{"alg" => alg} = key = Enum.find(keys, fn k -> k["kid"] == kid end)
-    Joken.Signer.create(alg, key)
-  end
-
-  defp get_config do
-    case System.get_env("GOOGLE_OPENID_CONFIG_URL") do
-      nil ->
-        throw("GOOGLE_OPENID_CONFIG_URL environment variable is not set")
-
-      url ->
-        url
-        |> HTTPoison.get!()
-        |> Map.get(:body)
-        |> Jason.decode!()
-        |> Map.take(["issuer"])
-    end
-  end
-
-  defp get_keys do
-    case System.get_env("GOOGLE_OAUTH2_CERTS_URL") do
-      nil ->
-        throw("GOOGLE_OAUTH2_CERTS_URL environment variable is not set")
-
-      url ->
-        url
-        |> HTTPoison.get!()
-        |> Map.get(:body)
-        |> Jason.decode!()
-        |> Map.get("keys")
-    end
-  end
+  defp audience, do: System.get_env("GOOGLE_CLIENT_ID")
 end

--- a/backend/test/richard_burton/auth_claims_test.exs
+++ b/backend/test/richard_burton/auth_claims_test.exs
@@ -1,0 +1,59 @@
+defmodule RichardBurton.Auth.ClaimsTest do
+  @moduledoc """
+  Tests for OIDC ID token claim validation (issuer, audience, subject, expiry).
+  """
+  use ExUnit.Case, async: true
+
+  alias RichardBurton.Auth.Claims
+
+  @iss "https://accounts.google.com"
+  @aud "client-id.apps.googleusercontent.com"
+  @now 1_000_000
+
+  defp claims(overrides \\ %{}) do
+    Map.merge(
+      %{
+        "iss" => @iss,
+        "aud" => @aud,
+        "sub" => "subject-123",
+        "exp" => @now + 3600
+      },
+      overrides
+    )
+  end
+
+  test "returns the subject id when every claim is valid" do
+    assert Claims.validate(claims(), @iss, @aud, @now) == {:ok, "subject-123"}
+  end
+
+  test "rejects an expired token" do
+    assert Claims.validate(claims(%{"exp" => @now - 1}), @iss, @aud, @now) == :error
+  end
+
+  test "rejects a token that expires exactly now" do
+    assert Claims.validate(claims(%{"exp" => @now}), @iss, @aud, @now) == :error
+  end
+
+  test "rejects a mismatched issuer" do
+    assert Claims.validate(claims(%{"iss" => "https://unknown.com"}), @iss, @aud, @now) == :error
+  end
+
+  test "rejects a mismatched audience" do
+    assert Claims.validate(claims(%{"aud" => "other-client"}), @iss, @aud, @now) == :error
+  end
+
+  test "rejects a missing or blank subject" do
+    assert Claims.validate(Map.delete(claims(), "sub"), @iss, @aud, @now) == :error
+    assert Claims.validate(claims(%{"sub" => ""}), @iss, @aud, @now) == :error
+  end
+
+  test "rejects a missing or non-integer expiry" do
+    assert Claims.validate(Map.delete(claims(), "exp"), @iss, @aud, @now) == :error
+    assert Claims.validate(claims(%{"exp" => "soon"}), @iss, @aud, @now) == :error
+  end
+
+  test "rejects when the issuer or audience are not configured" do
+    assert Claims.validate(claims(), nil, @aud, @now) == :error
+    assert Claims.validate(claims(), @iss, nil, @now) == :error
+  end
+end

--- a/backend/test/richard_burton/auth_key_store_test.exs
+++ b/backend/test/richard_burton/auth_key_store_test.exs
@@ -1,0 +1,76 @@
+defmodule RichardBurton.Auth.KeyStoreTest do
+  @moduledoc """
+  Tests for the JWKS key store, focused on the key-rotation behaviour: an
+  unknown `kid` must trigger a refetch rather than failing until restart.
+  """
+  use ExUnit.Case, async: false
+
+  alias RichardBurton.Auth.KeyStore
+
+  @issuer "https://accounts.google.com"
+
+  # Agent-backed JWKS provider whose published keys can be changed mid-test to
+  # simulate the identity provider rotating its signing keys.
+  defmodule StubJWKS do
+    use Agent
+    @behaviour RichardBurton.Auth.JWKS
+
+    def start_link(result), do: Agent.start_link(fn -> result end, name: __MODULE__)
+
+    def publish(result), do: Agent.update(__MODULE__, fn _ -> result end)
+
+    @impl true
+    def fetch, do: Agent.get(__MODULE__, & &1)
+  end
+
+  defp key(kid) do
+    %{"kid" => kid, "alg" => "RS256", "kty" => "RSA", "n" => "modulus-#{kid}", "e" => "AQAB"}
+  end
+
+  defp jwks(kids), do: {:ok, %{issuer: @issuer, keys: Enum.map(kids, &key/1), max_age: 3600}}
+
+  setup do
+    start_supervised!({StubJWKS, jwks(["k1"])})
+
+    store =
+      start_supervised!(
+        {KeyStore, provider: StubJWKS, refresh_cooldown: 0, name: :test_key_store}
+      )
+
+    %{store: store}
+  end
+
+  test "serves a cached key by kid", %{store: store} do
+    assert {:ok, %{"kid" => "k1"}} = KeyStore.fetch_key(store, "k1")
+  end
+
+  test "exposes the issuer fetched from the provider", %{store: store} do
+    assert KeyStore.issuer(store) == @issuer
+  end
+
+  test "returns :error for a kid the provider has not published", %{store: store} do
+    assert KeyStore.fetch_key(store, "unknown") == :error
+  end
+
+  test "refetches and resolves a rotated key on a cache miss", %{store: store} do
+    # k2 is not published yet: a miss triggers a refresh but still fails.
+    assert KeyStore.fetch_key(store, "k2") == :error
+
+    # The provider rotates and now publishes k2.
+    StubJWKS.publish(jwks(["k1", "k2"]))
+
+    # The next request for k2 misses the cache, refetches, and now resolves it
+    # — no restart required.
+    assert {:ok, %{"kid" => "k2"}} = KeyStore.fetch_key(store, "k2")
+  end
+
+  test "stays available (serves cached keys) when a refresh fails", %{store: store} do
+    StubJWKS.publish({:error, :unavailable})
+
+    # A miss triggers a failing refresh; it must not crash and must return :error.
+    assert KeyStore.fetch_key(store, "k3") == :error
+
+    # Previously cached keys are still served.
+    assert {:ok, %{"kid" => "k1"}} = KeyStore.fetch_key(store, "k1")
+  end
+end


### PR DESCRIPTION
## Problem

Google's JWKS signing keys were fetched once at boot and frozen. On rotation, tokens carried an unknown `kid`, verification raised a `MatchError`, and **every login failed until restart**. Token **expiry was also never checked** (`Joken.verify` only checks the signature), so tokens were accepted indefinitely.

## Change
- `Auth.KeyStore` — a GenServer that caches the JWKS and refreshes it on a schedule and lazily on an unknown `kid`, so rotation no longer needs a restart.
- `Auth.JWKS` behaviour with `Auth.JWKS.Google` (HTTP) and `Auth.JWKS.Stub` (tests) providers, selected via `:jwks_provider` config.
- `Auth.Claims` — now validates `iss`/`aud`/`sub` **and `exp`**.
- `Auth.Google` is now a thin implementation over these.