### PR TITLE
Broaden Storybook coverage and fix Tailwind v4 fallout

### DIFF
--- a/frontend/components/Button.tsx
+++ b/frontend/components/Button.tsx
@@ -65,7 +65,7 @@ const Button = forwardRef<HTMLButtonElement, Props>(function Button(
       data-width={width}
       data-alignment={alignment}
       className={`
-        flex py-1.5 px-2 transition-colors items-center rounded font-base shadow-sm text-xs group space-x-2 whitespace-nowrap
+        flex py-1.5 px-2 transition-colors items-center rounded font-base shadow-sm text-xs group gap-2 whitespace-nowrap
         data-[loading=false]:disabled:bg-gray-100 data-[loading=false]:disabled:text-gray-300 data-[loading=false]:disabled:hover:bg-gray-100
         data-[variant=primary]:text-white data-[variant=primary]:bg-indigo-600 data-[variant=primary]:hover:bg-indigo-700 data-[variant=primary]:loading:bg-indigo-700
         data-[variant=secondary]:text-gray-900 data-[variant=secondary]:bg-yellow-500 data-[variant=secondary]:hover:bg-yellow-600 data-[variant=secondary]:loading:bg-yellow-600

--- a/frontend/components/DataInput.stories.tsx
+++ b/frontend/components/DataInput.stories.tsx
@@ -10,6 +10,13 @@ const meta = {
   title: "Publications/Data input",
   component: DataInput,
   args: { rowId: 1, colId: "title", value: "", error: "", onChange: () => {} },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
+        <Story />
+      </div>
+    ),
+  ],
   parameters: { layout: "centered" },
 } satisfies Meta<typeof DataInput>;
 

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -124,11 +124,10 @@ const Modal: FC<Props> = ({ children, isOpen, onClose, label = "Dialog" }) => {
                   w-full sm:w-11/12 lg:w-2/3 xl:w-1/2
                   h-full sm:h-auto sm:max-h-[85%] lg:max-h-[80%] min-h-0
                 `}
-                initial={{ scale: 0.9, transform: "translateX(-50%)" }}
+                initial={{ scale: 0.9 }}
                 animate={{
                   scale: 1,
                   top: isWiderThanSmall ? "12%" : "0",
-                  transform: "translateX(-50%)",
                 }}
                 exit={{ scale: 0.9, top: 0 }}
               >

--- a/frontend/components/TextArea.stories.tsx
+++ b/frontend/components/TextArea.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   // clear without the frame masquerading as the textarea's own chrome.
   decorators: [
     (Story) => (
-      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8">
+      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
         <Story />
       </div>
     ),

--- a/frontend/components/TextArea.tsx
+++ b/frontend/components/TextArea.tsx
@@ -42,7 +42,7 @@ export default forwardRef<HTMLDivElement, Props>(function TextArea(
       data-fill={Boolean(fill)}
       data-labeled={Boolean(label)}
       className={`
-        relative group
+        relative group bg-white
         w-full gap-1 inline-flex items-center rounded scrollbar scrollbar-none
         error-within:shadow-sm focus-within:error-within:bg-red-400/80, error-within:bg-red-300/40
         has-disabled:opacity-60 has-disabled:cursor-not-allowed

--- a/frontend/components/TextArrayDataInput.stories.tsx
+++ b/frontend/components/TextArrayDataInput.stories.tsx
@@ -18,6 +18,13 @@ const meta = {
     onChange: fn(),
     "aria-label": "Authors",
   },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
+        <Story />
+      </div>
+    ),
+  ],
   parameters: { layout: "centered" },
 } satisfies Meta<typeof TextArrayDataInput>;
 

--- a/frontend/components/TextDataInput.stories.tsx
+++ b/frontend/components/TextDataInput.stories.tsx
@@ -17,6 +17,13 @@ const meta = {
     onChange: fn(),
     "aria-label": "Title",
   },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
+        <Story />
+      </div>
+    ),
+  ],
   parameters: { layout: "centered" },
 } satisfies Meta<typeof TextDataInput>;
 

--- a/frontend/components/TextEnumArrayDataInput.stories.tsx
+++ b/frontend/components/TextEnumArrayDataInput.stories.tsx
@@ -18,6 +18,13 @@ const meta = {
     onChange: fn(),
     "aria-label": "Countries",
   },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
+        <Story />
+      </div>
+    ),
+  ],
   parameters: { layout: "centered" },
 } satisfies Meta<typeof TextEnumArrayDataInput>;
 

--- a/frontend/components/TextEnumDataInput.stories.tsx
+++ b/frontend/components/TextEnumDataInput.stories.tsx
@@ -17,6 +17,13 @@ const meta = {
     onChange: fn(),
     "aria-label": "Country",
   },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
+        <Story />
+      </div>
+    ),
+  ],
   parameters: { layout: "centered" },
 } satisfies Meta<typeof TextEnumDataInput>;
 

--- a/frontend/components/TextInput.stories.tsx
+++ b/frontend/components/TextInput.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   // clear without the frame masquerading as the input's own chrome.
   decorators: [
     (Story) => (
-      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8">
+      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
         <Story />
       </div>
     ),

--- a/frontend/components/TextInput.tsx
+++ b/frontend/components/TextInput.tsx
@@ -42,7 +42,7 @@ export default forwardRef<HTMLDivElement, Props>(function TextInput(
       data-fill={Boolean(fill)}
       data-labeled={Boolean(label)}
       className={`
-        relative group
+        relative group bg-white
         w-full gap-1 inline-flex items-center rounded scrollbar scrollbar-none
         error-within:shadow-sm focus-within:error-within:bg-red-400/80, error-within:bg-red-300/40
         has-disabled:opacity-60 has-disabled:cursor-not-allowed

--- a/frontend/components/TextNumberDataInput.stories.tsx
+++ b/frontend/components/TextNumberDataInput.stories.tsx
@@ -17,6 +17,13 @@ const meta = {
     onChange: fn(),
     "aria-label": "Year",
   },
+  decorators: [
+    (Story) => (
+      <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
+        <Story />
+      </div>
+    ),
+  ],
   parameters: { layout: "centered" },
 } satisfies Meta<typeof TextNumberDataInput>;
 

--- a/frontend/components/Tooltip.stories.tsx
+++ b/frontend/components/Tooltip.stories.tsx
@@ -11,6 +11,13 @@ const meta = {
     message: "Something needs your attention",
     children: <button className="px-3 py-1 rounded border">Hover me</button>,
   },
+  decorators: [
+    (Story) => (
+      <div className="py-8">
+        <Story />
+      </div>
+    ),
+  ],
   parameters: { layout: "centered" },
 } satisfies Meta<typeof Tooltip>;
 

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -18,7 +18,7 @@
 @custom-variant settled (&[data-phase="settled"]);
 @custom-variant error (&[data-error="true"]);
 @custom-variant error-within (&:has([data-error="true"]));
-@custom-variant peer-error (:merge(.peer):is([data-error="true"]) ~ &);
+@custom-variant peer-error (.peer[data-error="true"] ~ &);
 @custom-variant loading (&[data-loading="true"]);
 
 /* Scrollbar utilities (was the `tailwind-scrollbar` plugin). */
@@ -71,4 +71,8 @@ body {
 
 @utility absolute-center {
   @apply left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2;
+}
+
+@utility bg-stripes-diagonal {
+  @apply bg-[repeating-linear-gradient(45deg,#e1e1e1_0,#e1e1e1_1px,transparent_0,transparent_50%)] bg-size-[10px_10px];
 }


### PR DESCRIPTION
Add stories for the data-input components on a striped backdrop so their transparent areas and content-fit are visible.

Fix regressions the v4 upgrade introduced: modal centering and the icon button (translate/space utilities now set different CSS properties) plus the peer-error variant's invalid :merge() selector.