### PR TITLE
Add CSRF protection and finish the auth cutover

### DIFF
--- a/backend/lib/richard_burton/auth_csrf.ex
+++ b/backend/lib/richard_burton/auth_csrf.ex
@@ -1,0 +1,28 @@
+defmodule RichardBurton.Auth.Csrf do
+  @moduledoc """
+  Double-submit CSRF token: a signed, session-bound token issued as a readable
+  (`http_only: false`) cookie at login and echoed back in the `rb-csrf-token`
+  header on state-changing admin requests (see `RichardBurtonWeb.Plugs.VerifyCsrf`).
+
+  It is signed with the endpoint's `secret_key_base`, so it can't be forged
+  without the server secret, and it carries the session's subject so a token
+  minted for one user can't authorize another's request. Defense in depth on top
+  of the `SameSite=Lax` session cookie.
+  """
+  alias RichardBurton.Auth.Session
+  alias RichardBurtonWeb.Endpoint
+
+  @salt "csrf token"
+
+  @spec sign(String.t()) :: String.t()
+  def sign(subject_id) do
+    Phoenix.Token.sign(Endpoint, @salt, subject_id)
+  end
+
+  @spec verify(term()) :: {:ok, String.t()} | {:error, atom()}
+  def verify(token) when is_binary(token) do
+    Phoenix.Token.verify(Endpoint, @salt, token, max_age: Session.max_age())
+  end
+
+  def verify(_), do: {:error, :invalid}
+end

--- a/backend/lib/richard_burton_web/controllers/publication_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/publication_controller.ex
@@ -8,7 +8,7 @@ defmodule RichardBurtonWeb.PublicationController do
     {:ok, results, keywords} = Publication.Index.search(query)
 
     conn
-    |> put_resp_header("x-total-count", Integer.to_string(Publication.Index.count()))
+    |> put_resp_header("rb-total-count", Integer.to_string(Publication.Index.count()))
     |> json(%{entries: results, keywords: keywords})
   end
 
@@ -16,7 +16,7 @@ defmodule RichardBurtonWeb.PublicationController do
     {:ok, results} = Publication.Index.all()
 
     conn
-    |> put_resp_header("x-total-count", Integer.to_string(Publication.Index.count()))
+    |> put_resp_header("rb-total-count", Integer.to_string(Publication.Index.count()))
     |> json(%{entries: results})
   end
 

--- a/backend/lib/richard_burton_web/controllers/session_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/session_controller.ex
@@ -9,6 +9,7 @@ defmodule RichardBurtonWeb.SessionController do
   """
   use RichardBurtonWeb, :controller
 
+  alias RichardBurton.Auth.Csrf
   alias RichardBurton.Auth.Session
   alias RichardBurton.User
 
@@ -43,21 +44,34 @@ defmodule RichardBurtonWeb.SessionController do
     end
 
     conn
-    |> delete_resp_cookie("rb-session",
+    |> delete_resp_cookie("rb-session", same_site: "Lax", secure: secure_cookie?())
+    |> delete_resp_cookie("csrf-token",
       same_site: "Lax",
-      secure: Application.get_env(:richard_burton, :phx_session_tls, true)
+      secure: secure_cookie?(),
+      http_only: false
     )
     |> send_resp(:no_content, "")
   end
 
+  # Sets the httpOnly `rb-session` cookie plus the readable `csrf-token` cookie
+  # the browser echoes back in the `rb-csrf-token` header (see Auth.Csrf).
   defp put_session_cookie(conn, subject_id) do
     {:ok, token} = Session.create(subject_id)
 
-    put_resp_cookie(conn, "rb-session", token,
+    conn
+    |> put_resp_cookie("rb-session", token,
       http_only: true,
       same_site: "Lax",
-      secure: Application.get_env(:richard_burton, :phx_session_tls, true),
+      secure: secure_cookie?(),
+      max_age: Session.max_age()
+    )
+    |> put_resp_cookie("csrf-token", Csrf.sign(subject_id),
+      http_only: false,
+      same_site: "Lax",
+      secure: secure_cookie?(),
       max_age: Session.max_age()
     )
   end
+
+  defp secure_cookie?, do: Application.get_env(:richard_burton, :phx_session_tls, true)
 end

--- a/backend/lib/richard_burton_web/controllers/user_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/user_controller.ex
@@ -17,6 +17,11 @@ defmodule RichardBurtonWeb.UserController do
     end
   end
 
+  @doc """
+  Upserts the user for the verified provider subject (assigned by the bearer
+  plug). Login itself goes through `POST /sessions`; this endpoint is kept for
+  the planned admin user-management dashboard (see roadmap 12).
+  """
   def create(conn = %{assigns: %{subject_id: subject_id}}, attrs) do
     case User.insert(Map.put(attrs, "subject_id", subject_id)) do
       {:ok, user} -> conn |> put_status(:created) |> json(user)

--- a/backend/lib/richard_burton_web/endpoint.ex
+++ b/backend/lib/richard_burton_web/endpoint.ex
@@ -51,7 +51,23 @@ defmodule RichardBurtonWeb.Endpoint do
   plug(CORSPlug,
     origin: &RichardBurton.Application.origin/0,
     credentials: Application.compile_env(:richard_burton, :phx_cors_credentials, false),
-    expose: ["content-disposition", "x-total-count"]
+    expose: ["content-disposition", "rb-total-count"],
+    # CORSPlug's default allow-headers list, plus our custom rb-csrf-token so the
+    # double-submit header survives the preflight once a csrf-token cookie exists.
+    headers: [
+      "Authorization",
+      "Content-Type",
+      "Accept",
+      "Origin",
+      "User-Agent",
+      "DNT",
+      "Cache-Control",
+      "X-Mx-ReqToken",
+      "Keep-Alive",
+      "X-Requested-With",
+      "If-Modified-Since",
+      "rb-csrf-token"
+    ]
   )
 
   plug(RichardBurtonWeb.Router)

--- a/backend/lib/richard_burton_web/plugs/authorize/admin.ex
+++ b/backend/lib/richard_burton_web/plugs/authorize/admin.ex
@@ -1,6 +1,7 @@
-defmodule RichardBurtonWeb.Plugs.AuthorizeAdmin do
+defmodule RichardBurtonWeb.Plugs.Authorize.Admin do
   @moduledoc """
-  Plug for authentication with Google
+  Authorizes the request only if the authenticated subject (assigned by an
+  `Authenticate` plug) has the `:admin` role.
   """
 
   alias RichardBurton.Auth

--- a/backend/lib/richard_burton_web/plugs/authorize/recaptcha.ex
+++ b/backend/lib/richard_burton_web/plugs/authorize/recaptcha.ex
@@ -1,4 +1,4 @@
-defmodule RichardBurtonWeb.Plugs.AuthorizeRecaptcha do
+defmodule RichardBurtonWeb.Plugs.Authorize.Recaptcha do
   @moduledoc """
   Plug for recaptcha verification
   """

--- a/backend/lib/richard_burton_web/plugs/verify_csrf.ex
+++ b/backend/lib/richard_burton_web/plugs/verify_csrf.ex
@@ -1,0 +1,30 @@
+defmodule RichardBurtonWeb.Plugs.VerifyCsrf do
+  @moduledoc """
+  Double-submit CSRF check for state-changing admin requests. Safe methods
+  (GET/HEAD/OPTIONS) pass through untouched. For unsafe methods it requires an
+  `rb-csrf-token` header carrying a valid `RichardBurton.Auth.Csrf` token whose
+  subject matches the authenticated session (assigned by `Authenticate.Cookie`,
+  which must run first). Defense in depth on top of the `SameSite=Lax` cookie.
+  """
+  alias RichardBurton.Auth.Csrf
+
+  import Plug.Conn
+
+  @safe_methods ~w(GET HEAD OPTIONS)
+
+  def init(params), do: params
+
+  def call(conn = %{method: method}, _params) when method in @safe_methods do
+    conn
+  end
+
+  def call(conn, _params) do
+    with [token] <- get_req_header(conn, "rb-csrf-token"),
+         {:ok, subject_id} <- Csrf.verify(token),
+         true <- subject_id == conn.assigns[:subject_id] do
+      conn
+    else
+      _ -> conn |> send_resp(:forbidden, "Invalid CSRF token") |> halt()
+    end
+  end
+end

--- a/backend/lib/richard_burton_web/router.ex
+++ b/backend/lib/richard_burton_web/router.ex
@@ -15,11 +15,12 @@ defmodule RichardBurtonWeb.Router do
 
   pipeline :authorize_admin do
     plug(RichardBurtonWeb.Plugs.Authenticate.Cookie)
-    plug(RichardBurtonWeb.Plugs.AuthorizeAdmin)
+    plug(RichardBurtonWeb.Plugs.VerifyCsrf)
+    plug(RichardBurtonWeb.Plugs.Authorize.Admin)
   end
 
   pipeline :authorize_recaptcha do
-    plug(RichardBurtonWeb.Plugs.AuthorizeRecaptcha)
+    plug(RichardBurtonWeb.Plugs.Authorize.Recaptcha)
   end
 
   scope "/api", RichardBurtonWeb do

--- a/backend/test/richard_burton/auth_csrf_test.exs
+++ b/backend/test/richard_burton/auth_csrf_test.exs
@@ -1,0 +1,22 @@
+defmodule RichardBurton.Auth.CsrfTest do
+  use ExUnit.Case, async: true
+
+  alias RichardBurton.Auth.Csrf
+
+  describe "sign/1 and verify/1" do
+    test "a signed token verifies back to its subject" do
+      token = Csrf.sign("subject-123")
+      assert Csrf.verify(token) == {:ok, "subject-123"}
+    end
+
+    test "a tampered token is rejected" do
+      token = Csrf.sign("subject-123")
+      assert {:error, _} = Csrf.verify(token <> "tampered")
+    end
+
+    test "a non-token value is rejected" do
+      assert {:error, _} = Csrf.verify("not-a-token")
+      assert {:error, :invalid} = Csrf.verify(nil)
+    end
+  end
+end

--- a/backend/test/richard_burton_web/controllers/publication_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/publication_controller_test.exs
@@ -27,11 +27,31 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
       get(conn, publication_path(conn, :index))
     end
 
-    test "returns X-total-count header with value 0", %{conn: conn} do
+    test "returns rb-total-count header with value 0", %{conn: conn} do
       assert ["0"] ==
                conn
                |> get(publication_path(conn, :index))
-               |> Plug.Conn.get_resp_header("x-total-count")
+               |> Plug.Conn.get_resp_header("rb-total-count")
+    end
+  end
+
+  describe "CSRF protection on admin mutations" do
+    test "rejects a POST without a CSRF token", %{conn: conn} do
+      conn =
+        conn
+        |> delete_req_header("rb-csrf-token")
+        |> post(publication_path(conn, :create_all), %{"_json" => []})
+
+      assert response(conn, 403)
+    end
+
+    test "rejects a POST whose CSRF token is for a different subject", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("rb-csrf-token", RichardBurton.Auth.Csrf.sign("99999"))
+        |> post(publication_path(conn, :create_all), %{"_json" => []})
+
+      assert response(conn, 403)
     end
   end
 

--- a/backend/test/richard_burton_web/controllers/session_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/session_controller_test.exs
@@ -4,6 +4,7 @@ defmodule RichardBurtonWeb.SessionControllerTest do
 
   import Routes, only: [session_path: 2]
 
+  alias RichardBurton.Auth.Csrf
   alias RichardBurton.Auth.Session
   alias RichardBurton.Repo
   alias RichardBurton.User
@@ -22,6 +23,7 @@ defmodule RichardBurtonWeb.SessionControllerTest do
 
       assert %{"email" => @email, "role" => "reader"} = json_response(conn, 201)
       assert Session.verify(conn.resp_cookies["rb-session"].value) == {:ok, @subject_id}
+      assert Csrf.verify(conn.resp_cookies["csrf-token"].value) == {:ok, @subject_id}
     end
 
     test "for an existing user, sets rb-session and returns 200 with the user", %{conn: conn} do
@@ -32,6 +34,7 @@ defmodule RichardBurtonWeb.SessionControllerTest do
 
       assert %{"email" => @email, "role" => "reader"} = json_response(conn, 200)
       assert Session.verify(conn.resp_cookies["rb-session"].value) == {:ok, @subject_id}
+      assert Csrf.verify(conn.resp_cookies["csrf-token"].value) == {:ok, @subject_id}
     end
   end
 
@@ -43,6 +46,7 @@ defmodule RichardBurtonWeb.SessionControllerTest do
 
       assert response(conn, 204)
       assert %{max_age: 0, universal_time: {{1970, 1, 1}, _}} = conn.resp_cookies["rb-session"]
+      assert %{max_age: 0} = conn.resp_cookies["csrf-token"]
       assert Repo.aggregate(Session, :count) == 0
     end
   end

--- a/backend/test/richard_burton_web/controllers/user_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/user_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule RichardBurtonWeb.UserControllerTest do
   @moduledoc """
-  Tests for the Publication controller
+  Tests for the user controller
   """
   use RichardBurtonWeb.ConnCase
   import Routes, only: [user_path: 2]

--- a/backend/test/richard_burton_web/endpoint_cors_test.exs
+++ b/backend/test/richard_burton_web/endpoint_cors_test.exs
@@ -1,0 +1,53 @@
+defmodule RichardBurtonWeb.EndpointCorsTest do
+  @moduledoc """
+  Guards the CORS contract for the app's custom headers. The frontend attaches
+  the rb-csrf-token header (double-submit CSRF) once a csrf-token cookie exists,
+  and reads the rb-total-count header off the index response. If CORSPlug doesn't
+  allow/expose these, every browser request breaks after sign-in even though curl
+  works fine.
+  """
+  use RichardBurtonWeb.ConnCase, async: false
+
+  @origin "http://localhost:3000"
+
+  setup do
+    previous = System.get_env("PHX_CONSUMER_URL")
+    System.put_env("PHX_CONSUMER_URL", @origin)
+
+    on_exit(fn ->
+      case previous do
+        nil -> System.delete_env("PHX_CONSUMER_URL")
+        value -> System.put_env("PHX_CONSUMER_URL", value)
+      end
+    end)
+
+    :ok
+  end
+
+  defp allow_header(conn, name) do
+    conn
+    |> get_resp_header(name)
+    |> List.first("")
+    |> String.downcase()
+  end
+
+  test "preflight allows the rb-csrf-token request header" do
+    conn =
+      build_conn()
+      |> put_req_header("origin", @origin)
+      |> put_req_header("access-control-request-method", "POST")
+      |> put_req_header("access-control-request-headers", "rb-csrf-token")
+      |> options("/api/publications/bulk")
+
+    assert allow_header(conn, "access-control-allow-headers") =~ "rb-csrf-token"
+  end
+
+  test "the index response exposes the rb-total-count header" do
+    conn =
+      build_conn()
+      |> put_req_header("origin", @origin)
+      |> get("/api/publications")
+
+    assert allow_header(conn, "access-control-expose-headers") =~ "rb-total-count"
+  end
+end

--- a/backend/test/support/conn_case.ex
+++ b/backend/test/support/conn_case.ex
@@ -40,13 +40,15 @@ defmodule RichardBurtonWeb.ConnCase do
   setup :verify_on_exit!
 
   defp build_conn do
-    # Admin routes authenticate via the rb-session cookie (a real DB-backed Auth.Session);
-    # the bearer header is for the login routes (mocked Auth.verify).
+    # Admin routes authenticate via the rb-session cookie (a real DB-backed Auth.Session)
+    # plus a matching rb-csrf-token header; the bearer header is for the login routes
+    # (mocked Auth.verify).
     {:ok, token} = RichardBurton.Auth.Session.create("12345")
 
     Phoenix.ConnTest.build_conn()
     |> Plug.Test.put_req_cookie("rb-session", token)
     |> Plug.Conn.put_req_header("authorization", "Bearer token")
+    |> Plug.Conn.put_req_header("rb-csrf-token", RichardBurton.Auth.Csrf.sign("12345"))
   end
 
   def uploaded_file_fixture(path) do

--- a/frontend/app/api/auth/callback/[provider]/route.ts
+++ b/frontend/app/api/auth/callback/[provider]/route.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import HTTP from "modules/http";
 import { User } from "modules/users";
 import { NextRequest, NextResponse } from "next/server";
@@ -64,34 +63,32 @@ export async function GET(
   const email = decodeEmail(idToken);
   const authorization = { headers: { Authorization: `Bearer ${idToken}` } };
 
-  // Admin gate: only admins may sign in.
+  // Exchange the id_token for the app session: POST /sessions upserts the user,
+  // mints the rb-session + csrf-token cookies, and returns the user (with role).
+  // Relay the cookies only once the admin gate passes.
   let user: User | null = null;
+  let sessionCookies: string[] = [];
   try {
-    const { data } = await http.post<User>("/users", { email }, authorization);
-    user = data;
-  } catch (e) {
-    if (axios.isAxiosError(e) && e.response?.status === 409) {
-      user = e.response.data as User;
-    } else {
-      console.error(e);
+    const response = await http.post<User>(
+      "/sessions",
+      { email },
+      authorization,
+    );
+    user = response.data;
+    const setCookie = response.headers["set-cookie"];
+    if (setCookie) {
+      sessionCookies = [setCookie].flat();
     }
+  } catch (e) {
+    console.error(e);
   }
 
+  // Admin gate: only admins may sign in.
   if (!user || !User.isAdmin(user.role)) {
     return finish("/auth/error?error=AccessDenied");
   }
 
-  // Mint the Phoenix rb-session and relay its Set-Cookie to the browser.
-  try {
-    const response = await http.post("/sessions", { email }, authorization);
-    const relayedCookies = response.headers["set-cookie"];
-    if (relayedCookies) {
-      relayed.push(...[relayedCookies].flat());
-    }
-  } catch {
-    // Exchange failed; redirect anyway — the user just won't have a session yet.
-  }
-
+  relayed.push(...sessionCookies);
   return finish(next);
 }
 

--- a/frontend/modules/http.ts
+++ b/frontend/modules/http.ts
@@ -8,6 +8,12 @@ interface HttpModule {
   client(options: HttpClientOptions): HttpClient;
 }
 
+function readCookie(name: string): string | undefined {
+  const prefix = `${name}=`;
+  const row = document.cookie.split("; ").find((r) => r.startsWith(prefix));
+  return row?.slice(prefix.length);
+}
+
 const HTTP: HttpModule = {
   client(options) {
     // withCredentials so the browser sends/receives the backend's rb-session cookie.
@@ -20,6 +26,17 @@ const HTTP: HttpModule = {
       axios.create({ withCredentials: true, ...options }),
       { ignoreHeaders: true },
     );
+
+    // Double-submit CSRF: echo the readable `csrf-token` cookie (set by the
+    // backend at login) in the rb-csrf-token header. The backend enforces it on
+    // state-changing admin endpoints; everything else ignores it. Server-side
+    // callers (no document) skip it — they authenticate with the bearer token.
+    instance.interceptors.request.use((config) => {
+      const token =
+        typeof document === "undefined" ? undefined : readCookie("csrf-token");
+      if (token) config.headers.set("rb-csrf-token", token);
+      return config;
+    });
 
     // A backend 401 means the rb-session is gone (expired/revoked) — send the
     // user to sign in again. (GET /users/me returns null, not 401, so polling

--- a/frontend/modules/publication/remote.spec.ts
+++ b/frontend/modules/publication/remote.spec.ts
@@ -57,7 +57,7 @@ describe("index", () => {
         ],
         keywords: ["machado"],
       },
-      headers: { xTotalCount: "42" },
+      headers: { "rb-total-count": "42" },
     });
 
     await index();

--- a/frontend/modules/publication/remote.ts
+++ b/frontend/modules/publication/remote.ts
@@ -54,8 +54,9 @@ async function index({ search }: { search?: string } = {}): Promise<void> {
     const { data, headers } = await http.get<IndexResult>(url);
     const { entries, keywords } = data;
 
-    if (headers.xTotalCount) {
-      store.set(totalIndexCountAtom, parseInt(headers.xTotalCount));
+    // Read raw: the client no longer camelCases response headers (see modules/http).
+    if (headers["rb-total-count"]) {
+      store.set(totalIndexCountAtom, parseInt(headers["rb-total-count"]));
     }
     store.set(keywordsAtom, keywords);
 


### PR DESCRIPTION
Add a signed, session-bound double-submit CSRF token: POST /sessions issues a readable csrf-token cookie, the frontend echoes it in the rb-csrf-token header, and a VerifyCsrf plug enforces it on state-changing admin requests (safe methods pass through). Consolidate login into a single POST /sessions call in the OAuth callback — it already upserts the user and returns it for the admin gate — and relay the cookies only after the gate passes; keep POST /users for the planned admin user-management dashboard. Group the request plugs into Authenticate.* and Authorize.* namespaces, and prefix the app's own headers with rb- (rb-csrf-token, rb-total-count), reading the index-count header raw now that the client no longer camelCases response headers.