### PR TITLE
Edit a publication in place

### DIFF
--- a/.github/workflows/run-backend-fingerprint-audit.yml
+++ b/.github/workflows/run-backend-fingerprint-audit.yml
@@ -1,0 +1,35 @@
+name: Run backend fingerprint audit
+on:
+  push:
+    branches: [main]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  Fingerprints:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: "backend"
+    services:
+      db:
+        image: postgres:15.1
+        ports: ["5432:5432"]
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: erlef/setup-beam@v1
+        with:
+          version-type: strict
+          version-file: backend/.tool-versions
+      # config/dev.exs imports the gitignored dev.local.exs, so stub it before any
+      # mix task loads the dev config (the audit and seeds run in the dev env).
+      - run: echo -e "import Config\nconfig :richard_burton, []" >> config/dev.local.exs
+      - run: mix deps.get
+      # Seed a real dataset through the write paths, then verify every stored
+      # fingerprint still matches what the algorithm computes. Fingerprints are
+      # hand-synced derived state, so this catches write-path drift before prod.
+      - run: mix ecto.setup
+      - run: mix rb.audit_fingerprints

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ rel/
 *.local.*
 credentials.md
 .claude
+/CLAUDE.md

--- a/backend/dev/richard_burton_web/controllers/dev_session_controller.ex
+++ b/backend/dev/richard_burton_web/controllers/dev_session_controller.ex
@@ -1,0 +1,54 @@
+defmodule RichardBurtonWeb.DevSessionController do
+  @moduledoc """
+  Dev/test-only credentials provider. Mints an admin `rb-session` (plus the
+  readable `csrf-token`) without the Google OAuth handshake, so the admin UI can
+  be exercised locally.
+
+  Kept out of production two ways: this file lives outside `lib/`, on a compile
+  path only added for `:dev`/`:test` (see `elixirc_paths` in `mix.exs`), so the
+  module is not compiled into a prod release at all; and the route is wired only
+  when `Mix.env() in [:dev, :test]` (see the router).
+  """
+  use RichardBurtonWeb, :controller
+
+  alias RichardBurton.Auth.Csrf
+  alias RichardBurton.Auth.Session
+  alias RichardBurton.Repo
+  alias RichardBurton.User
+
+  @subject_id "dev-admin"
+  @email "dev-admin@localhost"
+
+  @doc "Upserts the dev admin user and sets the session cookies for it."
+  def create(conn, _params) do
+    user = upsert_admin()
+    {:ok, token} = Session.create(@subject_id)
+
+    conn
+    |> put_resp_cookie(Session.cookie_name(), token,
+      http_only: true,
+      same_site: "Lax",
+      secure: false,
+      max_age: Session.max_age()
+    )
+    |> put_resp_cookie("csrf-token", Csrf.sign(@subject_id),
+      http_only: false,
+      same_site: "Lax",
+      secure: false,
+      max_age: Session.max_age()
+    )
+    |> put_status(:created)
+    |> json(user)
+  end
+
+  # `User.changeset` forces the `:reader` role, so write the admin role directly.
+  defp upsert_admin do
+    case User.get(@subject_id) do
+      nil ->
+        Repo.insert!(%User{subject_id: @subject_id, email: @email, role: :admin})
+
+      user ->
+        user |> Ecto.Changeset.change(role: :admin) |> Repo.update!()
+    end
+  end
+end

--- a/backend/lib/mix/tasks/rb.audit_fingerprints.ex
+++ b/backend/lib/mix/tasks/rb.audit_fingerprints.ex
@@ -1,0 +1,113 @@
+defmodule Mix.Tasks.Rb.AuditFingerprints do
+  @shortdoc "Checks stored fingerprints against the current algorithm"
+
+  @moduledoc """
+  Recomputes every fingerprint from its associations and reports any row whose
+  stored value has drifted from what the current algorithm produces.
+
+  Fingerprints are denormalised, hand-synced derived state — nothing at the DB
+  level guarantees they match the associations — so this task is the safety net:
+  run it on demand or on a schedule to detect drift. It exits non-zero when drift
+  is found, so it can gate CI.
+
+      mix rb.audit_fingerprints
+  """
+
+  use Mix.Task
+
+  alias RichardBurton.Author
+  alias RichardBurton.Country
+  alias RichardBurton.OriginalBook
+  alias RichardBurton.Publication
+  alias RichardBurton.Publisher
+  alias RichardBurton.Repo
+  alias RichardBurton.TranslatedBook
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    drift = audit_original_books() ++ audit_translated_books() ++ audit_publications()
+
+    case drift do
+      [] ->
+        Mix.shell().info("Fingerprints consistent.")
+
+      _ ->
+        Enum.each(drift, fn {schema, id, field} ->
+          Mix.shell().error("#{schema} ##{id}: #{field} is stale")
+        end)
+
+        Mix.raise("#{length(drift)} fingerprint(s) drifted from the current algorithm.")
+    end
+  end
+
+  defp audit_original_books do
+    OriginalBook
+    |> Repo.all()
+    |> Repo.preload(:authors)
+    |> Enum.flat_map(fn book ->
+      check(
+        "original_books",
+        book.id,
+        :authors_fingerprint,
+        book.authors_fingerprint,
+        Author.fingerprint(book.authors)
+      )
+    end)
+  end
+
+  defp audit_translated_books do
+    TranslatedBook
+    |> Repo.all()
+    |> Repo.preload([:authors, :original_book])
+    |> Enum.flat_map(fn book ->
+      check(
+        "translated_books",
+        book.id,
+        :authors_fingerprint,
+        book.authors_fingerprint,
+        Author.fingerprint(book.authors)
+      ) ++
+        check(
+          "translated_books",
+          book.id,
+          :original_book_fingerprint,
+          book.original_book_fingerprint,
+          OriginalBook.fingerprint(book.original_book)
+        )
+    end)
+  end
+
+  defp audit_publications do
+    Publication
+    |> Repo.all()
+    |> Repo.preload([:countries, :publishers, :translated_book])
+    |> Enum.flat_map(fn pub ->
+      check(
+        "publications",
+        pub.id,
+        :countries_fingerprint,
+        pub.countries_fingerprint,
+        Country.fingerprint(pub.countries)
+      ) ++
+        check(
+          "publications",
+          pub.id,
+          :publishers_fingerprint,
+          pub.publishers_fingerprint,
+          Publisher.fingerprint(pub.publishers)
+        ) ++
+        check(
+          "publications",
+          pub.id,
+          :translated_book_fingerprint,
+          pub.translated_book_fingerprint,
+          TranslatedBook.fingerprint(pub.translated_book)
+        )
+    end)
+  end
+
+  defp check(_schema, _id, _field, stored, stored), do: []
+  defp check(schema, id, field, _stored, _computed), do: [{schema, id, field}]
+end

--- a/backend/lib/richard_burton/author.ex
+++ b/backend/lib/richard_burton/author.ex
@@ -12,9 +12,9 @@ defmodule RichardBurton.Author do
   alias RichardBurton.TranslatedBook
   alias RichardBurton.Util
 
-  @external_attributes [:name]
+  @readable_attributes [:name]
 
-  @derive {Jason.Encoder, only: @external_attributes}
+  @derive {Jason.Encoder, only: @readable_attributes}
   schema "authors" do
     field(:name, :string)
 

--- a/backend/lib/richard_burton/author.ex
+++ b/backend/lib/richard_burton/author.ex
@@ -10,7 +10,7 @@ defmodule RichardBurton.Author do
   alias RichardBurton.Repo
   alias RichardBurton.OriginalBook
   alias RichardBurton.TranslatedBook
-  alias RichardBurton.Util
+  alias RichardBurton.Fingerprint
 
   @readable_attributes [:name]
 
@@ -65,9 +65,7 @@ defmodule RichardBurton.Author do
   def fingerprint(authors) when is_list(authors) do
     authors
     |> Enum.map(fn %Author{name: name} -> name end)
-    |> Enum.sort()
-    |> Enum.join()
-    |> Util.create_fingerprint()
+    |> Fingerprint.of_set()
   end
 
   def link_fingerprint(changeset = %Ecto.Changeset{valid?: true}) do

--- a/backend/lib/richard_burton/country.ex
+++ b/backend/lib/richard_burton/country.ex
@@ -102,6 +102,7 @@ defmodule RichardBurton.Country do
     countries =
       changeset
       |> get_change(:countries)
+      |> Enum.reject(&(&1.action == :replace))
       |> Enum.map(&apply_changes/1)
       |> Enum.map(&maybe_insert!/1)
 

--- a/backend/lib/richard_burton/country.ex
+++ b/backend/lib/richard_burton/country.ex
@@ -8,7 +8,7 @@ defmodule RichardBurton.Country do
   alias RichardBurton.Country
   alias RichardBurton.Repo
   alias RichardBurton.Publication
-  alias RichardBurton.Util
+  alias RichardBurton.Fingerprint
 
   @derive {Jason.Encoder, only: [:code]}
   schema "countries" do
@@ -83,9 +83,7 @@ defmodule RichardBurton.Country do
   def fingerprint(countries) when is_list(countries) do
     countries
     |> Enum.map(fn %Country{code: code} -> code end)
-    |> Enum.sort()
-    |> Enum.join()
-    |> Util.create_fingerprint()
+    |> Fingerprint.of_set()
   end
 
   def maybe_insert!(attrs) do

--- a/backend/lib/richard_burton/fingerprint.ex
+++ b/backend/lib/richard_burton/fingerprint.ex
@@ -1,0 +1,29 @@
+defmodule RichardBurton.Fingerprint do
+  @moduledoc """
+  Computes the fingerprints used as composite-identity keys for publications and
+  their shared associations.
+
+  A set-valued attribute (countries, publishers, translators, original authors)
+  is collapsed into a single scalar so a Postgres unique constraint can enforce
+  set identity — which a many-to-many relationship can't express directly.
+
+  All set fingerprints go through `of_set/1` so the delimiter is defined in one
+  place: without a separator, variable-length values collide (e.g. `["AnnBob"]`
+  and `["Ann", "Bob"]` both join to `"AnnBob"`). The composite-record fingerprints
+  (`OriginalBook`/`TranslatedBook`) instead concatenate fixed-width sub-fingerprints,
+  which is already unambiguous, so they don't use this.
+  """
+
+  alias RichardBurton.Util
+
+  # Postgres text can never contain a NUL byte, so it's an always-safe separator.
+  @separator "\0"
+
+  @doc "Fingerprints an order-independent set of strings."
+  def of_set(strings) when is_list(strings) do
+    strings
+    |> Enum.sort()
+    |> Enum.join(@separator)
+    |> Util.create_fingerprint()
+  end
+end

--- a/backend/lib/richard_burton/flat_publication.ex
+++ b/backend/lib/richard_burton/flat_publication.ex
@@ -55,15 +55,15 @@ defmodule RichardBurton.FlatPublication do
     Repo.all(FlatPublication)
   end
 
-  def validate(attrs) do
-    %FlatPublication{} |> changeset(attrs) |> validate_changeset()
+  def validate(attrs, exclude_id \\ nil) do
+    %FlatPublication{} |> changeset(attrs) |> validate_changeset(exclude_id)
   end
 
-  defp validate_changeset(changeset = %{valid?: false}) do
+  defp validate_changeset(changeset = %{valid?: false}, _exclude_id) do
     {:error, Validation.get_errors(changeset)}
   end
 
-  defp validate_changeset(changeset = %{valid?: true}) do
+  defp validate_changeset(changeset = %{valid?: true}, exclude_id) do
     where =
       Enum.map(
         [
@@ -76,12 +76,20 @@ defmodule RichardBurton.FlatPublication do
         &{&1, get_field(changeset, &1)}
       )
 
-    query = from(fp in FlatPublication, where: ^where)
+    conflict =
+      from(fp in FlatPublication, where: ^where)
+      |> exclude_self(exclude_id)
+      |> Repo.exists?()
 
-    if Repo.exists?(query) do
+    if conflict do
       {:error, :conflict}
     else
       :ok
     end
   end
+
+  # The row being re-validated during an edit must not count as a conflict with
+  # itself; without an id (a fresh create) there is nothing to exclude.
+  defp exclude_self(query, nil), do: query
+  defp exclude_self(query, id), do: from(fp in query, where: fp.id != ^id)
 end

--- a/backend/lib/richard_burton/flat_publication.ex
+++ b/backend/lib/richard_burton/flat_publication.ex
@@ -13,7 +13,7 @@ defmodule RichardBurton.FlatPublication do
   alias RichardBurton.Validation
   alias RichardBurton.Country
 
-  @external_attributes [
+  @writable_attributes [
     :title,
     :year,
     :countries,
@@ -23,7 +23,9 @@ defmodule RichardBurton.FlatPublication do
     :original_authors
   ]
 
-  @derive {Jason.Encoder, only: @external_attributes}
+  @readable_attributes [:id | @writable_attributes]
+
+  @derive {Jason.Encoder, only: @readable_attributes}
   schema "flat_publications" do
     field(:title, :string)
     field(:year, :integer)
@@ -41,8 +43,8 @@ defmodule RichardBurton.FlatPublication do
   @doc false
   def changeset(flat_publication, attrs) do
     flat_publication
-    |> cast(attrs, @external_attributes)
-    |> validate_required(@external_attributes)
+    |> cast(attrs, @writable_attributes)
+    |> validate_required(@writable_attributes)
     |> Country.validate_countries()
     |> Country.link_fingerprint()
     |> Publisher.link_fingerprint()

--- a/backend/lib/richard_burton/original_book.ex
+++ b/backend/lib/richard_burton/original_book.ex
@@ -11,9 +11,9 @@ defmodule RichardBurton.OriginalBook do
   alias RichardBurton.TranslatedBook
   alias RichardBurton.Util
 
-  @external_attributes [:authors, :title]
+  @readable_attributes [:authors, :title]
 
-  @derive {Jason.Encoder, only: @external_attributes}
+  @derive {Jason.Encoder, only: @readable_attributes}
   schema "original_books" do
     field(:title, :string)
     field(:authors_fingerprint, :binary)

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -14,9 +14,9 @@ defmodule RichardBurton.Publication do
   alias RichardBurton.TranslatedBook
   alias RichardBurton.Validation
 
-  @external_attributes [:countries, :publishers, :title, :year, :translated_book]
+  @readable_attributes [:countries, :publishers, :title, :year, :translated_book]
 
-  @derive {Jason.Encoder, only: @external_attributes}
+  @derive {Jason.Encoder, only: @readable_attributes}
   schema "publications" do
     field(:title, :string)
     field(:year, :integer)

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -24,10 +24,17 @@ defmodule RichardBurton.Publication do
     field(:countries_fingerprint, :string)
     field(:publishers_fingerprint, :string)
 
-    belongs_to(:translated_book, TranslatedBook)
+    belongs_to(:translated_book, TranslatedBook, on_replace: :nilify)
 
-    many_to_many(:countries, Country, join_through: "publication_countries")
-    many_to_many(:publishers, Publisher, join_through: "publication_publishers")
+    many_to_many(:countries, Country,
+      join_through: "publication_countries",
+      on_replace: :delete
+    )
+
+    many_to_many(:publishers, Publisher,
+      join_through: "publication_publishers",
+      on_replace: :delete
+    )
 
     timestamps()
   end
@@ -92,6 +99,24 @@ defmodule RichardBurton.Publication do
 
   def validate(attrs) do
     Validation.validate(changeset(%Publication{}, attrs), &link_assocs/1)
+  end
+
+  def update(id, attrs) do
+    case Repo.get(Publication, id) do
+      nil ->
+        {:error, :not_found}
+
+      publication ->
+        publication
+        |> preload()
+        |> changeset(attrs)
+        |> link_assocs()
+        |> Repo.update()
+        |> case do
+          {:ok, updated} -> {:ok, preload(updated)}
+          {:error, changeset} -> {:error, Validation.get_errors(changeset)}
+        end
+    end
   end
 
   defp link_fingerprints(changeset) do

--- a/backend/lib/richard_burton/publication_codec.ex
+++ b/backend/lib/richard_burton/publication_codec.ex
@@ -117,6 +117,7 @@ defmodule RichardBurton.Publication.Codec do
 
     %FlatPublication{}
     |> FlatPublication.changeset(attrs)
+    |> Ecto.Changeset.put_change(:id, publication.id)
     |> Ecto.Changeset.apply_changes()
   end
 

--- a/backend/lib/richard_burton/publisher.ex
+++ b/backend/lib/richard_burton/publisher.ex
@@ -9,7 +9,7 @@ defmodule RichardBurton.Publisher do
   alias RichardBurton.Publisher
   alias RichardBurton.Repo
   alias RichardBurton.Publication
-  alias RichardBurton.Util
+  alias RichardBurton.Fingerprint
 
   @derive {Jason.Encoder, only: [:name]}
   schema "publishers" do
@@ -47,9 +47,7 @@ defmodule RichardBurton.Publisher do
   def fingerprint(publishers) when is_list(publishers) do
     publishers
     |> Enum.map(fn %Publisher{name: name} -> name end)
-    |> Enum.sort()
-    |> Enum.join()
-    |> Util.create_fingerprint()
+    |> Fingerprint.of_set()
   end
 
   def maybe_insert!(attrs) do

--- a/backend/lib/richard_burton/publisher.ex
+++ b/backend/lib/richard_burton/publisher.ex
@@ -66,6 +66,7 @@ defmodule RichardBurton.Publisher do
     publishers =
       changeset
       |> get_change(:publishers)
+      |> Enum.reject(&(&1.action == :replace))
       |> Enum.map(&apply_changes/1)
       |> Enum.map(&maybe_insert!/1)
 

--- a/backend/lib/richard_burton/translated_book.ex
+++ b/backend/lib/richard_burton/translated_book.ex
@@ -13,9 +13,9 @@ defmodule RichardBurton.TranslatedBook do
   alias RichardBurton.TranslatedBook
   alias RichardBurton.Util
 
-  @external_attributes [:authors, :original_book]
+  @readable_attributes [:authors, :original_book]
 
-  @derive {Jason.Encoder, only: @external_attributes}
+  @derive {Jason.Encoder, only: @readable_attributes}
   schema "translated_books" do
     field(:authors_fingerprint, :string)
     field(:original_book_fingerprint, :string)

--- a/backend/lib/richard_burton_web/controllers/publication_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/publication_controller.ex
@@ -82,6 +82,29 @@ defmodule RichardBurtonWeb.PublicationController do
     conn |> put_status(status) |> json(Publication.Codec.flatten(response_body))
   end
 
+  def update(conn, params = %{"id" => id}) do
+    {status, body} =
+      params
+      |> Map.delete("id")
+      |> Publication.Codec.nest()
+      |> then(&Publication.update(id, &1))
+      |> case do
+        {:ok, publication} ->
+          {:ok, Publication.Codec.flatten(publication)}
+
+        {:error, :not_found} ->
+          {:not_found, %{error: :not_found}}
+
+        {:error, :conflict} ->
+          {:conflict, %{errors: :conflict}}
+
+        {:error, errors} ->
+          {:bad_request, %{errors: errors}}
+      end
+
+    conn |> put_status(status) |> json(body)
+  end
+
   def validate(conn, %{"csv" => %Plug.Upload{path: path}}) do
     case Publication.Codec.from_csv(path) do
       {:ok, publications} ->
@@ -104,8 +127,16 @@ defmodule RichardBurtonWeb.PublicationController do
     |> json(result)
   end
 
-  defp validate_publication(p) do
-    case FlatPublication.validate(p) do
+  def validate(conn, params = %{"id" => id}) do
+    publication = Map.delete(params, "id")
+
+    conn
+    |> put_status(:ok)
+    |> json(validate_publication(publication, id))
+  end
+
+  defp validate_publication(p, exclude_id \\ nil) do
+    case FlatPublication.validate(p, exclude_id) do
       :ok -> %{publication: p, errors: nil}
       {:error, errors} -> %{publication: p, errors: errors}
     end

--- a/backend/lib/richard_burton_web/router.ex
+++ b/backend/lib/richard_burton_web/router.ex
@@ -79,5 +79,12 @@ defmodule RichardBurtonWeb.Router do
 
       live_dashboard("/dashboard", metrics: RichardBurtonWeb.Telemetry)
     end
+
+    # Dev/test-only credentials provider — mints an admin session without Google.
+    scope "/api/dev", RichardBurtonWeb do
+      pipe_through(:api)
+
+      post("/session", DevSessionController, :create)
+    end
   end
 end

--- a/backend/lib/richard_burton_web/router.ex
+++ b/backend/lib/richard_burton_web/router.ex
@@ -46,6 +46,8 @@ defmodule RichardBurtonWeb.Router do
     scope "/publications" do
       post("/bulk", PublicationController, :create_all)
       post("/validate", PublicationController, :validate)
+      put("/:id", PublicationController, :update)
+      post("/:id/validate", PublicationController, :validate)
     end
   end
 

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -37,8 +37,8 @@ defmodule RichardBurton.MixProject do
     ]
   end
 
-  # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(:test), do: ["lib", "test/support", "dev"]
+  defp elixirc_paths(:dev), do: ["lib", "dev"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Specifies your project dependencies.

--- a/backend/priv/repo/migrations/20260715120000_recompute_name_fingerprints.exs
+++ b/backend/priv/repo/migrations/20260715120000_recompute_name_fingerprints.exs
@@ -1,0 +1,80 @@
+defmodule RichardBurton.Repo.Migrations.RecomputeNameFingerprints do
+  use Ecto.Migration
+
+  # The country/publisher/author fingerprints moved from a delimiter-less join to
+  # a NUL-delimited one (RichardBurton.Fingerprint.of_set/1), which changes the
+  # stored value for any record with 2+ names/codes — and cascades into the
+  # original_book and translated_book fingerprints derived from them. Recompute the
+  # affected columns so existing identities stay consistent. No-op on a fresh
+  # (empty) database.
+  #
+  # Written as raw SQL rather than calling the app's fingerprint functions, so the
+  # migration stays reproducible even if that code later changes. Each statement
+  # mirrors the algorithm: sort the values byte-wise (COLLATE "C", matching
+  # Elixir's `Enum.sort`), join on a NUL byte, SHA-256, then hex-encode uppercase.
+  # Columns are recomputed in dependency order (a book's authors fingerprint feeds
+  # the fingerprints derived from it).
+
+  # A set fingerprint (order-independent), mirroring RichardBurton.Fingerprint.of_set/1.
+  defp set_fp(value, order) do
+    "upper(encode(sha256(string_agg(convert_to(#{value}, 'UTF8'), '\\x00' " <>
+      "ORDER BY #{order} COLLATE \"C\")), 'hex'))"
+  end
+
+  # A fingerprint of concatenated parts (fixed-width sub-fingerprints, a title).
+  defp concat_fp(parts), do: "upper(encode(sha256(convert_to(#{parts}, 'UTF8')), 'hex'))"
+
+  def up do
+    execute("""
+    UPDATE original_books ob SET authors_fingerprint = sub.fp
+    FROM (
+      SELECT oba.original_book_id AS id, #{set_fp("a.name", "a.name")} AS fp
+      FROM original_book_authors oba JOIN authors a ON a.id = oba.author_id
+      GROUP BY oba.original_book_id
+    ) sub WHERE ob.id = sub.id
+    """)
+
+    execute("""
+    UPDATE translated_books tb SET authors_fingerprint = sub.fp
+    FROM (
+      SELECT tba.translated_book_id AS id, #{set_fp("a.name", "a.name")} AS fp
+      FROM translated_book_authors tba JOIN authors a ON a.id = tba.author_id
+      GROUP BY tba.translated_book_id
+    ) sub WHERE tb.id = sub.id
+    """)
+
+    execute("""
+    UPDATE translated_books tb
+    SET original_book_fingerprint = #{concat_fp("ob.title || ob.authors_fingerprint")}
+    FROM original_books ob WHERE ob.id = tb.original_book_id
+    """)
+
+    execute("""
+    UPDATE publications p SET countries_fingerprint = sub.fp
+    FROM (
+      SELECT pc.publication_id AS id, #{set_fp("c.code", "c.code")} AS fp
+      FROM publication_countries pc JOIN countries c ON c.id = pc.country_id
+      GROUP BY pc.publication_id
+    ) sub WHERE p.id = sub.id
+    """)
+
+    execute("""
+    UPDATE publications p SET publishers_fingerprint = sub.fp
+    FROM (
+      SELECT pp.publication_id AS id, #{set_fp("pu.name", "pu.name")} AS fp
+      FROM publication_publishers pp JOIN publishers pu ON pu.id = pp.publisher_id
+      GROUP BY pp.publication_id
+    ) sub WHERE p.id = sub.id
+    """)
+
+    execute("""
+    UPDATE publications p
+    SET translated_book_fingerprint =
+      #{concat_fp("tb.original_book_fingerprint || tb.authors_fingerprint")}
+    FROM translated_books tb WHERE tb.id = p.translated_book_id
+    """)
+  end
+
+  # Irreversible: the previous (buggy) fingerprints are not worth restoring.
+  def down, do: :ok
+end

--- a/backend/test/richard_burton/author_test.exs
+++ b/backend/test/richard_burton/author_test.exs
@@ -110,6 +110,14 @@ defmodule RichardBurton.AuthorTest do
 
       assert Author.fingerprint(authors1) == Author.fingerprint(authors2)
     end
+
+    test "given sets whose names concatenate the same, generates different fingerprints" do
+      # Without a delimiter, ["AnnBob"] and ["Ann", "Bob"] both join to "AnnBob".
+      one = [%Author{name: "AnnBob"}]
+      two = [%Author{name: "Ann"}, %Author{name: "Bob"}]
+
+      refute Author.fingerprint(one) == Author.fingerprint(two)
+    end
   end
 
   defmodule WithManyAuthors do

--- a/backend/test/richard_burton/flat_publication_test.exs
+++ b/backend/test/richard_burton/flat_publication_test.exs
@@ -53,6 +53,11 @@ defmodule RichardBurton.FlatPublicationTest do
     %Publication{} |> Publication.changeset(Publication.Codec.nest(attrs)) |> Repo.insert()
   end
 
+  defp insert_publication(attrs) do
+    {:ok, publication} = attrs |> Publication.Codec.nest() |> Publication.insert()
+    publication
+  end
+
   describe "changeset/2" do
     test "when valid attributes are provided, is valid" do
       assert changeset(@valid_attrs).valid?
@@ -168,6 +173,31 @@ defmodule RichardBurton.FlatPublicationTest do
         |> Publication.validate()
 
       assert expected == FlatPublication.validate(attrs)
+    end
+  end
+
+  describe "validate/2" do
+    import FlatPublication, only: [validate: 2]
+
+    test "excludes the given id, so the row being edited is not a conflict with itself" do
+      publication = insert_publication(@valid_attrs)
+
+      assert :ok == validate(@valid_attrs, publication.id)
+    end
+
+    test "still reports a conflict when a different row matches the attributes" do
+      conflicting = insert_publication(@valid_attrs)
+      other = insert_publication(Map.put(@valid_attrs, "title", "Another title"))
+
+      # Excluding `other` does not hide the collision with `conflicting`.
+      assert conflicting.id != other.id
+      assert {:error, :conflict} == validate(@valid_attrs, other.id)
+    end
+
+    test "with a nil id, behaves like validate/1" do
+      insert_publication(@valid_attrs)
+
+      assert {:error, :conflict} == validate(@valid_attrs, nil)
     end
   end
 end

--- a/backend/test/richard_burton/publication_codec_test.exs
+++ b/backend/test/richard_burton/publication_codec_test.exs
@@ -126,7 +126,7 @@ defmodule RichardBurton.Publication.CodecTest do
       countries: "GB",
       countries_fingerprint: "B4043B0B8297E379BC559AB33B6AE9C7A9B4EF6519D3BAEE53270F0C0DD3D960",
       publishers: "Bickers & Son, Noonday Press",
-      publishers_fingerprint: "74A2D52E4AC165134F6A85A9A109A3459B37B557C2D3939D33F02821A8D8A97D",
+      publishers_fingerprint: "830DE6E9CE04669334B8C1A5D61E94E37A8842B9241C2EB3C9E72E7973CF3A7C",
       authors: "Isabel Burton",
       original_authors: "José de Alencar",
       original_title: "Iracema",
@@ -360,7 +360,7 @@ defmodule RichardBurton.Publication.CodecTest do
       countries: [%Country{code: "GB"}],
       countries_fingerprint: "B4043B0B8297E379BC559AB33B6AE9C7A9B4EF6519D3BAEE53270F0C0DD3D960",
       publishers: [%Publisher{name: "Bickers & Son"}, %Publisher{name: "Noonday Press"}],
-      publishers_fingerprint: "74A2D52E4AC165134F6A85A9A109A3459B37B557C2D3939D33F02821A8D8A97D",
+      publishers_fingerprint: "830DE6E9CE04669334B8C1A5D61E94E37A8842B9241C2EB3C9E72E7973CF3A7C",
       translated_book: %TranslatedBook{
         authors: [
           %Author{name: "Isabel Burton"}

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -281,12 +281,20 @@ defmodule RichardBurton.Publication.IndexTest do
     test "returns all publications flattened" do
       {:ok, output} = Publication.Index.all()
 
-      actual =
-        output
-        |> Enum.map(&%{&1 | __meta__: nil, id: nil, translated_book_fingerprint: nil})
-        |> Enum.sort()
+      # Fingerprint values are covered by the fingerprint/composite-key tests; this
+      # test is about the flattened representation, so ignore them.
+      strip =
+        &%{
+          &1
+          | __meta__: nil,
+            id: nil,
+            countries_fingerprint: nil,
+            publishers_fingerprint: nil,
+            translated_book_fingerprint: nil
+        }
 
-      expected = @publications |> Enum.map(&%{&1 | __meta__: nil}) |> Enum.sort()
+      actual = output |> Enum.map(strip) |> Enum.sort()
+      expected = @publications |> Enum.map(strip) |> Enum.sort()
 
       assert expected == actual
     end

--- a/backend/test/richard_burton/publication_test.exs
+++ b/backend/test/richard_burton/publication_test.exs
@@ -5,6 +5,7 @@ defmodule RichardBurton.PublicationTest do
 
   use RichardBurton.DataCase
 
+  alias RichardBurton.Country
   alias RichardBurton.Publication
   alias RichardBurton.TranslatedBook
   alias RichardBurton.Util
@@ -61,6 +62,11 @@ defmodule RichardBurton.PublicationTest do
 
   defp insert(attrs) do
     attrs |> changeset() |> Repo.insert()
+  end
+
+  defp insert_publication(attrs \\ @valid_attrs) do
+    {:ok, publication} = Publication.insert(attrs)
+    publication
   end
 
   describe "changeset/2" do
@@ -247,6 +253,98 @@ defmodule RichardBurton.PublicationTest do
       assert {@skeleton_attrs, @skeleton_attrs_error_map} == description
 
       assert [] == Publication.all()
+    end
+  end
+
+  describe "update/2" do
+    test "updates the publication and returns {:ok, updated}" do
+      publication = insert_publication()
+
+      result = Publication.update(publication.id, Map.put(@valid_attrs, "title", "New Title"))
+
+      assert {:ok, updated} = result
+      assert updated.id == publication.id
+      assert updated.title == "New Title"
+      assert [%Publication{title: "New Title"}] = Publication.all()
+    end
+
+    test "editing a keyed field changes identity without a collision" do
+      publication = insert_publication()
+
+      result = Publication.update(publication.id, Map.put(@valid_attrs, "year", 2000))
+
+      assert {:ok, updated} = result
+      assert updated.id == publication.id
+      assert updated.year == 2000
+    end
+
+    test "when the edit collides with another publication, returns {:error, :conflict}" do
+      insert_publication()
+      other = insert_publication(Map.put(@valid_attrs, "year", 1999))
+
+      assert {:error, :conflict} == Publication.update(other.id, @valid_attrs)
+    end
+
+    test "re-saving the same attributes does not conflict with itself" do
+      publication = insert_publication()
+
+      assert {:ok, _} = Publication.update(publication.id, @valid_attrs)
+    end
+
+    test "when the attributes are invalid, returns an error map" do
+      publication = insert_publication()
+
+      result = Publication.update(publication.id, Map.put(@valid_attrs, "title", ""))
+      assert {:error, %{title: :required}} = result
+    end
+
+    test "when the id does not exist, returns {:error, :not_found}" do
+      assert {:error, :not_found} == Publication.update(999_999, @valid_attrs)
+    end
+
+    test "replaces the linked countries, dropping the old join row but keeping the shared country" do
+      publication =
+        insert_publication(
+          Map.put(@valid_attrs, "countries", [%{"code" => "GB"}, %{"code" => "US"}])
+        )
+
+      {:ok, updated} = Publication.update(publication.id, @valid_attrs)
+
+      # The publication now links only GB...
+      assert ["GB"] == Enum.map(updated.countries, & &1.code)
+      # ...but the shared US country row is untouched (only the join row was removed).
+      assert ["GB", "US"] == Country.all() |> Enum.map(& &1.code) |> Enum.sort()
+    end
+
+    test "recomputes the fingerprint when an association changes" do
+      publication = insert_publication()
+      original_fingerprint = publication.countries_fingerprint
+
+      {:ok, updated} =
+        Publication.update(
+          publication.id,
+          Map.put(@valid_attrs, "countries", [%{"code" => "US"}])
+        )
+
+      assert ["US"] == Enum.map(updated.countries, & &1.code)
+      # The stored fingerprint reflects the new country, not the stale one.
+      refute updated.countries_fingerprint == original_fingerprint
+      assert Country.fingerprint("US") == updated.countries_fingerprint
+    end
+
+    test "repoints the translated book when the original fields change, leaving the old one" do
+      publication = insert_publication()
+      assert 1 == length(TranslatedBook.all())
+
+      {:ok, updated} =
+        Publication.update(
+          publication.id,
+          put_in(@valid_attrs, ["translated_book", "original_book", "title"], "A different book")
+        )
+
+      assert "A different book" == updated.translated_book.original_book.title
+      # The previous translated book is left behind
+      assert 2 == length(TranslatedBook.all())
     end
   end
 end

--- a/backend/test/richard_burton/publisher_test.exs
+++ b/backend/test/richard_burton/publisher_test.exs
@@ -133,6 +133,14 @@ defmodule RichardBurton.PublisherTest do
 
       assert Publisher.fingerprint(publishers1) == Publisher.fingerprint(publishers2)
     end
+
+    test "given sets whose names concatenate the same, generates different fingerprints" do
+      # Without a delimiter, ["AB"] + ["C"] and ["A"] + ["BC"] both join to "ABC".
+      one = [%Publisher{name: "AB"}, %Publisher{name: "C"}]
+      two = [%Publisher{name: "A"}, %Publisher{name: "BC"}]
+
+      refute Publisher.fingerprint(one) == Publisher.fingerprint(two)
+    end
   end
 
   describe "link/1" do

--- a/backend/test/richard_burton_web/controllers/dev_session_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/dev_session_controller_test.exs
@@ -1,0 +1,29 @@
+defmodule RichardBurtonWeb.DevSessionControllerTest do
+  @moduledoc "Tests for the dev/test-only credentials provider."
+  use RichardBurtonWeb.ConnCase
+
+  alias RichardBurton.Auth.Session
+  alias RichardBurton.User
+
+  describe "POST /api/dev/session" do
+    test "mints an admin session and sets the session cookies", %{conn: conn} do
+      conn = post(conn, "/api/dev/session")
+
+      result = json_response(conn, 201)
+
+      assert %{"email" => "dev-admin@localhost", "role" => "admin"} = result
+      # The rb-session cookie authenticates as a real user with the admin role.
+      assert {:ok, subject_id} = Session.verify(conn.resp_cookies["rb-session"].value)
+      assert %User{role: :admin} = User.get(subject_id)
+      # The readable csrf-token cookie is set too (the frontend echoes it back).
+      assert conn.resp_cookies["csrf-token"].value
+    end
+
+    test "keeps the dev user an admin when called again", %{conn: conn} do
+      post(build_conn(), "/api/dev/session")
+      conn = post(conn, "/api/dev/session")
+
+      assert %{"role" => "admin"} = json_response(conn, 201)
+    end
+  end
+end

--- a/backend/test/richard_burton_web/controllers/publication_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/publication_controller_test.exs
@@ -87,7 +87,7 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
         |> post(publication_path(meta.conn, :create_all), input)
         |> json_response(201)
 
-      assert publications == result
+      assert publications == Enum.map(result, &Map.delete(&1, "id"))
     end
 
     test "returns 201 and inserts publications with several countries", meta do
@@ -162,7 +162,7 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
 
       assert 3 == FlatPublication.all() |> length()
       assert ["GB", "US", "BR"] == Country.all() |> Enum.map(&Country.get_code/1)
-      assert output == result
+      assert output == Enum.map(result, &Map.delete(&1, "id"))
     end
 
     test "returns 201 and inserts publications with several publishers", meta do
@@ -239,7 +239,7 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
 
       assert 3 == FlatPublication.all() |> length()
       assert publishers == Publisher.all() |> Enum.map(&Publisher.get_name/1)
-      assert output == result
+      assert output == Enum.map(result, &Map.delete(&1, "id"))
     end
 
     test "returns 409 when publications are repeated, and returns the first repeated one", meta do

--- a/backend/test/richard_burton_web/controllers/publication_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/publication_controller_test.exs
@@ -4,7 +4,7 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
   """
   alias RichardBurton.FlatPublication
   use RichardBurtonWeb.ConnCase
-  import Routes, only: [publication_path: 2]
+  import Routes, only: [publication_path: 2, publication_path: 3]
 
   alias RichardBurton.Country
   alias RichardBurton.Publication
@@ -642,5 +642,125 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
       assert expected_content_disposition == content_disposition
       assert expected_data == response(conn, 200)
     end
+  end
+
+  describe "PUT /publications/:id" do
+    test "updates a publication and returns the flattened result", meta do
+      publication = insert_publication(@publication_attrs)
+      expect_auth_authorize_admin()
+
+      attrs = %{@publication_attrs | "title" => "A New Title"}
+
+      result =
+        meta.conn
+        |> put(publication_path(meta.conn, :update, publication.id), attrs)
+        |> json_response(200)
+
+      assert result["id"] == publication.id
+      assert result["title"] == "A New Title"
+      # The change is persisted and visible through the read model.
+      assert ["A New Title"] == FlatPublication.all() |> Enum.map(& &1.title)
+    end
+
+    test "edits a keyed field, changing the record's identity", meta do
+      publication = insert_publication(@publication_attrs)
+      expect_auth_authorize_admin()
+
+      attrs = %{@publication_attrs | "year" => "1999"}
+
+      result =
+        meta.conn
+        |> put(publication_path(meta.conn, :update, publication.id), attrs)
+        |> json_response(200)
+
+      assert result["id"] == publication.id
+      assert result["year"] == 1999
+    end
+
+    test "updates the translated book when the original fields change", meta do
+      publication = insert_publication(@publication_attrs)
+      expect_auth_authorize_admin()
+
+      attrs = %{@publication_attrs | "original_title" => "Iracema (rev.)"}
+
+      result =
+        meta.conn
+        |> put(publication_path(meta.conn, :update, publication.id), attrs)
+        |> json_response(200)
+
+      assert result["original_title"] == "Iracema (rev.)"
+    end
+
+    test "returns 409 when the edit collides with another publication", meta do
+      a = insert_publication(@publication_attrs)
+      _b = insert_publication(%{@publication_attrs | "title" => "Another Title"})
+      expect_auth_authorize_admin()
+
+      # Editing `a` to `b`'s title collides with `b`'s composite key.
+      attrs = %{@publication_attrs | "title" => "Another Title"}
+
+      conn = put(meta.conn, publication_path(meta.conn, :update, a.id), attrs)
+      assert response(conn, 409)
+    end
+
+    test "re-saving the same data does not conflict with itself", meta do
+      publication = insert_publication(@publication_attrs)
+      expect_auth_authorize_admin()
+
+      conn =
+        put(meta.conn, publication_path(meta.conn, :update, publication.id), @publication_attrs)
+
+      assert response(conn, 200)
+    end
+
+    test "returns 400 for invalid data", meta do
+      publication = insert_publication(@publication_attrs)
+      expect_auth_authorize_admin()
+
+      attrs = %{@publication_attrs | "title" => ""}
+
+      conn = put(meta.conn, publication_path(meta.conn, :update, publication.id), attrs)
+      assert response(conn, 400)
+    end
+
+    test "returns 404 for a missing publication", meta do
+      expect_auth_authorize_admin()
+
+      conn = put(meta.conn, publication_path(meta.conn, :update, 999_999), @publication_attrs)
+      assert response(conn, 404)
+    end
+  end
+
+  describe "POST /publications/:id/validate" do
+    test "does not report the row being edited as a conflict", meta do
+      publication = insert_publication(@publication_attrs)
+      expect_auth_authorize_admin()
+
+      result =
+        meta.conn
+        |> post(publication_path(meta.conn, :validate, publication.id), @publication_attrs)
+        |> json_response(200)
+
+      assert result["errors"] == nil
+    end
+
+    test "reports a conflict against a different publication", meta do
+      _a = insert_publication(@publication_attrs)
+      b = insert_publication(%{@publication_attrs | "title" => "Another Title"})
+      expect_auth_authorize_admin()
+
+      # Validating `b` against `a`'s data conflicts with `a`.
+      result =
+        meta.conn
+        |> post(publication_path(meta.conn, :validate, b.id), @publication_attrs)
+        |> json_response(200)
+
+      assert result["errors"] == "conflict"
+    end
+  end
+
+  defp insert_publication(attrs) do
+    {:ok, publication} = attrs |> Publication.Codec.nest() |> Publication.insert()
+    publication
   end
 end

--- a/frontend/app/api/auth/dev/route.ts
+++ b/frontend/app/api/auth/dev/route.ts
@@ -1,0 +1,32 @@
+import HTTP from "modules/http";
+import { NextRequest, NextResponse } from "next/server";
+
+const http = HTTP.client({ baseURL: process.env.NEXT_INTERNAL_API_URL });
+
+// Dev-only credentials provider: asks the backend to mint an admin rb-session
+// (no Google OAuth) and relays its Set-Cookie to the browser, exactly like the
+// OAuth callback. Guarded to development on both ends — 404 otherwise.
+export async function GET(request: NextRequest) {
+  if (process.env.NODE_ENV !== "development") {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const response = NextResponse.redirect(new URL("/", request.url));
+
+  try {
+    const backend = await http.post("/dev/session", {});
+    const setCookie = backend.headers["set-cookie"];
+    if (setCookie) {
+      for (const cookie of [setCookie].flat()) {
+        response.headers.append("Set-Cookie", cookie);
+      }
+    }
+  } catch (e) {
+    console.error(e);
+    return NextResponse.redirect(
+      new URL("/auth/error?error=Verification", request.url),
+    );
+  }
+
+  return response;
+}

--- a/frontend/app/auth/error/page.tsx
+++ b/frontend/app/auth/error/page.tsx
@@ -68,7 +68,9 @@ export default async function AuthErrorPage({
                   <p className="text-sm">{description.suggestion}</p>
                 )}
               </div>
-              <SignInButton label="Try again" />
+              <div className="mx-auto">
+                <SignInButton label="Try again" centered />
+              </div>
             </section>
           </div>
         ) : null

--- a/frontend/app/auth/sign-in/page.tsx
+++ b/frontend/app/auth/sign-in/page.tsx
@@ -1,3 +1,4 @@
+import DevSignInButton from "components/DevSignInButton";
 import Layout from "components/Layout";
 import SignInButton from "components/SignInButton";
 import type { Metadata } from "next";
@@ -29,8 +30,9 @@ export default async function SignInPage({
             <p className="text-lg">
               Sign in with your Google account to access the platform.
             </p>
-            <div className="flex justify-center">
+            <div className="flex flex-col items-center gap-3">
               <SignInButton next={next} />
+              {process.env.NODE_ENV === "development" && <DevSignInButton />}
             </div>
           </section>
         </div>

--- a/frontend/components/Button.stories.tsx
+++ b/frontend/components/Button.stories.tsx
@@ -42,7 +42,11 @@ export const Default: Story = {
   },
 };
 
-/** The four visual variants, side by side. */
+/**
+ * The visual variants, side by side. The two outlined styles are the quieter
+ * options: `outline` for a neutral secondary action, `outline-primary` where the
+ * action is primary but shouldn't carry a filled button's weight.
+ */
 export const Variants: Story = {
   args: { width: "fit" },
   render: (args) => (
@@ -50,9 +54,47 @@ export const Variants: Story = {
       <Button {...args} variant="primary" label="Primary" />
       <Button {...args} variant="secondary" label="Secondary" />
       <Button {...args} variant="outline" label="Outline" />
+      <Button {...args} variant="outline-primary" label="Outline primary" />
       <Button {...args} variant="danger" label="Danger" />
     </div>
   ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const outline = canvas.getByRole("button", { name: "Outline" });
+    const primary = canvas.getByRole("button", { name: "Primary" });
+
+    // Outlined means a visible border over an unfilled ground — not a grey fill.
+    const border = getComputedStyle(outline);
+    await expect(border.borderTopWidth).toBe("1px");
+    await expect(border.borderTopColor).not.toBe("rgba(0, 0, 0, 0)");
+    // A transparent border keeps filled variants the same size as outlined ones.
+    await expect(primary.offsetHeight).toBe(outline.offsetHeight);
+  },
+};
+
+/**
+ * `size`: `small` (the default) suits dense surfaces like toolbars and table
+ * rows; `medium` suits forms, where the actions want more presence.
+ */
+export const Sizes: Story = {
+  args: { width: "fit" },
+  render: (args) => (
+    <div className="flex flex-wrap gap-3 items-center">
+      <Button {...args} size="small" label="Small" />
+      <Button {...args} size="medium" label="Medium" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const small = canvas.getByRole("button", { name: "Small" });
+    const medium = canvas.getByRole("button", { name: "Medium" });
+
+    // Roomier type and a taller hit target, not just wider padding.
+    await expect(parseFloat(getComputedStyle(medium).fontSize)).toBeGreaterThan(
+      parseFloat(getComputedStyle(small).fontSize),
+    );
+    await expect(medium.offsetHeight).toBeGreaterThan(small.offsetHeight);
+  },
 };
 
 /** `width`: `full` fills its container, `fixed` is a set width, `fit` hugs its content. */

--- a/frontend/components/Button.tsx
+++ b/frontend/components/Button.tsx
@@ -26,12 +26,14 @@ const Spinner: FC<{ className: string }> = ({ className }) => (
   </svg>
 );
 
-type Props = HTMLProps<HTMLButtonElement> & {
+type Props = Omit<HTMLProps<HTMLButtonElement>, "size"> & {
   label: string;
-  variant?: "primary" | "secondary" | "outline" | "danger";
+  variant?: "primary" | "secondary" | "outline" | "outline-primary" | "danger";
   Icon?: FC<{ className: string }> | ReactNode;
   alignment?: "center" | "left";
   width?: "full" | "fixed" | "fit";
+  /** `small` suits dense surfaces (toolbars, table rows); `medium` suits forms. */
+  size?: "small" | "medium";
   labelSrOnly?: boolean;
   type?: "button" | "submit" | "reset";
   loading?: boolean;
@@ -45,6 +47,7 @@ const Button = forwardRef<HTMLButtonElement, Props>(function Button(
     Icon,
     alignment = "center",
     width = "full",
+    size = "small",
     type = "button",
     labelSrOnly,
     loading,
@@ -64,12 +67,17 @@ const Button = forwardRef<HTMLButtonElement, Props>(function Button(
       data-variant={variant}
       data-width={width}
       data-alignment={alignment}
+      data-size={size}
       className={`
-        flex py-1.5 px-2 transition-colors items-center rounded font-base shadow-sm text-xs group gap-2 whitespace-nowrap
-        data-[loading=false]:disabled:bg-gray-100 data-[loading=false]:disabled:text-gray-300 data-[loading=false]:disabled:hover:bg-gray-100
+        flex transition-colors items-center rounded font-base shadow-sm group gap-2 whitespace-nowrap
+        border border-transparent
+        data-[size=small]:py-1.5 data-[size=small]:px-2 data-[size=small]:text-xs
+        data-[size=medium]:py-2 data-[size=medium]:px-4 data-[size=medium]:text-sm
+        data-[loading=false]:disabled:bg-gray-100 data-[loading=false]:disabled:text-gray-300 data-[loading=false]:disabled:border-gray-200 data-[loading=false]:disabled:hover:bg-gray-100
         data-[variant=primary]:text-white data-[variant=primary]:bg-indigo-600 data-[variant=primary]:hover:bg-indigo-700 data-[variant=primary]:loading:bg-indigo-700
         data-[variant=secondary]:text-gray-900 data-[variant=secondary]:bg-yellow-500 data-[variant=secondary]:hover:bg-yellow-600 data-[variant=secondary]:loading:bg-yellow-600
-        data-[variant=outline]:text-gray-700 data-[variant=outline]:bg-gray-100 data-[variant=outline]:hover:bg-gray-active data-[variant=outline]:loading:bg-gray-active
+        data-[variant=outline]:text-gray-700 data-[variant=outline]:bg-white data-[variant=outline]:border-gray-300 data-[variant=outline]:hover:bg-gray-100 data-[variant=outline]:loading:bg-gray-100
+        data-[variant=outline-primary]:text-indigo-600 data-[variant=outline-primary]:bg-white data-[variant=outline-primary]:border-indigo-500 data-[variant=outline-primary]:hover:bg-indigo-50 data-[variant=outline-primary]:loading:bg-indigo-50
         data-[variant=danger]:text-white data-[variant=danger]:bg-red-600 data-[variant=danger]:hover:bg-red-700 data-[variant=danger]:loading:bg-red-700
         data-[alignment=center]:justify-center
         data-[width=full]:w-full

--- a/frontend/components/DataInput.stories.tsx
+++ b/frontend/components/DataInput.stories.tsx
@@ -57,3 +57,17 @@ export const WithError: Story = {
     );
   },
 };
+
+/**
+ * `bordered` — the outlined variant used by the edit form. The dispatcher
+ * forwards it to the underlying input, which draws a visible box.
+ */
+export const Bordered: Story = {
+  beforeEach: () => seed(),
+  args: { colId: "title", value: "Dom Casmurro", bordered: true },
+  play: async ({ canvasElement }) => {
+    const input = within(canvasElement).getByRole("textbox");
+    const box = input.closest("[data-bordered='true']")!;
+    await expect(getComputedStyle(box).borderTopWidth).toBe("1px");
+  },
+};

--- a/frontend/components/DataInput.tsx
+++ b/frontend/components/DataInput.tsx
@@ -6,8 +6,8 @@ import {
   type PublicationKey,
   type PublicationKeyType,
 } from "modules/publication/model";
-import { overrideField } from "modules/publication/store";
 import { validate } from "modules/publication/remote";
+import { overrideField } from "modules/publication/store";
 import { FC, FocusEvent, HTMLProps, Ref, forwardRef } from "react";
 import TextArrayDataInput from "./TextArrayDataInput";
 import TextDataInput from "./TextDataInput";
@@ -32,61 +32,66 @@ type Props = Omit<HTMLProps<HTMLInputElement>, "onChange" | "ref"> & {
   error: string;
   onChange?: (value: string) => void;
   autoValidated?: boolean;
+  /** What to run when `autoValidated` fires. Defaults to the bulk validate; the
+   * edit form passes the id-aware one. */
+  onValidate?: () => void;
   fill?: boolean;
+  bordered?: boolean;
 };
 
-const DataInput = forwardRef<HTMLElement, Props>(
-  function DataInput(props, ref) {
-    const {
-      rowId,
-      colId,
-      value: data,
-      error,
-      autoValidated,
-      onBlur,
-      onChange,
-    } = props;
+const DataInput = forwardRef<HTMLElement, Props>(function DataInput(
+  { onValidate, ...props },
+  ref,
+) {
+  const {
+    rowId,
+    colId,
+    value: data,
+    error,
+    autoValidated,
+    onBlur,
+    onChange,
+  } = props;
 
-    const type = Publication.ATTRIBUTE_TYPES[props.colId];
-    const Component = COMPONENTS_PER_TYPE[type];
-    const placeholder = Publication.ATTRIBUTE_LABELS[colId];
+  const type = Publication.ATTRIBUTE_TYPES[props.colId];
+  const Component = COMPONENTS_PER_TYPE[type];
+  const placeholder = Publication.ATTRIBUTE_LABELS[colId];
 
-    function doValidate() {
-      if (autoValidated) {
-        validate([rowId]);
-      }
-    }
+  const validateRow = onValidate ?? (() => validate([rowId]));
 
-    function handleChange(value: string) {
-      overrideField(rowId, colId, value);
-      if (type == "array" || type == "enum") {
-        doValidate();
-      }
-      onChange?.(value);
-    }
+  function doValidate() {
+    if (autoValidated) validateRow();
+  }
 
-    function handleBlur(event: FocusEvent<HTMLInputElement>) {
+  function handleChange(value: string) {
+    overrideField(rowId, colId, value);
+    if (type == "array" || type == "enum") {
       doValidate();
-      onBlur?.(event);
     }
+    onChange?.(value);
+  }
 
-    return (
-      <Tooltip variant="error" message={props.error}>
-        <Component
-          {...props}
-          {...Publication.define(colId)}
-          ref={ref}
-          value={data}
-          onBlur={handleBlur}
-          onChange={handleChange}
-          placeholder={placeholder}
-          error={error}
-          fill
-        />
-      </Tooltip>
-    );
-  },
-);
+  function handleBlur(event: FocusEvent<HTMLInputElement>) {
+    doValidate();
+    onBlur?.(event);
+  }
+
+  return (
+    <Tooltip variant="error" message={props.error}>
+      <Component
+        {...props}
+        {...Publication.define(colId)}
+        ref={ref}
+        value={data}
+        onBlur={handleBlur}
+        onChange={handleChange}
+        placeholder={placeholder}
+        error={error}
+        fill
+      />
+    </Tooltip>
+  );
+});
 
 export type { Props as DataInputProps };
 export default DataInput;

--- a/frontend/components/DevSignInButton.tsx
+++ b/frontend/components/DevSignInButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { FC } from "react";
+
+// Dev-only credentials shortcut. Navigates to the `/api/auth/dev` route handler
+// (a full navigation, not a client-side <Link>, so its Set-Cookie reaches the
+// browser), which mints an admin session and redirects home. Rendered only in
+// development — see the sign-in page.
+const DevSignInButton: FC = () => (
+  <button
+    type="button"
+    onClick={() => window.location.assign("/api/auth/dev")}
+    className="text-sm text-gray-500 underline hover:text-indigo-600"
+  >
+    Dev admin sign-in
+  </button>
+);
+
+export default DevSignInButton;

--- a/frontend/components/Menu.stories.tsx
+++ b/frontend/components/Menu.stories.tsx
@@ -33,3 +33,23 @@ export const Default: Story = {
     ).toBeInTheDocument();
   },
 };
+
+/**
+ * `bordered` — the outlined dropdown that pairs with a bordered input (white,
+ * bordered, `text-sm`), instead of the subtle borderless dense style.
+ */
+export const Bordered: Story = {
+  args: { bordered: true },
+  render: (args) => (
+    <Menu {...args} aria-label="Books">
+      <MenuItem selected={false}>Dom Casmurro</MenuItem>
+      <MenuItem selected>Memórias Póstumas</MenuItem>
+      <MenuItem selected={false}>Quincas Borba</MenuItem>
+    </Menu>
+  ),
+  play: async ({ canvasElement }) => {
+    const listbox = within(canvasElement).getByRole("listbox");
+    await expect(getComputedStyle(listbox).borderTopWidth).toBe("1px");
+    await expect(getComputedStyle(listbox).fontSize).toBe("14px");
+  },
+};

--- a/frontend/components/Menu.tsx
+++ b/frontend/components/Menu.tsx
@@ -5,10 +5,14 @@ import { DetailedHTMLProps, forwardRef, OlHTMLAttributes } from "react";
 type Props = Omit<
   DetailedHTMLProps<OlHTMLAttributes<HTMLOListElement>, HTMLOListElement>,
   "className"
->;
+> & {
+  /** Outlined style to match a `bordered` TextInput; defaults to the subtle
+   * dense style used in the workspace table. */
+  bordered?: boolean;
+};
 
 export default forwardRef<HTMLOListElement, Props>(function Menu(
-  { ...props },
+  { bordered = false, ...props },
   ref,
 ) {
   return (
@@ -16,7 +20,12 @@ export default forwardRef<HTMLOListElement, Props>(function Menu(
       // Default listbox role for standalone use; MenuProvider passes the same
       // role (plus the combobox wiring) through `...props` when it owns the menu.
       role="listbox"
-      className="z-30 overflow-y-scroll text-xs rounded shadow-sm max-h-48 w-max bg-gray-active scrollbar-thumb-gray-300 scrollbar-thin"
+      data-bordered={bordered}
+      className={`
+        z-60 overflow-y-auto rounded max-h-48 w-max scrollbar-thumb-gray-300 scrollbar-thin
+        data-[bordered=false]:text-xs data-[bordered=false]:shadow-sm data-[bordered=false]:bg-gray-active
+        data-[bordered=true]:text-sm data-[bordered=true]:p-1 data-[bordered=true]:space-y-0.5 data-[bordered=true]:bg-white data-[bordered=true]:border data-[bordered=true]:border-gray-200 data-[bordered=true]:shadow-md
+      `}
       ref={ref}
       {...props}
     />

--- a/frontend/components/MenuProvider.stories.tsx
+++ b/frontend/components/MenuProvider.stories.tsx
@@ -14,7 +14,7 @@ const options: MenuOption[] = [
  * MenuProvider is fully controlled — open state, active index, and selection all
  * live in the parent. This harness wires them up so the menu is interactive.
  */
-const Harness = () => {
+const Harness = ({ bordered }: { bordered?: boolean }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const [selected, setSelected] = useState<string>();
@@ -28,6 +28,7 @@ const Harness = () => {
         setIsOpen={setIsOpen}
         setActiveIndex={setActiveIndex}
         onSelect={(option) => setSelected(option.label)}
+        bordered={bordered}
       >
         <button
           aria-label="Open menu"
@@ -120,6 +121,20 @@ export const HighlightsWithArrowKeys: Story = {
     // the trigger and the active option is tracked via aria, never moved to the
     // list.
     await expect(trigger).toHaveFocus();
+  },
+};
+
+/**
+ * `bordered` — the outlined dropdown style is forwarded to `Menu` so the
+ * option list matches a bordered input (visible border, `text-sm`).
+ */
+export const Bordered: Story = {
+  render: () => <Harness bordered />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByText("Open menu"));
+    const listbox = await screen.findByRole("listbox");
+    await expect(getComputedStyle(listbox).borderTopWidth).toBe("1px");
   },
 };
 

--- a/frontend/components/MenuProvider.tsx
+++ b/frontend/components/MenuProvider.tsx
@@ -23,6 +23,7 @@ type Props<OptionType extends Option | string> = {
   options: OptionType[];
   isOpen: boolean;
   activeIndex: number | null;
+  bordered?: boolean;
   setIsOpen: (value: boolean) => void;
   setActiveIndex: (value: number | null) => void;
   onSelect: (option: OptionType) => void;
@@ -36,6 +37,7 @@ const MenuProvider = <OptionType extends Option | string>({
   setIsOpen,
   setActiveIndex,
   onSelect,
+  bordered,
 }: Props<OptionType>) => {
   const listRef = useRef<(HTMLLIElement | null)[]>([]);
 
@@ -98,6 +100,7 @@ const MenuProvider = <OptionType extends Option | string>({
           >
             <Menu
               ref={refs.setFloating}
+              bordered={bordered}
               {...getFloatingProps({
                 style: {
                   position: strategy,

--- a/frontend/components/Multicombobox.stories.tsx
+++ b/frontend/components/Multicombobox.stories.tsx
@@ -12,15 +12,17 @@ const OPTIONS = ["Fiction", "Poetry", "Essay", "Drama"];
 const Controlled: FC<{
   value?: string[];
   error?: string;
+  bordered?: boolean;
   getOptions: (search: string) => Promise<string[]> | string[];
   onChange: (value: string[]) => void;
-}> = ({ value: initial = [], error, getOptions, onChange }) => {
+}> = ({ value: initial = [], error, bordered, getOptions, onChange }) => {
   const [value, setValue] = useState(initial);
 
   return (
     <Multicombobox<string>
       value={value}
       error={error}
+      bordered={bordered}
       placeholder="Add a genre"
       getOptions={getOptions}
       onChange={(next) => {
@@ -47,6 +49,7 @@ const meta = {
     <Controlled
       value={args.value}
       error={args.error}
+      bordered={args.bordered}
       getOptions={args.getOptions}
       onChange={args.onChange}
     />
@@ -96,6 +99,27 @@ export const Default: Story = {
     // Typing runs the async option lookup that backs the floating menu.
     await userEvent.type(input, "dr");
     await waitFor(() => expect(args.getOptions).toHaveBeenCalledWith("dr"));
+  },
+};
+
+/**
+ * `bordered` — the outlined variant used in forms (e.g. the edit modal). The
+ * dropdown adopts the matching outlined style (white, bordered, `text-sm`)
+ * rather than the subtle dense style of the workspace table.
+ */
+export const Bordered: Story = {
+  args: { bordered: true, value: ["Fiction"] },
+  parameters: {
+    a11y: { config: { rules: [{ id: "aria-hidden-focus", enabled: false }] } },
+  },
+  play: async ({ canvasElement }) => {
+    const input = within(canvasElement).getByRole("combobox");
+    await userEvent.type(input, "e");
+    const listbox = await screen.findByRole("listbox");
+    // Outlined dropdown: a visible border and the larger text-sm size, unlike
+    // the borderless text-xs subtle menu.
+    await expect(getComputedStyle(listbox).borderTopWidth).toBe("1px");
+    await expect(getComputedStyle(listbox).fontSize).toBe("14px");
   },
 };
 

--- a/frontend/components/Multicombobox.tsx
+++ b/frontend/components/Multicombobox.tsx
@@ -19,6 +19,7 @@ type Props<ItemType extends string | Item> = {
   onChange: (value: ItemType[]) => void;
   getOptions: (search: string) => Promise<ItemType[]> | ItemType[];
   forwardedRef?: ForwardedRef<HTMLDivElement>;
+  bordered?: boolean;
 };
 
 function isStringArray(value: unknown): value is string[] {
@@ -120,6 +121,7 @@ export default function Multicombobox<ItemType extends string | Item>({
       setIsOpen={setIsOpen}
       setActiveIndex={setActiveIndex}
       onSelect={handleOptionSelect}
+      bordered={props.bordered}
     >
       <TextInput
         {...props}

--- a/frontend/components/Notifications.tsx
+++ b/frontend/components/Notifications.tsx
@@ -82,7 +82,7 @@ const Notifications: FC = () => {
     <FloatingPortal>
       <section
         aria-label="Notifications"
-        className="flex fixed top-10 left-1/2 flex-col items-center space-y-2 -translate-x-1/2 z-60"
+        className="flex fixed top-10 left-1/2 flex-col items-center space-y-2 -translate-x-1/2 z-70"
       >
         <AnimatePresence>
           {snackbars.map(

--- a/frontend/components/NumberInput.stories.tsx
+++ b/frontend/components/NumberInput.stories.tsx
@@ -9,10 +9,11 @@ import NumberInput from "./NumberInput";
 const Controlled: FC<{
   value?: number;
   error?: string;
+  bordered?: boolean;
   min?: number;
   max?: number;
   onChange?: (value: number) => void;
-}> = ({ value: initial, error, min, max, onChange }) => {
+}> = ({ value: initial, error, bordered, min, max, onChange }) => {
   const [value, setValue] = useState(initial);
 
   return (
@@ -20,6 +21,7 @@ const Controlled: FC<{
       aria-label="Year"
       value={value}
       error={error}
+      bordered={bordered}
       min={min}
       max={max}
       onChange={(next) => {
@@ -39,6 +41,7 @@ const meta = {
     <Controlled
       value={args.value}
       error={args.error}
+      bordered={args.bordered}
       min={args.min as number | undefined}
       max={args.max as number | undefined}
       onChange={args.onChange}
@@ -93,5 +96,15 @@ export const WithError: Story = {
       "aria-invalid",
       "true",
     );
+  },
+};
+
+/** `bordered` — the outlined variant (edit form), a visible box with `text-sm`. */
+export const Bordered: Story = {
+  args: { value: 1953, bordered: true },
+  play: async ({ canvasElement }) => {
+    const input = within(canvasElement).getByRole("textbox");
+    const box = input.closest("[data-bordered='true']")!;
+    await expect(getComputedStyle(box).borderTopWidth).toBe("1px");
   },
 };

--- a/frontend/components/NumberInput.tsx
+++ b/frontend/components/NumberInput.tsx
@@ -11,6 +11,7 @@ type Props = Omit<HTMLProps<HTMLInputElement>, "value" | "onChange"> & {
   value?: number;
   error?: string;
   onChange?: (value: number) => void;
+  bordered?: boolean;
 };
 
 const IncrementButton: FC<{

--- a/frontend/components/PublicationIndexTable.stories.tsx
+++ b/frontend/components/PublicationIndexTable.stories.tsx
@@ -1,8 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import {
+  overrideField,
+  publicationIdsAtom,
   resetAll,
   resetAttributes,
   setAttributesVisible,
+  store,
 } from "modules/publication/store";
 import { sampleManyPublications, seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
@@ -37,6 +40,31 @@ export const Default: Story = {
     // 3 seeded publications → 3 body rows (+ the header row). Cell contents are
     // gated behind an IntersectionObserver, so we assert on the rows themselves.
     await expect(canvas.getAllByRole("row")).toHaveLength(4);
+  },
+};
+
+/**
+ * The index shows what is *saved*. The modal's edit draft lives in the same
+ * override overlay, so without this the values would visibly change in the table
+ * beneath the open modal, before anything was saved.
+ */
+export const IgnoresPendingEdits: Story = {
+  beforeEach: () => {
+    seed();
+    const [id] = store.get(publicationIdsAtom)!;
+    overrideField(id, "title", "Edited in the modal");
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // The stored title still renders ("Dom Casmurro" is both title and original
+    // title in the fixture, hence findAll)...
+    await expect(
+      (await canvas.findAllByText("Dom Casmurro")).length,
+    ).toBeGreaterThan(0);
+    // ...and the pending edit is nowhere in the table.
+    await expect(
+      canvas.queryByText("Edited in the modal"),
+    ).not.toBeInTheDocument();
   },
 };
 

--- a/frontend/components/PublicationIndexTable.tsx
+++ b/frontend/components/PublicationIndexTable.tsx
@@ -7,8 +7,7 @@ import {
 } from "modules/publication/model";
 import {
   useHiddenAttributes,
-  usePublicationField,
-  usePublicationFieldError,
+  usePublicationStoredField,
   useVisiblePublicationIds,
 } from "modules/publication/hooks";
 import {
@@ -99,9 +98,11 @@ const ColumnHeader: FC<{ colId: ColId; toggleable?: boolean }> = ({
 const Content: FC<{
   rowId: RowId;
   colId: ColId;
-  error: string;
-  value: string;
-}> = ({ value, colId }) => {
+}> = ({ rowId, colId }) => {
+  // Read-only surface: the *stored* value. An editing surface injects its own
+  // Content, which reads the edited value — see PublicationWorkspace.
+  const value = usePublicationStoredField(rowId, colId);
+
   return (
     <div className="px-2 py-1 truncate">
       {Publication.describeValue(value, colId)}
@@ -126,9 +127,6 @@ const Column: FC<{
   selected = false,
   selectable = false,
 }) => {
-  const value = usePublicationField(rowId, colId);
-  const error = usePublicationFieldError(rowId, colId);
-
   // `truncate` sets overflow:hidden, which zeroes the grid item's auto min-width so
   // the fixed-width track never expands to fit the content.
   return (
@@ -139,7 +137,7 @@ const Column: FC<{
       data-error={invalid}
       data-focused={focused}
     >
-      <Content rowId={rowId} colId={colId} value={value} error={error} />
+      <Content rowId={rowId} colId={colId} />
     </Aria.Cell>
   );
 };

--- a/frontend/components/PublicationModal.stories.tsx
+++ b/frontend/components/PublicationModal.stories.tsx
@@ -1,9 +1,27 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Publication } from "modules/publication/model";
 import { resetAll, setAll } from "modules/publication/store";
-import { expect, screen, waitFor } from "storybook/test";
+import { SessionProvider } from "modules/session";
+import { expect, screen, userEvent, waitFor } from "storybook/test";
 
 import { PublicationModal } from "./PublicationModal";
+
+const ADMIN = { email: "admin@rb.test", role: "admin" as const };
+
+const DOM_CASMURRO = {
+  id: 1,
+  publication: {
+    ...Publication.empty(),
+    title: "Dom Casmurro",
+    authors: "Helen Caldwell",
+    originalTitle: "Dom Casmurro",
+    originalAuthors: "Machado de Assis",
+    year: "1953",
+    countries: "US",
+    publishers: "Noonday Press",
+  },
+  errors: null,
+};
 
 // A URL-driven modal: it opens when the `?publication=<id>` query is present and
 // renders that publication (read from the store) as a searchable article.
@@ -27,23 +45,7 @@ export const Closed: Story = {
 
 /** Opened by a `?publication=1` URL query, showing that publication's details. */
 export const Default: Story = {
-  beforeEach: () =>
-    setAll([
-      {
-        id: 1,
-        publication: {
-          ...Publication.empty(),
-          title: "Dom Casmurro",
-          authors: "Helen Caldwell",
-          originalTitle: "Dom Casmurro",
-          originalAuthors: "Machado de Assis",
-          year: "1953",
-          countries: "US",
-          publishers: "Noonday Press",
-        },
-        errors: null,
-      },
-    ]),
+  beforeEach: () => setAll([DOM_CASMURRO]),
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
     // Full-screen portalled modal — bound it in the docs page.
@@ -54,6 +56,110 @@ export const Default: Story = {
     // "Helen Caldwell" appears in both the heading and a searchable link.
     await expect(screen.getAllByText(/Helen Caldwell/).length).toBeGreaterThan(
       0,
+    );
+  },
+};
+
+export const Editing: Story = {
+  beforeEach: () => setAll([DOM_CASMURRO]),
+  decorators: [
+    (Story) => (
+      <SessionProvider session={ADMIN}>
+        <Story />
+      </SessionProvider>
+    ),
+  ],
+  parameters: {
+    nextjs: { navigation: { query: { publication: "1" } } },
+    docs: { story: { inline: false, height: "30rem" } },
+  },
+  play: async () => {
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument(),
+    );
+
+    // The Publishers field holds one chip. Clicking the field's label must not
+    // remove it.
+    await expect(screen.getByText("Noonday Press")).toBeInTheDocument();
+    await userEvent.click(screen.getByText("Publishers"));
+    await expect(screen.getByText("Noonday Press")).toBeInTheDocument();
+  },
+};
+
+/**
+ * Save is disabled while the row has validation errors — there is nothing to gain
+ * from a round-trip the server will reject.
+ */
+export const EditingWithErrors: Story = {
+  beforeEach: () => setAll([{ ...DOM_CASMURRO, errors: "conflict" }]),
+  decorators: [
+    (Story) => (
+      <SessionProvider session={ADMIN}>
+        <Story />
+      </SessionProvider>
+    ),
+  ],
+  parameters: {
+    nextjs: { navigation: { query: { publication: "1" } } },
+    docs: { story: { inline: false, height: "30rem" } },
+  },
+  play: async () => {
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled(),
+    );
+    // Cancel stays available — you must be able to back out of a broken row.
+    await expect(screen.getByRole("button", { name: "Cancel" })).toBeEnabled();
+  },
+};
+
+/**
+ * A combobox dropdown opened inside the edit modal must stack *above* the modal,
+ * not behind it. Regression guard for the z-index bug (the menu was `z-30`,
+ * under the modal's `z-50`, so it opened but was hidden by the dialog). Uses the
+ * Countries field, which autocompletes from a static list (no backend).
+ */
+export const EditingMenuAboveModal: Story = {
+  beforeEach: () => setAll([DOM_CASMURRO]),
+  decorators: [
+    (Story) => (
+      <SessionProvider session={ADMIN}>
+        <Story />
+      </SessionProvider>
+    ),
+  ],
+  parameters: {
+    nextjs: { navigation: { query: { publication: "1" } } },
+    docs: { story: { inline: false, height: "30rem" } },
+    a11y: { config: { rules: [{ id: "aria-hidden-focus", enabled: false }] } },
+  },
+  play: async () => {
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument(),
+    );
+
+    // Capture the modal overlay's z-index now: once the dropdown opens, its own
+    // focus manager aria-hides the dialog, so it's no longer queryable by role.
+    const overlay = screen.getByRole("dialog").closest(".z-50")!;
+    const modalZ = Number(getComputedStyle(overlay).zIndex);
+
+    await userEvent.type(
+      screen.getByRole("combobox", { name: "Countries" }),
+      "United",
+    );
+    const listbox = await screen.findByRole("listbox");
+
+    // The dropdown's z-index must beat the modal overlay's — both are body-level
+    // floating portals, so their stacking is decided by z-index.
+    await expect(Number(getComputedStyle(listbox).zIndex)).toBeGreaterThan(
+      modalZ,
     );
   },
 };

--- a/frontend/components/PublicationModal.tsx
+++ b/frontend/components/PublicationModal.tsx
@@ -1,11 +1,26 @@
 "use client";
 
-import { Publication, type PublicationKey } from "modules/publication/model";
-import { usePublication } from "modules/publication/hooks";
+import {
+  useIsPublicationValid,
+  usePublication,
+  usePublicationErrorDescription,
+  usePublicationField,
+  usePublicationFieldError,
+} from "modules/publication/hooks";
+import {
+  Publication,
+  type PublicationId,
+  type PublicationKey,
+} from "modules/publication/model";
+import { update, validateUpdate } from "modules/publication/remote";
+import { discardEdit } from "modules/publication/store";
+import { useIsAdmin } from "modules/session";
 import Link from "next/link";
-import { FC } from "react";
+import { FC, SubmitEvent, useState } from "react";
 import { z } from "zod";
 import { Article } from "./Article";
+import Button from "./Button";
+import DataInput from "./DataInput";
 import { Modal, useURLQueryModal } from "./Modal";
 import Tooltip from "./Tooltip";
 
@@ -55,7 +70,7 @@ const PublicationHeading: FC<{ publication: Publication }> = ({
       </span>
     </Tooltip>
     <Tooltip variant="info" message="Who translated this publication">
-      <span className="text-lg font-light tracking-tighter text-indigo-500 sm:text-xl">
+      <span className="text-lg font-light tracking-tighter text-indigo-500 sm:text-xl whitespace-nowrap">
         ({publication.authors})
       </span>
     </Tooltip>
@@ -95,25 +110,130 @@ const PublicationDescription: FC<{ publication: Publication }> = ({
   );
 };
 
+const EditField: FC<{ id: PublicationId; attribute: PublicationKey }> = ({
+  id,
+  attribute,
+}) => {
+  const value = usePublicationField(id, attribute);
+  const error = usePublicationFieldError(id, attribute);
+
+  return (
+    <div className="flex flex-col gap-1 text-sm">
+      <span className="text-gray-500">
+        {Publication.ATTRIBUTE_LABELS[attribute]}
+      </span>
+      <DataInput
+        rowId={id}
+        colId={attribute}
+        value={value}
+        error={error}
+        aria-label={Publication.ATTRIBUTE_LABELS[attribute]}
+        bordered
+        autoValidated
+        onValidate={() => validateUpdate(id)}
+      />
+    </div>
+  );
+};
+
+const PublicationEditForm: FC<{ id: PublicationId; onDone: () => void }> = ({
+  id,
+  onDone,
+}) => {
+  const [saving, setSaving] = useState(false);
+  const error = usePublicationErrorDescription(id);
+  const isValid = useIsPublicationValid(id);
+
+  async function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    const saved = await update(id);
+    setSaving(false);
+    if (saved) onDone();
+  }
+
+  function handleCancel() {
+    discardEdit(id);
+    onDone();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-5 p-8 w-full">
+      <h1 className="text-2xl font-normal">Edit publication</h1>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {Publication.ATTRIBUTES.map((attribute) => (
+          <EditField key={attribute} id={id} attribute={attribute} />
+        ))}
+      </div>
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <div className="flex gap-3 justify-end">
+        <Button
+          label="Cancel"
+          variant="outline"
+          width="fit"
+          size="medium"
+          onClick={handleCancel}
+        />
+        <Button
+          label="Save"
+          type="submit"
+          width="fit"
+          size="medium"
+          loading={saving}
+          // Nothing to gain from a round-trip we know the server will reject.
+          // `saving` is included because Button lets an explicit `disabled`
+          // override its own `loading`-implies-disabled.
+          disabled={!isValid || saving}
+        />
+      </div>
+    </form>
+  );
+};
+
 const PublicationModal: FC = () => {
   const { value, ...modal } = useURLQueryModal(PUBLICATION_MODAL_KEY);
 
   const publicationId = Param.parse(value);
 
   const publication = usePublication(publicationId);
+  const isAdmin = useIsAdmin();
+
+  const [editingId, setEditingId] = useState<PublicationId>();
+  const editing = editingId !== undefined && editingId === publicationId;
+
+  function close() {
+    if (editing && publicationId !== undefined) discardEdit(publicationId);
+    modal.close();
+  }
 
   return (
-    <Modal
-      isOpen={modal.isOpen}
-      onClose={modal.close}
-      label="Publication details"
-    >
-      {publication && (
-        <Article
-          heading={<PublicationHeading publication={publication} />}
-          content={<PublicationDescription publication={publication} />}
-        />
-      )}
+    <Modal isOpen={modal.isOpen} onClose={close} label="Publication details">
+      {publication &&
+        publicationId !== undefined &&
+        (editing ? (
+          <PublicationEditForm
+            id={publicationId}
+            onDone={() => setEditingId(undefined)}
+          />
+        ) : (
+          <Article
+            heading={<PublicationHeading publication={publication} />}
+            content={
+              <div className="space-y-6">
+                <PublicationDescription publication={publication} />
+                {isAdmin && (
+                  <Button
+                    label="Edit"
+                    variant="outline-primary"
+                    width="fit"
+                    size="medium"
+                    onClick={() => setEditingId(publicationId)}
+                  />
+                )}
+              </div>
+            }
+          />
+        ))}
     </Modal>
   );
 };

--- a/frontend/components/PublicationWorkspace.stories.tsx
+++ b/frontend/components/PublicationWorkspace.stories.tsx
@@ -31,6 +31,23 @@ export const Default: Story = {
   },
 };
 
+/**
+ * The new-publication row is an editing surface too, so typing into it must
+ * stick. It renders through the *base* `Column` (not the workspace's extended
+ * one), so a table that reads stored values by default would leave this row
+ * permanently empty — seeded rows would keep working and hide it.
+ */
+export const NewRowAcceptsInput: Story = {
+  beforeEach: () => seed([]),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const title = await canvas.findByPlaceholderText("Title");
+
+    await userEvent.type(title, "Dom Casmurro");
+    await waitFor(() => expect(title).toHaveValue("Dom Casmurro"));
+  },
+};
+
 /** Field-level validation errors — the title and year cells are flagged. */
 export const WithInvalidRow: Story = {
   beforeEach: () =>

--- a/frontend/components/PublicationWorkspace.tsx
+++ b/frontend/components/PublicationWorkspace.tsx
@@ -19,10 +19,13 @@ import {
   useIsPublicationFocused,
   useIsPublicationValid,
   usePublicationErrorDescription,
+  usePublicationField,
+  usePublicationFieldError,
   useVisiblePublicationIds,
 } from "modules/publication/hooks";
-import { DRAFT_ID, addNew } from "modules/publication/store";
 import { validate } from "modules/publication/remote";
+import { DRAFT_ID, addNew } from "modules/publication/store";
+import { select, useIsSelected, useIsSelectionEmpty } from "modules/selection";
 import {
   FC,
   KeyboardEventHandler,
@@ -31,7 +34,6 @@ import {
   useEffect,
   useRef,
 } from "react";
-import { select, useIsSelected, useIsSelectionEmpty } from "modules/selection";
 import DataInput from "./DataInput";
 import Tooltip from "./Tooltip";
 
@@ -83,7 +85,10 @@ const ExtendedSignalColumn: FC<{ rowId: RowId }> = ({ rowId }) => {
   );
 };
 
-const ExtendedContent: typeof Content = ({ rowId, colId, value, error }) => {
+const ExtendedContent: typeof Content = ({ rowId, colId }) => {
+  const value = usePublicationField(rowId, colId);
+  const error = usePublicationFieldError(rowId, colId);
+
   return (
     <DataInput
       rowId={rowId}
@@ -130,8 +135,10 @@ const useSubmit = () => {
   }, []);
 };
 
-const SubmittableData: typeof Content = ({ rowId, colId, value, error }) => {
+const SubmittableData: typeof Content = ({ rowId, colId }) => {
   const submit = useSubmit();
+  const value = usePublicationField(rowId, colId);
+  const error = usePublicationFieldError(rowId, colId);
 
   const handleKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
     (event) => {

--- a/frontend/components/Select.tsx
+++ b/frontend/components/Select.tsx
@@ -22,12 +22,24 @@ type Props = Omit<
 > & {
   error: string;
   value?: Option;
+  /** Outlined style — applies to the input *and* its dropdown. */
+  bordered?: boolean;
   onChange: (option: Option) => void;
   getOptions: (search: string) => Promise<Option[]>;
 };
 
 export default forwardRef<HTMLInputElement, Props>(function Select(
-  { value, error, onChange, onBlur, onFocus, onKeyDown, getOptions, ...props },
+  {
+    value,
+    error,
+    bordered,
+    onChange,
+    onBlur,
+    onFocus,
+    onKeyDown,
+    getOptions,
+    ...props
+  },
   ref,
 ) {
   const [isOpen, setIsOpen] = useState(false);
@@ -109,9 +121,11 @@ export default forwardRef<HTMLInputElement, Props>(function Select(
       setIsOpen={setIsOpen}
       setActiveIndex={setActiveIndex}
       onSelect={handleSelect}
+      bordered={bordered}
     >
       <TextInput
         {...props}
+        bordered={bordered}
         ref={ref}
         inputRef={inputRef}
         onChange={handleInputChange}

--- a/frontend/components/SignInButton.tsx
+++ b/frontend/components/SignInButton.tsx
@@ -7,11 +7,13 @@ import Button from "./Button";
 type Props = {
   next?: string;
   label?: string;
+  centered?: boolean;
 };
 
 const SignInButton: FC<Props> = ({
   next = "/",
   label = "Sign in with Google",
+  centered = false,
 }) => {
   const handleClick = () => {
     window.location.assign(`/api/auth/google?next=${encodeURIComponent(next)}`);
@@ -21,7 +23,7 @@ const SignInButton: FC<Props> = ({
     <Button
       label={label}
       variant="outline"
-      alignment="left"
+      alignment={centered ? "center" : "left"}
       onClick={handleClick}
       Icon={GoogleIcon}
       width="fixed"

--- a/frontend/components/TextInput.stories.tsx
+++ b/frontend/components/TextInput.stories.tsx
@@ -1,7 +1,49 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { colord, extend } from "colord";
+import a11yPlugin from "colord/plugins/a11y";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import TextInput from "./TextInput";
+
+extend([a11yPlugin]);
+
+// Paint `colors` over one another on a 1px canvas and read the result as sRGB.
+// This is the part colord can't do: it resolves alpha compositing, and Tailwind
+// v4 computes to `oklch`, which colord cannot parse.
+function paint(colors: string[]): string {
+  const ctx = document.createElement("canvas").getContext("2d")!;
+  for (const color of colors) {
+    ctx.fillStyle = color;
+    ctx.fillRect(0, 0, 1, 1);
+  }
+  const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+  return `rgb(${r}, ${g}, ${b})`;
+}
+
+// Every background painted behind `el`, page-first. The input is `bg-transparent`
+// and the error fill is translucent, so the colour behind the text only exists
+// once the whole stack is composited.
+function backgroundsBehind(el: HTMLElement): string[] {
+  const ancestors: HTMLElement[] = [];
+  for (let n: HTMLElement | null = el; n; n = n.parentElement)
+    ancestors.unshift(n);
+  return ["#fff", ...ancestors.map((n) => getComputedStyle(n).backgroundColor)];
+}
+
+/**
+ * WCAG contrast ratio between an element's text and what is painted behind it.
+ *
+ * Storybook's a11y addon can't cover this: axe abstains here — "background color
+ * could not be determined due to a background gradient" — and reports
+ * *incomplete*, which `a11y: { test: "error" }` does not fail on. Compositing the
+ * stack ourselves turns that into a definite number.
+ */
+function textContrast(el: HTMLElement): number {
+  const behind = backgroundsBehind(el);
+  return colord(paint(behind)).contrast(
+    paint([...behind, getComputedStyle(el).color]),
+  );
+}
 
 const meta = {
   title: "Components/Text input",
@@ -69,5 +111,56 @@ export const WithError: Story = {
   play: async ({ canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox");
     await expect(input).toHaveAttribute("aria-invalid", "true");
+  },
+};
+
+/**
+ * `bordered` — the outlined variant for standalone forms (e.g. the edit modal):
+ * a visible box with `text-sm`. The default borderless look is what the dense
+ * table cells rely on.
+ */
+export const Bordered: Story = {
+  args: { bordered: true, value: "Dom Casmurro", "aria-label": "Title" },
+  play: async ({ canvasElement }) => {
+    const input = within(canvasElement).getByRole("textbox");
+    const box = input.closest("[data-bordered='true']")!;
+    await expect(getComputedStyle(box).borderTopWidth).toBe("1px");
+  },
+};
+
+/**
+ * Errored + focused, **bordered** (outlined form) variant: the text must stay
+ * dark and readable. The subtle variant's white-on-red treatment would be
+ * white-on-white here — regression guard for that.
+ */
+export const ErrorFocusedBordered: Story = {
+  args: {
+    bordered: true,
+    error: "must be a number",
+    value: "nineteen",
+    "aria-label": "Year",
+  },
+  play: async ({ canvasElement }) => {
+    const input = within(canvasElement).getByRole("textbox");
+    await userEvent.click(input);
+    await expect(input).toHaveFocus();
+    // The subtle variant's white-on-red treatment would be white-on-white here.
+    await expect(textContrast(input)).toBeGreaterThanOrEqual(4.5);
+  },
+};
+
+/**
+ * Errored + focused, **subtle** (dense table) variant: fills red with white
+ * text — a strong error signal. Guards the stray-comma bug that had voided the
+ * red focus fill (leaving white text on the near-white focus background).
+ */
+export const ErrorFocusedSubtle: Story = {
+  args: { error: "must be a number", value: "nineteen" },
+  play: async ({ canvasElement }) => {
+    const input = within(canvasElement).getByRole("textbox");
+    await userEvent.click(input);
+    await expect(input).toHaveFocus();
+    // The bug left the text unreadable on the near-white focus background.
+    await expect(textContrast(input)).toBeGreaterThanOrEqual(4.5);
   },
 };

--- a/frontend/components/TextInput.tsx
+++ b/frontend/components/TextInput.tsx
@@ -23,10 +23,24 @@ type Props = Omit<
   /** Stretch to fill the parent's height (e.g. a table cell). Defaults to
    * fitting the content. */
   fill?: boolean;
+  /** Draw a visible bordered box — for standalone forms. Off by default, which
+   * keeps the subtle look the dense table cells rely on. */
+  bordered?: boolean;
 };
 
 export default forwardRef<HTMLDivElement, Props>(function TextInput(
-  { value, error, left, right, inputRef, onChange, label, fill, ...props },
+  {
+    value,
+    error,
+    left,
+    right,
+    inputRef,
+    onChange,
+    label,
+    fill,
+    bordered,
+    ...props
+  },
   ref,
 ) {
   const labelId = useId();
@@ -41,15 +55,18 @@ export default forwardRef<HTMLDivElement, Props>(function TextInput(
       ref={ref}
       data-fill={Boolean(fill)}
       data-labeled={Boolean(label)}
+      data-bordered={Boolean(bordered)}
       className={`
         relative group bg-white
         w-full gap-1 inline-flex items-center rounded scrollbar scrollbar-none
-        error-within:shadow-sm focus-within:error-within:bg-red-400/80, error-within:bg-red-300/40
+        error-within:shadow-sm
         has-disabled:opacity-60 has-disabled:cursor-not-allowed
         data-[fill=true]:h-full
         data-[fill=false]:h-fit
-        data-[labeled=true]:mt-2 data-[labeled=true]:px-2 data-[labeled=true]:py-2 data-[labeled=true]:bg-gray-active data-[labeled=true]:shadow-sm data-[labeled=true]:focus-within:bg-indigo-500/10
-        data-[labeled=false]:text-xs data-[labeled=false]:p-1 data-[labeled=false]:overflow-x-scroll data-[labeled=false]:focus-within:bg-gray-active data-[labeled=false]:focus-within:shadow-sm
+        data-[labeled=true]:mt-2 data-[labeled=true]:px-2 data-[labeled=true]:py-2 data-[labeled=true]:shadow-sm data-[labeled=true]:not-error-within:bg-gray-active data-[labeled=true]:not-error-within:focus-within:bg-indigo-500/10
+        data-[labeled=false]:data-[bordered=false]:text-xs data-[labeled=false]:data-[bordered=false]:p-1 data-[labeled=false]:overflow-x-scroll data-[labeled=false]:focus-within:shadow-sm data-[labeled=false]:not-error-within:focus-within:bg-gray-active
+        data-[bordered=false]:error-within:bg-red-300/40 data-[bordered=false]:error-within:focus-within:bg-red-300/70
+        data-[bordered=true]:border data-[bordered=true]:px-2.5 data-[bordered=true]:py-1.5 data-[bordered=true]:text-sm data-[bordered=true]:not-error-within:border-gray-300 data-[bordered=true]:not-error-within:focus-within:border-indigo-400 data-[bordered=true]:error-within:border-red-400 data-[bordered=true]:error-within:focus-within:border-red-500
       `}
     >
       {left}
@@ -57,7 +74,7 @@ export default forwardRef<HTMLDivElement, Props>(function TextInput(
         {...props}
         ref={inputRef}
         value={value}
-        className="px-1 w-full bg-transparent outline-none peer shrink grow placeholder:text-xs error:focus:text-white error:placeholder-white disabled:cursor-not-allowed"
+        className="px-1 w-full bg-transparent outline-none peer shrink grow placeholder:text-xs disabled:cursor-not-allowed"
         onChange={handleChange}
         data-error={Boolean(error)}
         placeholder={label ? "" : props.placeholder}

--- a/frontend/modules/publication/hooks.ts
+++ b/frontend/modules/publication/hooks.ts
@@ -19,6 +19,7 @@ import {
   overriddenCountAtom,
   overriddenIdsAtom,
   publicationOrNullFamily,
+  storedFieldValueFamily,
   totalCountAtom,
   totalIndexCountAtom,
   validCountAtom,
@@ -60,6 +61,14 @@ function usePublicationField<K extends PublicationKey>(
   key: K,
 ) {
   return useAtomValue(fieldValueFamily({ id, key })) as Publication[K];
+}
+
+/** A single cell's stored value, ignoring pending edits — its own subscription. */
+function usePublicationStoredField<K extends PublicationKey>(
+  id: PublicationId,
+  key: K,
+) {
+  return useAtomValue(storedFieldValueFamily({ id, key })) as Publication[K];
 }
 
 function usePublicationError(id: PublicationId) {
@@ -160,6 +169,7 @@ export {
   usePublicationFieldError,
   usePublicationIndexCount,
   usePublicationOverride,
+  usePublicationStoredField,
   useTotalPublicationCount,
   useValidPublicationCount,
   useVisibleAttributes,

--- a/frontend/modules/publication/model.spec.ts
+++ b/frontend/modules/publication/model.spec.ts
@@ -14,7 +14,11 @@ describe("empty", () => {
 
     // Every model attribute is present and empty — the shape editing relies on.
     ATTRIBUTES.forEach((key) => expect(publication[key]).toBe(""));
-    expect(Object.keys(publication).sort()).toEqual([...ATTRIBUTES].sort());
+    // Plus a null id: an unsaved row has no server PK yet.
+    expect(publication.id).toBeNull();
+    expect(Object.keys(publication).sort()).toEqual(
+      ["id", ...ATTRIBUTES].sort(),
+    );
   });
 });
 

--- a/frontend/modules/publication/model.ts
+++ b/frontend/modules/publication/model.ts
@@ -11,13 +11,16 @@ type Publication = {
   authors: string;
   originalTitle: string;
   originalAuthors: string;
+  // The server PK: a real id on persisted rows (index/search), null on
+  // unsaved/working rows. Read-only: never cast from client input.
+  id: number | null;
 };
 
-type PublicationKey = keyof Publication;
+type PublicationKey = keyof Omit<Publication, "id">;
 type PublicationError = null | string | Record<PublicationKey, string>;
 type ValidationResult = { publication: Publication; errors: PublicationError };
 type PublicationEntry = ValidationResult & { id: number };
-type PublicationId = number;
+type PublicationId = NonNullable<Publication["id"]>;
 type PublicationKeyType = "array" | "text" | "enum" | "enumArray" | "number";
 
 const ATTRIBUTES: PublicationKey[] = [
@@ -81,6 +84,7 @@ const ERROR_MESSAGES: Record<string, string> = {
 
 function empty(): Publication {
   return {
+    id: null,
     authors: "",
     countries: "",
     originalAuthors: "",

--- a/frontend/modules/publication/remote.spec.ts
+++ b/frontend/modules/publication/remote.spec.ts
@@ -5,7 +5,14 @@ import hash from "object-hash";
 
 import type { Publication } from "./model";
 import { empty } from "./model";
-import { bulk, index, upload, validate } from "./remote";
+import {
+  bulk,
+  index,
+  update,
+  upload,
+  validate,
+  validateUpdate,
+} from "./remote";
 import {
   createId,
   errorFamily,
@@ -13,6 +20,8 @@ import {
   isValidatingAtom,
   keywordsAtom,
   lastValidatedFamily,
+  overrideFamily,
+  overrideField,
   publicationFamily,
   publicationIdsAtom,
   resetAll,
@@ -30,7 +39,11 @@ vi.mock("components/Notifications", () => ({ notify: vi.fn() }));
 const mockRequest = vi.mocked(request);
 const mockNotify = vi.mocked(notify);
 
-type Http = { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn> };
+type Http = {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+};
 let http: Http;
 
 function pub(fields: Partial<Publication> = {}): Publication {
@@ -42,7 +55,7 @@ beforeEach(() => {
   store.set(isValidatingAtom, false);
   vi.clearAllMocks();
 
-  http = { get: vi.fn(), post: vi.fn() };
+  http = { get: vi.fn(), post: vi.fn(), put: vi.fn() };
   // By default, `request(op)` runs the op against our fake http client.
   mockRequest.mockImplementation(((op: (client: AxiosInstance) => unknown) =>
     op(http as unknown as AxiosInstance)) as typeof request);
@@ -137,6 +150,108 @@ describe("bulk", () => {
     expect(result).toBe(created);
     // The list is reset while the server responds.
     expect(store.get(publicationIdsAtom)).toBeUndefined();
+  });
+});
+
+describe("update", () => {
+  test("PUTs the edited row, replaces it with the server value, and clears the edit", async () => {
+    const id = 7;
+    store.set(publicationFamily(id), pub({ title: "Old title" }));
+    overrideField(id, "title", "New title");
+    const returned = { ...pub({ title: "New title" }), id };
+    http.put.mockResolvedValue({ data: returned });
+
+    const ok = await update(id);
+
+    expect(ok).toBe(true);
+    const [url, body] = http.put.mock.calls[0];
+    expect(url).toBe("publications/7");
+    // The body is the visible value (base ⊕ pending edit).
+    expect((body as Publication).title).toBe("New title");
+    // The row is replaced with the server's value and the edit is cleared.
+    expect(store.get(publicationFamily(id))).toEqual(returned);
+    expect(store.get(overrideFamily(id))).toBeUndefined();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "success" }),
+    );
+  });
+
+  test("on a 409 conflict, notifies and returns false", async () => {
+    const id = 7;
+    store.set(publicationFamily(id), pub({ title: "A" }));
+    http.put.mockRejectedValue({
+      response: { status: 409, data: { errors: "conflict" } },
+    });
+
+    const ok = await update(id);
+
+    expect(ok).toBe(false);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "warning" }),
+    );
+  });
+
+  test("on a 400, surfaces the field errors on the row and returns false", async () => {
+    const id = 7;
+    store.set(publicationFamily(id), pub({ title: "" }));
+    http.put.mockRejectedValue({
+      response: { status: 400, data: { errors: { title: "required" } } },
+    });
+
+    const ok = await update(id);
+
+    expect(ok).toBe(false);
+    expect(store.get(errorFamily(id))).toEqual({ title: "required" });
+  });
+});
+
+describe("validateUpdate", () => {
+  test("POSTs the visible value to the row's validate endpoint and surfaces its errors", async () => {
+    const id = 7;
+    store.set(publicationFamily(id), pub({ title: "Old title" }));
+    overrideField(id, "title", "New title");
+    http.post.mockResolvedValue({
+      data: { publication: pub({ title: "New title" }), errors: "conflict" },
+    });
+
+    await validateUpdate(id);
+
+    const [url, body] = http.post.mock.calls[0];
+    // The id is in the path so the server can exclude the row from its own
+    // conflict check.
+    expect(url).toBe("publications/7/validate");
+    // The body is the visible value (base ⊕ pending edit).
+    expect((body as Publication).title).toBe("New title");
+    expect(store.get(errorFamily(id))).toBe("conflict");
+  });
+
+  // Each test uses its own id: these rows are written straight to
+  // `publicationFamily`, so they never enter `publicationIdsAtom` and `resetAll`
+  // can't clear them between tests.
+  test("skips the request when nothing changed", async () => {
+    const id = 8;
+    store.set(publicationFamily(id), pub({ title: "Dom Casmurro" }));
+    http.post.mockResolvedValue({
+      data: { publication: pub({ title: "Dom Casmurro" }), errors: null },
+    });
+
+    // Blur fires this on every field, so an untouched row must not re-ask.
+    await validateUpdate(id);
+    await validateUpdate(id);
+
+    expect(http.post).toHaveBeenCalledTimes(1);
+  });
+
+  test("clears the row's errors when the edit is valid", async () => {
+    const id = 9;
+    store.set(publicationFamily(id), pub({ title: "Dom Casmurro" }));
+    http.post.mockResolvedValue({
+      data: { publication: pub({ title: "Dom Casmurro" }), errors: null },
+    });
+
+    await validateUpdate(id);
+
+    expect(store.get(errorFamily(id))).toBeNull();
   });
 });
 

--- a/frontend/modules/publication/remote.spec.ts
+++ b/frontend/modules/publication/remote.spec.ts
@@ -3,8 +3,9 @@ import type { AxiosInstance } from "axios";
 import { notify } from "components/Notifications";
 import hash from "object-hash";
 
-import { empty } from "./model";
 import type { Publication } from "./model";
+import { empty } from "./model";
+import { bulk, index, upload, validate } from "./remote";
 import {
   createId,
   errorFamily,
@@ -20,7 +21,6 @@ import {
   totalIndexCountAtom,
   visiblePublicationFamily,
 } from "./store";
-import { bulk, index, upload, validate } from "./remote";
 
 // The two side-effecting seams. Mocking the modules keeps `pages/_app.tsx` and
 // the Notifications UI out of the test; the rest (store, model, hashing) is real.
@@ -53,8 +53,8 @@ describe("index", () => {
     http.get.mockResolvedValue({
       data: {
         entries: [
-          pub({ title: "Dom Casmurro" }),
-          pub({ title: "The Hour of the Star" }),
+          pub({ title: "Dom Casmurro", id: 7 }),
+          pub({ title: "The Hour of the Star", id: 12 }),
         ],
         keywords: ["machado"],
       },
@@ -64,7 +64,7 @@ describe("index", () => {
     await index();
 
     const ids = store.get(publicationIdsAtom);
-    expect(ids).toHaveLength(2);
+    expect(ids).toEqual([7, 12]);
     expect(store.get(publicationFamily(ids![0])).title).toBe("Dom Casmurro");
     expect(store.get(publicationFamily(ids![1])).title).toBe(
       "The Hour of the Star",

--- a/frontend/modules/publication/remote.ts
+++ b/frontend/modules/publication/remote.ts
@@ -1,19 +1,19 @@
 import { request } from "app";
 import { AxiosInstance } from "axios";
 import { notify } from "components/Notifications";
-import { TOTAL_COUNT_HEADER } from "modules/api";
 import { RESET } from "jotai/utils";
+import { TOTAL_COUNT_HEADER } from "modules/api";
 import hash from "object-hash";
 import { useCallback } from "react";
 import useDebounce from "utils/useDebounce";
 
+import type { Publication } from "./model";
 import {
   PublicationError,
   PublicationId,
   ValidationResult,
   describeError,
 } from "./model";
-import type { Publication } from "./model";
 import {
   createId,
   isIndexLoadingAtom,
@@ -65,10 +65,10 @@ async function index({ search }: { search?: string } = {}): Promise<void> {
       }
       store.set(keywordsAtom, keywords);
 
-      const ids = entries.map(() => createId());
+      const ids = entries.map((entry) => entry.id!);
       store.set(publicationIdsAtom, ids);
-      entries.forEach((publication, i) =>
-        store.set(publicationFamily(ids[i]), publication),
+      entries.forEach((entry, i) =>
+        store.set(publicationFamily(ids[i]), entry),
       );
     } finally {
       store.set(isIndexLoadingAtom, false);

--- a/frontend/modules/publication/remote.ts
+++ b/frontend/modules/publication/remote.ts
@@ -1,5 +1,5 @@
 import { request } from "app";
-import { AxiosInstance } from "axios";
+import { AxiosError, AxiosInstance } from "axios";
 import { notify } from "components/Notifications";
 import { RESET } from "jotai/utils";
 import { TOTAL_COUNT_HEADER } from "modules/api";
@@ -16,10 +16,12 @@ import {
 } from "./model";
 import {
   createId,
+  errorFamily,
   isIndexLoadingAtom,
   isValidatingAtom,
   keywordsAtom,
   lastValidatedFamily,
+  overrideFamily,
   publicationFamily,
   publicationIdsAtom,
   resetAll,
@@ -94,6 +96,64 @@ async function bulk(): Promise<Publication[]> {
   });
 }
 
+/**
+ * Persist edits to a single publication (admin). Returns whether it succeeded;
+ * on a conflict or validation error the row keeps its edits so they can be fixed.
+ */
+async function update(id: PublicationId): Promise<boolean> {
+  const publication = store.get(visiblePublicationFamily(id));
+
+  try {
+    const { data } = await request((http) =>
+      http.put<Publication>(`publications/${id}`, publication),
+    );
+
+    // Replace the row with the server's canonical value and clear the edit.
+    store.set(publicationFamily(id), data);
+    store.set(overrideFamily(id), RESET);
+    store.set(errorFamily(id), RESET);
+    notify({ message: "Publication updated.", level: "success" });
+    return true;
+  } catch (error) {
+    const { response } = error as AxiosError<{ errors: PublicationError }>;
+
+    if (response?.status === 409) {
+      notify({ message: describeError("conflict"), level: "warning" });
+    } else if (response?.status === 400) {
+      store.set(errorFamily(id), response.data?.errors ?? null);
+    } else {
+      notify({
+        message: "The publication could not be updated.",
+        level: "warning",
+      });
+    }
+
+    return false;
+  }
+}
+
+/**
+ * Live-validate a single publication's pending edits, excluding it from the
+ * conflict check so an in-place edit doesn't collide with itself.
+ */
+async function validateUpdate(id: PublicationId): Promise<void> {
+  const publication = store.get(visiblePublicationFamily(id));
+  const fingerprint = hash(publication);
+
+  // Same dedup as `validate`: this runs on every blur (and on every change for
+  // array fields), so a field the user only tabbed through costs no round-trip.
+  if (fingerprint === store.get(lastValidatedFamily(id))) return;
+  store.set(lastValidatedFamily(id), fingerprint);
+
+  return run(async (http) => {
+    const { data } = await http.post<ValidationResult>(
+      `publications/${id}/validate`,
+      publication,
+    );
+    setErrors([{ ...data, id }]);
+  });
+}
+
 /** Validate the given rows server-side, but only those whose value changed. */
 async function validate(ids: PublicationId[]): Promise<void> {
   return run(async (http) => {
@@ -153,4 +213,12 @@ function usePublicationIndex() {
   );
 }
 
-export { bulk, index, upload, usePublicationIndex, validate };
+export {
+  bulk,
+  index,
+  update,
+  upload,
+  usePublicationIndex,
+  validate,
+  validateUpdate,
+};

--- a/frontend/modules/publication/store.spec.ts
+++ b/frontend/modules/publication/store.spec.ts
@@ -87,6 +87,32 @@ describe("setAll", () => {
       "Dom Casmurro",
     );
   });
+
+  test("a cell is cached by value, so it keeps one stable atom", () => {
+    const a = createId();
+
+    // Each call passes a fresh `{id, key}` object, so caching by identity would
+    // mint a new atom every render — a new subscription per keystroke. Distinct
+    // cells must still get distinct atoms.
+    expect(fieldValueFamily({ id: a, key: "title" })).toBe(
+      fieldValueFamily({ id: a, key: "title" }),
+    );
+    expect(fieldValueFamily({ id: a, key: "title" })).not.toBe(
+      fieldValueFamily({ id: a, key: "authors" }),
+    );
+  });
+
+  test("a cell key survives the negative ids minted for unsaved rows", () => {
+    const a = createId();
+    setAll([entry(a, { title: "Dom Casmurro" })]);
+
+    // Ids are packed into a `<id>:<key>` string; a negative id carries its own
+    // "-", so splitting on the wrong separator would misread the id.
+    expect(a).toBeLessThan(0);
+    expect(store.get(fieldValueFamily({ id: a, key: "title" }))).toBe(
+      "Dom Casmurro",
+    );
+  });
 });
 
 describe("validity", () => {

--- a/frontend/modules/publication/store.spec.ts
+++ b/frontend/modules/publication/store.spec.ts
@@ -17,10 +17,10 @@ import {
   focusedRowIdAtom,
   hiddenAttributesAtom,
   isValidFamily,
-  overrideField,
-  overrideFamily,
   overriddenCountAtom,
   overriddenIdsAtom,
+  overrideFamily,
+  overrideField,
   publicationFamily,
   publicationIdsAtom,
   resetAll,
@@ -261,8 +261,12 @@ describe("focusNextInvalid", () => {
 });
 
 describe("ids and the draft", () => {
-  test("createId hands out unique, increasing ids", () => {
-    expect(createId()).toBeLessThan(createId());
+  test("createId hands out unique, negative ids (never collide with server ids)", () => {
+    const a = createId();
+    const b = createId();
+    expect(a).not.toBe(b);
+    expect(a).toBeLessThan(0);
+    expect(b).toBeLessThan(0);
   });
 
   test("the draft row starts empty", () => {

--- a/frontend/modules/publication/store.spec.ts
+++ b/frontend/modules/publication/store.spec.ts
@@ -11,6 +11,7 @@ import {
   addNew,
   createId,
   deletedCountAtom,
+  discardEdit,
   duplicate,
   fieldValueFamily,
   focusNextInvalid,
@@ -178,6 +179,22 @@ describe("overrides", () => {
     expect(store.get(fieldValueFamily({ id: a, key: "title" }))).toBe(
       "Dom Casmurro",
     );
+  });
+
+  test("discardEdit drops one row's pending edits and errors", () => {
+    const a = createId();
+    setAll([entry(a, { title: "Dom Casmurro" }, "conflict")]);
+    overrideField(a, "title", "changed");
+    expect(store.get(overriddenCountAtom)).toBe(1);
+    expect(store.get(isValidFamily(a))).toBe(false);
+
+    discardEdit(a);
+
+    expect(store.get(overriddenCountAtom)).toBe(0);
+    expect(store.get(fieldValueFamily({ id: a, key: "title" }))).toBe(
+      "Dom Casmurro",
+    );
+    expect(store.get(isValidFamily(a))).toBe(true);
   });
 });
 

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -1,4 +1,4 @@
-import { atom } from "jotai";
+import { Atom, atom } from "jotai";
 import { atomFamily } from "jotai-family";
 import { RESET, atomWithReset } from "jotai/utils";
 import { store } from "modules/store";
@@ -131,14 +131,35 @@ const errorDescriptionFamily = atomFamily((id: PublicationId) =>
 );
 
 type FieldKey = { id: PublicationId; key: PublicationKey };
-const sameField = (a: FieldKey, b: FieldKey) =>
-  a.id === b.id && a.key === b.key;
+type CellKey = `${PublicationId}:${PublicationKey}`;
+
+const cellKey = ({ id, key }: FieldKey): CellKey => `${id}:${key}`;
+
+const fieldKey = (cell: CellKey): FieldKey => {
+  const separator = cell.indexOf(":");
+  return {
+    id: Number(cell.slice(0, separator)),
+    key: cell.slice(separator + 1) as PublicationKey,
+  };
+};
+
+/**
+ * Cache a per-cell atom under a *string* key, keeping the `{id, key}` call
+ * signature.
+ *
+ * `atomFamily` only takes its `Map.get` fast path when no custom comparator is
+ * passed; give it one and it linear-scans the whole cache on every lookup. These
+ * caches hold an entry per cell (ids × attributes) and are read on every cell
+ * render, so an object key made lookup cost grow with the size of the index.
+ */
+function cellFamily<T>(initialize: (field: FieldKey) => Atom<T>) {
+  const family = atomFamily((cell: CellKey) => initialize(fieldKey(cell)));
+  return (field: FieldKey) => family(cellKey(field));
+}
 
 /** A single cell's value — its own subscription, so editing one cell is cheap. */
-const fieldValueFamily = atomFamily(
-  ({ id, key }: FieldKey) =>
-    atom((get) => get(visiblePublicationFamily(id))[key]),
-  sameField,
+const fieldValueFamily = cellFamily(({ id, key }) =>
+  atom((get) => get(visiblePublicationFamily(id))[key]),
 );
 
 /**
@@ -146,15 +167,12 @@ const fieldValueFamily = atomFamily(
  * returned. The read-only index reads this so an in-progress edit (the modal's
  * draft lives in the same override overlay) doesn't leak into the table beneath.
  */
-const storedFieldValueFamily = atomFamily(
-  ({ id, key }: FieldKey) => atom((get) => get(publicationFamily(id))[key]),
-  sameField,
+const storedFieldValueFamily = cellFamily(({ id, key }) =>
+  atom((get) => get(publicationFamily(id))[key]),
 );
 
-const fieldErrorDescriptionFamily = atomFamily(
-  ({ id, key }: FieldKey) =>
-    atom((get) => describeError(get(errorFamily(id)), key)),
-  sameField,
+const fieldErrorDescriptionFamily = cellFamily(({ id, key }) =>
+  atom((get) => describeError(get(errorFamily(id)), key)),
 );
 
 // --- Actions (imperative; operate on the module `store`) --------------------

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -141,6 +141,16 @@ const fieldValueFamily = atomFamily(
   sameField,
 );
 
+/**
+ * A single cell's *stored* value, ignoring pending edits — what the server last
+ * returned. The read-only index reads this so an in-progress edit (the modal's
+ * draft lives in the same override overlay) doesn't leak into the table beneath.
+ */
+const storedFieldValueFamily = atomFamily(
+  ({ id, key }: FieldKey) => atom((get) => get(publicationFamily(id))[key]),
+  sameField,
+);
+
 const fieldErrorDescriptionFamily = atomFamily(
   ({ id, key }: FieldKey) =>
     atom((get) => describeError(get(errorFamily(id)), key)),
@@ -191,6 +201,12 @@ function overrideField(
   store.set(overrideFamily(id), { ...current, [attribute]: value });
 }
 
+/** Drop a single row's pending edits and errors (cancelling an edit). */
+function discardEdit(id: PublicationId): void {
+  store.set(overrideFamily(id), RESET);
+  store.set(errorFamily(id), RESET);
+}
+
 function setAttributesVisible(keys: PublicationKey[], isVisible = true): void {
   keys.forEach((key) => store.set(attributeVisibleFamily(key), isVisible));
 }
@@ -239,7 +255,10 @@ function resetAll(): void {
     store.set(overrideFamily(id), RESET);
     store.set(errorFamily(id), RESET);
     store.set(deletedFamily(id), RESET);
+    store.set(lastValidatedFamily(id), RESET);
   });
+  store.set(overrideFamily(DRAFT_ID), RESET);
+  store.set(errorFamily(DRAFT_ID), RESET);
   store.set(publicationIdsAtom, RESET);
   store.set(focusedRowIdAtom, RESET);
   store.set(isIndexLoadingAtom, false);
@@ -284,6 +303,7 @@ export {
   attributeVisibleFamily,
   createId,
   deletedCountAtom,
+  discardEdit,
   duplicate,
   errorDescriptionFamily,
   errorFamily,
@@ -297,10 +317,10 @@ export {
   isValidatingAtom,
   keywordsAtom,
   lastValidatedFamily,
-  overrideField,
-  overrideFamily,
   overriddenCountAtom,
   overriddenIdsAtom,
+  overrideFamily,
+  overrideField,
   publicationFamily,
   publicationIdsAtom,
   publicationOrNullFamily,
@@ -315,11 +335,12 @@ export {
   setFocusedRowId,
   setPublications,
   store,
+  storedFieldValueFamily,
   totalCountAtom,
   totalIndexCountAtom,
   validCountAtom,
   visibleAttributesAtom,
+  visibleCountAtom,
   visibleIdsAtom,
   visiblePublicationFamily,
-  visibleCountAtom,
 };

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -15,15 +15,21 @@ import {
 } from "./model";
 
 /**
- * Well-known id for the always-present "new publication" draft row. Real
- * publications get stable ids from `createId()` (>= 1), so `0` never collides.
+ * Well-known id for the always-present "new publication" draft row. Persisted
+ * rows are addressed by their server id (the publication PK, positive) and
+ * unsaved rows by a client-minted id (negative, see `createId`), so `0` never
+ * collides with either.
  */
 const DRAFT_ID: PublicationId = 0;
 
-let sequence = 1;
-/** Mint a fresh, stable client id — decoupled from a publication's list position. */
+let sequence = -1;
+/**
+ * Mint a client id for an unsaved row (upload/review/duplicate). Negative and
+ * descending so it can never collide with a server id (positive) or the draft
+ * (`0`); persisted rows are addressed by their real server id instead.
+ */
 function createId(): PublicationId {
-  return sequence++;
+  return sequence--;
 }
 
 // --- Base atoms -------------------------------------------------------------
@@ -260,10 +266,13 @@ function focusNextInvalid(): void {
   const visibleIds = store.get(visibleIdsAtom);
   if (!visibleIds) return;
 
-  const focusedId = store.get(focusedRowIdAtom) ?? -1;
+  const isInvalid = (id: PublicationId) => store.get(errorFamily(id));
+  const focusedId = store.get(focusedRowIdAtom);
+  // Walk by list position (ids are no longer monotonic once rows are keyed by
+  // server id), then wrap to the first invalid row.
+  const start = focusedId === undefined ? -1 : visibleIds.indexOf(focusedId);
   const nextInvalidId =
-    visibleIds.find((id) => id > focusedId && store.get(errorFamily(id))) ||
-    visibleIds.find((id) => store.get(errorFamily(id)));
+    visibleIds.slice(start + 1).find(isInvalid) ?? visibleIds.find(isInvalid);
 
   store.set(focusedRowIdAtom, nextInvalidId);
 }

--- a/frontend/modules/session.tsx
+++ b/frontend/modules/session.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { User } from "modules/users";
+import { User } from "modules/users";
 import { createContext, ReactNode, useContext } from "react";
 
 // The signed-in user (or null), fetched once server-side in the root layout and
@@ -28,4 +28,9 @@ export function useSession(): User | null {
 
 export function useIsAuthenticated(): boolean {
   return useSession() != null;
+}
+
+export function useIsAdmin(): boolean {
+  const session = useSession();
+  return session != null && User.isAdmin(session.role);
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -54,6 +54,7 @@
         "@vitest/browser": "^4.1.10",
         "@vitest/browser-playwright": "^4.1.10",
         "@vitest/coverage-v8": "^4.1.10",
+        "colord": "^2.9.3",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.10",
         "jsdom": "^29.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -62,6 +62,7 @@
     "@vitest/browser": "^4.1.10",
     "@vitest/browser-playwright": "^4.1.10",
     "@vitest/coverage-v8": "^4.1.10",
+    "colord": "^2.9.3",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.10",
     "jsdom": "^29.1.1",

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -15,6 +15,7 @@
 @custom-variant focused (&[data-focused="true"]);
 @custom-variant error (&[data-error="true"]);
 @custom-variant error-within (&:has([data-error="true"]));
+@custom-variant not-error-within (&:not(:has([data-error="true"])));
 @custom-variant peer-error (.peer[data-error="true"] ~ &);
 @custom-variant loading (&[data-loading="true"]);
 


### PR DESCRIPTION
Adds in-place editing of an existing publication for admins.

## Backend

- **`PUT /api/publications/:id`** — `Publication.update/2` rebuilds the record through the existing changeset + association linking, mapping the composite-key constraint to a `409` conflict (mirroring `insert`). `on_replace` lets linked countries/publishers/translated-book be swapped; associations marked for removal are skipped so an edit can't resurrect or duplicate them.
- **`POST /api/publications/:id/validate`** — excludes the row being edited from the conflict check, so live validation doesn't collide with itself. Both routes sit behind the admin pipeline.
- **Expose the server id** on the flat read model and create response, so any returned row is addressable. Read-model attributes are split into a writable (cast/validated) and a readable (serialized) set, so the id is exposed without becoming client-writable.
- **Fingerprint fix.** Country/publisher/author fingerprints joined names with no separator, so `["AnnBob"]` and `["Ann", "Bob"]` collided — all routed through a single NUL-delimited `Fingerprint.of_set/1`, with a migration recomputing affected rows. Adds `mix rb.audit_fingerprints` + a CI job that fails on drift.

## Frontend

- **In-place edit form** in the publication modal: validates against the server as you type, saves with one `PUT`.
- Shared components grew variants rather than the form hand-rolling chrome — a bordered `TextInput` + matching dropdown, and `size` / `outline` variants on `Button`.
- Rows are keyed by **server id** (not a per-load client id), so the modal URL is stable and shareable; unsaved rows get negative ids to avoid collisions.
- The read-only table reads *stored* values, so the row beneath the modal no longer mutates as you type. Also fixes an errored field's focus contrast, and re-keys the per-cell atoms to a string for `atomFamily`'s fast path.

## Dev-only credentials

Adds a **"Dev admin sign-in"** that mints an admin session directly, so admin flows can be driven without a real Google OAuth handshake. Kept out of production twice over: the controller compiles only under `dev`/`test` (absent from release builds) and the route sits under the router's existing dev/test guard; the frontend button is gated on the dev environment too.