### PR TITLE
Add an E2E test suite with per-worker database isolation

### DIFF
--- a/.github/workflows/run-backend-audit.yml
+++ b/.github/workflows/run-backend-audit.yml
@@ -12,6 +12,13 @@ jobs:
         with:
           version-type: strict
           version-file: backend/.tool-versions
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/deps
+            backend/_build
+          key: mix-audit-${{ runner.os }}-${{ hashFiles('backend/.tool-versions', 'backend/mix.lock') }}
+          restore-keys: mix-audit-${{ runner.os }}-
       # config/dev.exs imports the gitignored dev.local.exs, so stub it (as the
       # test workflow does) before any mix task loads the dev config.
       - run: echo -e "import Config\nconfig :richard_burton, []" >> config/dev.local.exs

--- a/.github/workflows/run-backend-docs.yml
+++ b/.github/workflows/run-backend-docs.yml
@@ -15,6 +15,13 @@ jobs:
         with:
           version-type: strict
           version-file: backend/.tool-versions
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/deps
+            backend/_build
+          key: mix-docs-${{ runner.os }}-${{ hashFiles('backend/.tool-versions', 'backend/mix.lock') }}
+          restore-keys: mix-docs-${{ runner.os }}-
       - run: touch config/dev.local.exs
       - run: echo -e "import Config\nconfig :richard_burton, []" >> config/dev.local.exs
       - run: mix deps.get

--- a/.github/workflows/run-backend-fingerprint-audit.yml
+++ b/.github/workflows/run-backend-fingerprint-audit.yml
@@ -24,6 +24,13 @@ jobs:
         with:
           version-type: strict
           version-file: backend/.tool-versions
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/deps
+            backend/_build
+          key: mix-fingerprint-${{ runner.os }}-${{ hashFiles('backend/.tool-versions', 'backend/mix.lock') }}
+          restore-keys: mix-fingerprint-${{ runner.os }}-
       # config/dev.exs imports the gitignored dev.local.exs, so stub it before any
       # mix task loads the dev config (the audit and seeds run in the dev env).
       - run: echo -e "import Config\nconfig :richard_burton, []" >> config/dev.local.exs

--- a/.github/workflows/run-backend-formatter.yml
+++ b/.github/workflows/run-backend-formatter.yml
@@ -12,6 +12,13 @@ jobs:
         with:
           version-type: strict
           version-file: backend/.tool-versions
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/deps
+            backend/_build
+          key: mix-format-${{ runner.os }}-${{ hashFiles('backend/.tool-versions', 'backend/mix.lock') }}
+          restore-keys: mix-format-${{ runner.os }}-
       - run: echo -e "import Config\nconfig :richard_burton, []" >> config/dev.local.exs
       - run: mix deps.get
       - run: mix format --check-formatted

--- a/.github/workflows/run-backend-linter.yml
+++ b/.github/workflows/run-backend-linter.yml
@@ -12,6 +12,13 @@ jobs:
         with:
           version-type: strict
           version-file: backend/.tool-versions
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/deps
+            backend/_build
+          key: mix-lint-${{ runner.os }}-${{ hashFiles('backend/.tool-versions', 'backend/mix.lock') }}
+          restore-keys: mix-lint-${{ runner.os }}-
       - run: echo -e "import Config\nconfig :richard_burton, []" >> config/dev.local.exs
       - run: mix deps.get
       - run: mix credo

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -25,6 +25,13 @@ jobs:
         with:
           version-type: strict
           version-file: backend/.tool-versions
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/deps
+            backend/_build
+          key: mix-test-${{ runner.os }}-${{ hashFiles('backend/.tool-versions', 'backend/mix.lock') }}
+          restore-keys: mix-test-${{ runner.os }}-
       - run: echo -e "import Config\nconfig :richard_burton, []" >> config/dev.local.exs
       - run: mix deps.get
       # `mix coveralls` runs the suite (via the `test` alias, so ecto setup still

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -43,13 +43,15 @@ jobs:
           npm ci
           npx playwright install chromium --with-deps
 
-      # Two workers → two isolated (backend, frontend, database) stacks in
-      # parallel. Track-only for now (not a required check) — promote via branch
-      # protection once it has proven stable, consistent with the coverage rollout.
+      # One worker on CI: the 2-vCPU runner can't host two full stacks plus
+      # Postgres and Chromium without contention-induced flakes (bump as runners
+      # or the suite warrant — the harness scales via E2E_WORKERS). Track-only
+      # for now (not a required check) — promote via branch protection once it
+      # has proven stable, consistent with the coverage rollout.
       - name: Run Playwright E2E
         working-directory: frontend
         env:
-          E2E_WORKERS: 2
+          E2E_WORKERS: 1
         run: npm run test:e2e
 
       - name: Upload Playwright report

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -1,0 +1,61 @@
+name: Run E2E tests
+on:
+  push:
+    branches: [main]
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  E2E:
+    runs-on: ubuntu-latest
+    services:
+      db:
+        image: postgres:15.1
+        ports: ["5432:5432"]
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+
+      # Backend toolchain + compile the :e2e app. Playwright's globalSetup then
+      # creates/migrates the per-worker databases, and its webServer boots a
+      # Phoenix server per worker.
+      - uses: erlef/setup-beam@v1
+        with:
+          version-type: strict
+          version-file: backend/.tool-versions
+      - name: Compile backend (e2e)
+        working-directory: backend
+        env:
+          MIX_ENV: e2e
+        run: |
+          mix deps.get
+          mix compile
+
+      # Frontend toolchain + the Chromium binary Playwright drives.
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.tool-versions
+      - name: Install frontend deps + Chromium
+        working-directory: frontend
+        run: |
+          npm ci
+          npx playwright install chromium --with-deps
+
+      # Two workers → two isolated (backend, frontend, database) stacks in
+      # parallel. Track-only for now (not a required check) — promote via branch
+      # protection once it has proven stable, consistent with the coverage rollout.
+      - name: Run Playwright E2E
+        working-directory: frontend
+        env:
+          E2E_WORKERS: 2
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           version-type: strict
           version-file: backend/.tool-versions
+      # Hex deps + compiled build, keyed by toolchain and lockfile; the restore
+      # key lets a lockfile bump start from the previous build instead of cold.
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/deps
+            backend/_build
+          key: mix-e2e-${{ runner.os }}-${{ hashFiles('backend/.tool-versions', 'backend/mix.lock') }}
+          restore-keys: mix-e2e-${{ runner.os }}-
       - name: Compile backend (e2e)
         working-directory: backend
         env:
@@ -33,10 +42,18 @@ jobs:
           mix deps.get
           mix compile
 
-      # Frontend toolchain + the Chromium binary Playwright drives.
+      # Frontend toolchain (with the npm cache) + the Chromium binary Playwright
+      # drives — cached by lockfile, which pins the Playwright version; the
+      # install is a no-op when the binary is already present.
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/.tool-versions
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
       - name: Install frontend deps + Chromium
         working-directory: frontend
         run: |

--- a/.github/workflows/run-frontend-compiler.yml
+++ b/.github/workflows/run-frontend-compiler.yml
@@ -8,5 +8,10 @@ jobs:
         working-directory: "frontend"
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.tool-versions
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/run-frontend-formatter.yml
+++ b/.github/workflows/run-frontend-formatter.yml
@@ -8,5 +8,10 @@ jobs:
         working-directory: "frontend"
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.tool-versions
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
       - run: npm ci
       - run: npm run format:check

--- a/.github/workflows/run-frontend-linter.yml
+++ b/.github/workflows/run-frontend-linter.yml
@@ -8,5 +8,10 @@ jobs:
         working-directory: "frontend"
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.tool-versions
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -14,6 +14,17 @@ jobs:
         working-directory: "frontend"
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: frontend/.tool-versions
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      # The Chromium binary is cached by lockfile (which pins the Playwright
+      # version); the install below is a no-op download when already present.
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
       - run: npm ci
       # Storybook stories run as tests in a headless browser (@storybook/addon-vitest),
       # so the Playwright Chromium binary must be present.

--- a/backend/config/e2e.exs
+++ b/backend/config/e2e.exs
@@ -1,0 +1,42 @@
+import Config
+
+# E2E environment: a real HTTP server against a per-worker database, driven by the
+# Playwright suite (see frontend/e2e). Unlike :test it uses a normal connection
+# pool — committed writes must be visible across the separate HTTP requests a
+# browser makes — and isolates via POST /test/reset between tests rather than a
+# transactional rollback.
+#
+# Each Playwright worker boots its own backend with a distinct E2E_WORKER index,
+# giving it an isolated database and port (the DB-per-worker isolation model).
+worker = String.to_integer(System.get_env("E2E_WORKER", "0"))
+
+config :richard_burton,
+  phx_consumer_url: "http://localhost:#{3100 + worker}",
+  # The browser talks to the backend cross-origin with the rb-session cookie, so
+  # CORS must allow credentials (as in dev). The allowed origin itself comes from
+  # the PHX_CONSUMER_URL env var (Application.origin/0), set per worker at boot.
+  phx_cors_credentials: true,
+  google_client_id: nil,
+  google_openid_config_url: nil,
+  google_oauth2_certs_url: nil,
+  # No network calls: stub the JWKS provider (auth is exercised via dev sign-in)
+  # and capture emails in-process instead of opening an SMTP connection.
+  jwks_provider: RichardBurton.Auth.JWKS.Stub,
+  mailer_adapter: Swoosh.Adapters.Test
+
+config :richard_burton, RichardBurton.Repo,
+  username: "postgres",
+  password: "postgres",
+  hostname: "localhost",
+  database: "richard_burton_e2e#{worker}",
+  # A normal pool, NOT Ecto.Adapters.SQL.Sandbox: a browser's successive requests
+  # run on different connections and must see each other's committed writes.
+  pool_size: 10
+
+config :richard_burton, RichardBurtonWeb.Endpoint,
+  http: [ip: {127, 0, 0, 1}, port: 4100 + worker],
+  secret_key_base: "JVyOD7tvII62MK/o0JNJVbc7uHoYh4QfruGgKs9H/Y/NyurQ2lXCBF3sSNEctLFi",
+  server: true
+
+config :logger, level: :warning
+config :phoenix, :plug_init_mode, :runtime

--- a/backend/dev/richard_burton_web/controllers/e2e_reset_controller.ex
+++ b/backend/dev/richard_burton_web/controllers/e2e_reset_controller.ex
@@ -1,0 +1,33 @@
+defmodule RichardBurtonWeb.E2EResetController do
+  @moduledoc """
+  Resets the database between Playwright tests: truncates every table, restarts
+  identity sequences, and refreshes the search index. Mounted only in the :e2e
+  environment (see the router). Each worker owns its own database, so a reset
+  only clears that worker's data — this is what keeps parallel workers isolated.
+  """
+  use RichardBurtonWeb, :controller
+
+  alias RichardBurton.Repo
+
+  # Never truncate the migration ledger.
+  @preserved ["schema_migrations"]
+
+  def create(conn, _params) do
+    tables =
+      Repo.query!(
+        "SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename <> ALL($1)",
+        [@preserved]
+      ).rows
+      |> List.flatten()
+
+    quoted = Enum.map_join(tables, ", ", &~s("#{&1}"))
+    Repo.query!("TRUNCATE TABLE #{quoted} RESTART IDENTITY CASCADE")
+
+    # The materialized search views aren't cleared by TRUNCATE — rebuild them so a
+    # reset leaves an empty, consistent index.
+    Repo.query!("REFRESH MATERIALIZED VIEW search_documents")
+    Repo.query!("REFRESH MATERIALIZED VIEW search_keywords")
+
+    send_resp(conn, :no_content, "")
+  end
+end

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -144,9 +144,29 @@ defmodule RichardBurton.Publication do
   end
 
   def insert_all(attrs_list) do
-    Repo.transaction(fn ->
-      Enum.map(attrs_list, &insert_or_rollback/1)
-    end)
+    result =
+      Repo.transaction(fn ->
+        # Skip the per-statement search-index rebuild for the whole batch — the
+        # trigger would otherwise rebuild both materialized views for every
+        # inserted row. One rebuild below covers the entire transaction.
+        Repo.query!("SET LOCAL richard_burton.skip_search_refresh = 'on'")
+        Enum.map(attrs_list, &insert_or_rollback/1)
+      end)
+
+    case result do
+      {:ok, _publications} ->
+        refresh_search_index()
+        result
+
+      error ->
+        # Rolled back: nothing changed, so the index needs no refresh.
+        error
+    end
+  end
+
+  defp refresh_search_index do
+    Repo.query!("REFRESH MATERIALIZED VIEW search_documents")
+    Repo.query!("REFRESH MATERIALIZED VIEW search_keywords")
   end
 
   defp insert_or_rollback(attrs) do

--- a/backend/lib/richard_burton_web/router.ex
+++ b/backend/lib/richard_burton_web/router.ex
@@ -64,14 +64,10 @@ defmodule RichardBurtonWeb.Router do
     get("/publications", PublicationController, :export)
   end
 
-  # Enables LiveDashboard only for development
-  #
-  # If you want to use the LiveDashboard in production, you should put
-  # it behind authentication and allow only admins to access it.
-  # If your application does not have an admins-only section yet,
-  # you can use Plug.BasicAuth to set up some basic authentication
-  # as long as you are also using SSL (which you should anyway).
-  if Mix.env() in [:dev, :test] do
+  # Developer conveniences, never mounted in production: the LiveDashboard
+  # (if you ever want it in production, put it behind admin authentication)
+  # and the credentials provider that mints an admin session without Google.
+  if Mix.env() in [:dev, :test, :e2e] do
     import Phoenix.LiveDashboard.Router
 
     scope "/" do
@@ -80,11 +76,21 @@ defmodule RichardBurtonWeb.Router do
       live_dashboard("/dashboard", metrics: RichardBurtonWeb.Telemetry)
     end
 
-    # Dev/test-only credentials provider — mints an admin session without Google.
     scope "/api/dev", RichardBurtonWeb do
       pipe_through(:api)
 
       post("/session", DevSessionController, :create)
+    end
+  end
+
+  # Destructive test plumbing, mounted ONLY in the e2e environment: resets the
+  # worker's database between Playwright tests (truncates every table). Keeping
+  # it out of :dev means a misconfigured harness can never wipe real data.
+  if Mix.env() == :e2e do
+    scope "/test", RichardBurtonWeb do
+      pipe_through(:api)
+
+      post("/reset", E2EResetController, :create)
     end
   end
 end

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -39,6 +39,7 @@ defmodule RichardBurton.MixProject do
 
   defp elixirc_paths(:test), do: ["lib", "test/support", "dev"]
   defp elixirc_paths(:dev), do: ["lib", "dev"]
+  defp elixirc_paths(:e2e), do: ["lib", "dev"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Specifies your project dependencies.

--- a/backend/priv/repo/migrations/20260724010000_batch_search_index_refresh.exs
+++ b/backend/priv/repo/migrations/20260724010000_batch_search_index_refresh.exs
@@ -1,0 +1,45 @@
+defmodule RichardBurton.Repo.Migrations.BatchSearchIndexRefresh do
+  use Ecto.Migration
+
+  @moduledoc """
+  Let a transaction opt out of the per-statement search-index rebuild.
+
+  The refresh trigger fires on every INSERT/UPDATE to publications and their
+  associations, so a bulk insert of N publications rebuilds both materialized
+  views dozens of times inside one transaction — pathologically slow (each
+  rebuild is a full recompute, serialized on the same connection). With the
+  guard, `Publication.insert_all` sets `richard_burton.skip_search_refresh`
+  via SET LOCAL and rebuilds the views once after the batch commits.
+  """
+
+  def up do
+    execute("""
+    CREATE OR REPLACE FUNCTION refresh_search_index()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS
+    $$ BEGIN
+      IF current_setting('richard_burton.skip_search_refresh', true) = 'on' THEN
+        RETURN NULL;
+      END IF;
+      REFRESH MATERIALIZED VIEW search_documents;
+      REFRESH MATERIALIZED VIEW search_keywords;
+      RETURN NULL;
+    END $$;
+    """)
+  end
+
+  def down do
+    execute("""
+    CREATE OR REPLACE FUNCTION refresh_search_index()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS
+    $$ BEGIN
+      REFRESH MATERIALIZED VIEW search_documents;
+      REFRESH MATERIALIZED VIEW search_keywords;
+      RETURN NULL;
+    END $$;
+    """)
+  end
+end

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,4 @@
+/playwright-report/
+/test-results/
+/playwright/.cache/
+/.next-e2e-*/

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -1,0 +1,18 @@
+import { User } from "modules/users";
+import { redirect } from "next/navigation";
+import { ReactNode } from "react";
+import { getSession } from "../session";
+
+// Server-side guard for every /admin route: non-admin visitors are bounced back
+// to the public index before any admin UI renders. The backend independently
+// rejects unauthorized mutations — this keeps the pages themselves gated.
+export default async function AdminLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const session = await getSession();
+  if (!session || !User.isAdmin(session.role)) redirect("/");
+
+  return children;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,30 +1,8 @@
-import { SESSION_COOKIE } from "modules/api";
-import HTTP from "modules/http";
-import type { User } from "modules/users";
 import type { Metadata, Viewport } from "next";
-import { cookies } from "next/headers";
 import { ReactNode } from "react";
 import "styles/globals.css";
 import { Providers } from "./providers";
-
-const api = HTTP.client({ baseURL: process.env.NEXT_INTERNAL_API_URL });
-
-// Read the httpOnly rb-session cookie server-side and ask the backend who the
-// user is (GET /users/me → user or null). Fetched once here and provided
-// app-wide via the client SessionProvider — no client fetch/store/effect.
-async function getSession(): Promise<User | null> {
-  const cookie = (await cookies()).get(SESSION_COOKIE);
-  if (!cookie) return null;
-
-  try {
-    const { data } = await api.get<User | null>("/users/me", {
-      headers: { Cookie: `${cookie.name}=${cookie.value}` },
-    });
-    return data ?? null;
-  } catch {
-    return null;
-  }
-}
+import { getSession } from "./session";
 
 const APP_NAME = "Richard & Isabel Burton Platform";
 const IMAGE_ALT = `${APP_NAME}: A database about Brazilian literature in translation`;

--- a/frontend/app/session.ts
+++ b/frontend/app/session.ts
@@ -1,0 +1,23 @@
+import { SESSION_COOKIE } from "modules/api";
+import HTTP from "modules/http";
+import type { User } from "modules/users";
+import { cookies } from "next/headers";
+
+const api = HTTP.client({ baseURL: process.env.NEXT_INTERNAL_API_URL });
+
+// Read the httpOnly rb-session cookie server-side and ask the backend who the
+// user is (GET /users/me → user or null). Fetched in the root layout (provided
+// app-wide via SessionProvider) and re-checked by the admin layout guard.
+export async function getSession(): Promise<User | null> {
+  const cookie = (await cookies()).get(SESSION_COOKIE);
+  if (!cookie) return null;
+
+  try {
+    const { data } = await api.get<User | null>("/users/me", {
+      headers: { Cookie: `${cookie.name}=${cookie.value}` },
+    });
+    return data ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/components/DataInput.stories.tsx
+++ b/frontend/components/DataInput.stories.tsx
@@ -1,15 +1,37 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { seed } from "modules/publication/fixtures";
-import { expect, within } from "storybook/test";
+import { ComponentProps, FC, useState } from "react";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import DataInput from "./DataInput";
+
+// The dispatcher's `value` is a controlled prop (the app closes the loop via
+// usePublicationField): hold it in state so edits show on screen here too.
+const Controlled: FC<ComponentProps<typeof DataInput>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <DataInput
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 // The cell-editor dispatcher: picks the right Text*DataInput by the column's
 // attribute type and wires edits back into the publication store.
 const meta = {
   title: "Publications/Data input",
   component: DataInput,
-  args: { rowId: 1, colId: "title", value: "", error: "", onChange: () => {} },
+  args: { rowId: 1, colId: "title", value: "", error: "", onChange: fn() },
+  render: (args) => <Controlled {...args} />,
   decorators: [
     (Story) => (
       <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
@@ -24,14 +46,16 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-/** A text column renders a plain text cell. */
+/** A text column renders a plain, editable text cell. */
 export const Default: Story = {
   beforeEach: () => seed(),
   args: { colId: "title", value: "Dom Casmurro" },
   play: async ({ canvasElement }) => {
-    await expect(within(canvasElement).getByRole("textbox")).toHaveValue(
-      "Dom Casmurro",
-    );
+    const input = within(canvasElement).getByRole("textbox");
+    await expect(input).toHaveValue("Dom Casmurro");
+
+    await userEvent.type(input, "!");
+    await expect(input).toHaveValue("Dom Casmurro!");
   },
 };
 

--- a/frontend/components/MenuProvider.tsx
+++ b/frontend/components/MenuProvider.tsx
@@ -95,6 +95,7 @@ const MenuProvider = <OptionType extends Option | string>({
         {isOpen && (
           <FloatingFocusManager
             context={context}
+            modal={false}
             initialFocus={-1}
             visuallyHiddenDismiss
           >

--- a/frontend/components/ReferencesBackfill.mdx
+++ b/frontend/components/ReferencesBackfill.mdx
@@ -28,7 +28,9 @@ on the right. Reached from the admin panel at `/admin/publications/references`.
 ## States
 
 - **Populated** — the master-detail: the queue next to the editor, first
-  publication selected.
+  publication selected. Fully interactive: click through the queue, edit
+  references, and Skip / Save advance the position (persistence is the one
+  part stubbed out).
 - **Loading** — while the queue is being fetched.
 - **Empty** — nothing left to source ("All caught up").
 
@@ -39,9 +41,9 @@ on the right. Reached from the admin panel at `/admin/publications/references`.
 
 The queue is a single-select **listbox**: one tab stop, arrow / Home / End move
 the selection (via `aria-activedescendant`), and a click jumps straight to a
-publication. A dot marks whether each publication is already sourced, and the
-panel header counts the entries still missing references — decreasing live as
-sources are added.
+publication. A dot marks whether each publication has **saved** sources, and the
+panel header counts the entries still missing references — both react when a
+save lands, never to an unsaved draft.
 
 <Canvas of={ReferencesBackfillStories.Queue} />
 
@@ -50,6 +52,8 @@ sources are added.
 The detail pane shows the publication's context and progress. **Save & next** is
 disabled until a source is added — **Skip** moves past a publication you can't
 source. Edits write to the row's override overlay and are persisted by `update`
-on save.
+on save. On the last publication in the queue the button reads just **Save** —
+there is no next to advance to.
 
 <Canvas of={ReferencesBackfillStories.Step} />
+<Canvas of={ReferencesBackfillStories.LastStep} />

--- a/frontend/components/ReferencesBackfill.stories.tsx
+++ b/frontend/components/ReferencesBackfill.stories.tsx
@@ -1,6 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { RESET } from "jotai/utils";
 import { Publication } from "modules/publication/model";
-import { resetAll, setAll } from "modules/publication/store";
+import {
+  discardEdit,
+  overrideFamily,
+  publicationFamily,
+  resetAll,
+  setAll,
+  store,
+  visiblePublicationFamily,
+} from "modules/publication/store";
+import { ComponentProps, FC, useState } from "react";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import {
@@ -64,8 +74,57 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+/** Mimic a successful save without a server: promote the draft (base ⊕
+ * override) to the stored publication and clear the edit — exactly the state
+ * `update()` leaves behind. Dots and the count react to *stored* references,
+ * so they only change here, never while typing. */
+const persistDraft = (id: number) => {
+  store.set(publicationFamily(id), store.get(visiblePublicationFamily(id)));
+  store.set(overrideFamily(id), RESET);
+};
+
+/**
+ * Recreates the orchestrator's local state around the presentational view, so
+ * the story is fully interactive: clicking the queue moves the selection, Skip
+ * discards the draft and advances, Save "persists" locally and advances.
+ */
+const InteractiveView: FC<ComponentProps<typeof ReferencesBackfillView>> = ({
+  ids = [1, 2, 3],
+  onSelect,
+  onSave,
+  onSkip,
+}) => {
+  const [position, setPosition] = useState(0);
+  const advance = () =>
+    setPosition((p) => Math.min(p + 1, (ids?.length ?? 1) - 1));
+  const currentId = ids?.[position];
+
+  return (
+    <ReferencesBackfillView
+      ids={ids}
+      position={position}
+      saving={false}
+      onSelect={(p) => {
+        onSelect(p);
+        setPosition(p);
+      }}
+      onSave={() => {
+        if (currentId !== undefined) persistDraft(currentId);
+        onSave();
+        advance();
+      }}
+      onSkip={() => {
+        if (currentId !== undefined) discardEdit(currentId);
+        onSkip();
+        advance();
+      }}
+    />
+  );
+};
+
 /** The whole master-detail: the queue listbox next to the editor. */
 export const Populated: Story = {
+  render: (args) => <InteractiveView {...args} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByRole("listbox")).toBeInTheDocument();
@@ -78,12 +137,35 @@ export const Populated: Story = {
     await expect(
       canvas.getByRole("option", { name: "Dom Casmurro" }),
     ).toHaveAttribute("aria-selected", "true");
-    // Sourcing the selected publication drops the count live.
+    // Drafting a reference does NOT mark the publication sourced — the dot and
+    // the count only react to saved references.
     await userEvent.click(
       canvas.getByRole("button", { name: "Add reference" }),
     );
     await userEvent.type(canvas.getByLabelText("Reference 1"), "A citation");
+    await expect(within(header).getByText("2")).toBeInTheDocument();
+    await expect(
+      canvas.getByRole("option", { name: "Dom Casmurro" }),
+    ).toBeInTheDocument();
+
+    // Saving persists the draft: the dot flips, the count drops, and the
+    // wizard advances.
+    await userEvent.click(canvas.getByRole("button", { name: "Save & next" }));
+    await expect(
+      canvas.getByRole("option", { name: "Dom Casmurro — sourced" }),
+    ).toBeInTheDocument();
     await expect(within(header).getByText("1")).toBeInTheDocument();
+    await expect(canvas.getByText("2 / 3")).toBeInTheDocument();
+
+    // The story is interactive: clicking a queue item moves the selection and
+    // the detail pane follows.
+    await userEvent.click(
+      canvas.getByRole("option", { name: "The Devil to Pay" }),
+    );
+    await expect(
+      canvas.getByRole("option", { name: "The Devil to Pay" }),
+    ).toHaveAttribute("aria-selected", "true");
+    await expect(canvas.getByText("3 / 3")).toBeInTheDocument();
   },
 };
 
@@ -138,6 +220,25 @@ export const Queue: Story = {
 
     await userEvent.keyboard("{Home}");
     await expect(args.onSelect).toHaveBeenCalledWith(0);
+  },
+};
+
+/** On the final publication there is no "next" — the action is just Save. */
+export const LastStep: Story = {
+  render: (args) => (
+    <BackfillStep
+      id={1}
+      position={11}
+      total={12}
+      saving={false}
+      onSave={args.onSave}
+      onSkip={args.onSkip}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("12 / 12")).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "Save" })).toBeVisible();
   },
 };
 

--- a/frontend/components/ReferencesBackfill.tsx
+++ b/frontend/components/ReferencesBackfill.tsx
@@ -5,6 +5,7 @@ import ReferencesEditor from "components/ReferencesEditor";
 import {
   usePublication,
   usePublicationReferences,
+  useStoredPublicationReferences,
   useUnreferencedPublicationCount,
 } from "modules/publication/hooks";
 import type { PublicationId } from "modules/publication/model";
@@ -26,7 +27,9 @@ const QueueOption: FC<{
   onSelect: () => void;
 }> = ({ id, active, onSelect }) => {
   const publication = usePublication(id);
-  const sourced = usePublicationReferences(id).length > 0;
+  // Persisted sources only: a drafted reference must not turn the dot green (or
+  // decrement the count) until it is actually saved.
+  const sourced = useStoredPublicationReferences(id).length > 0;
   const ref = useRef<HTMLLIElement>(null);
 
   // Keep the selected option in view as arrow keys move through a long queue.
@@ -163,7 +166,9 @@ export const BackfillStep: FC<{
           onClick={onSkip}
         />
         <Button
-          label="Save & next"
+          // The last publication has no "next" to advance to — the action is
+          // just Save (position clamps, so the wizard stays put either way).
+          label={position === total - 1 ? "Save" : "Save & next"}
           width="fit"
           size="medium"
           loading={saving}

--- a/frontend/components/Select.stories.tsx
+++ b/frontend/components/Select.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps, FC, useState } from "react";
 import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 
 import Select from "./Select";
@@ -8,6 +9,26 @@ const OPTIONS = [
   { id: "2", label: "Portugal" },
   { id: "3", label: "Angola" },
 ];
+
+// The selected `value` is controlled (the dropdown/search state is internal):
+// hold it in state so a picked option sticks instead of the input going blank.
+const Controlled: FC<ComponentProps<typeof Select>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <Select
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 const meta = {
   title: "Components/Select",
@@ -22,6 +43,7 @@ const meta = {
     ),
     "aria-label": "Country",
   },
+  render: (args) => <Controlled {...args} />,
   parameters: { layout: "centered" },
 } satisfies Meta<typeof Select>;
 
@@ -123,5 +145,12 @@ export const SelectsHighlightedOption: Story = {
       id: "2",
       label: "Portugal",
     });
+    // Regression guard (combobox pattern): the pick sticks in the input, the
+    // menu stays closed, and focus remains in the input. Blurring on Enter used
+    // to bounce focus through the menu's focus-return, re-firing handleFocus and
+    // reopening an emptied menu over the fresh selection.
+    await waitFor(() => expect(input).toHaveValue("Portugal"));
+    await expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    await expect(input).toHaveFocus();
   },
 };

--- a/frontend/components/Select.tsx
+++ b/frontend/components/Select.tsx
@@ -78,7 +78,9 @@ export default forwardRef<HTMLInputElement, Props>(function Select(
     ) {
       handleSelect(options[activeIndex]);
       setIsOpen(false);
-      inputRef.current?.blur();
+      // Keep focus in the input (combobox pattern). Blurring here bounced focus
+      // through the menu's focus manager, whose focus-return re-triggered
+      // handleFocus and reopened an emptied menu over the fresh selection.
     }
 
     onKeyDown?.(event);

--- a/frontend/components/TextArea.stories.tsx
+++ b/frontend/components/TextArea.stories.tsx
@@ -1,13 +1,34 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps, FC, useState } from "react";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import TextArea from "./TextArea";
+
+// TextArea is controlled: hold `value` in state so typing shows on screen.
+const Controlled: FC<ComponentProps<typeof TextArea>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <TextArea
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 const meta = {
   title: "Components/Text area",
   component: TextArea,
   tags: ["autodocs"],
   args: { value: "", onChange: fn(), "aria-label": "Description" },
+  render: (args) => <Controlled {...args} />,
   // The textarea is borderless + `bg-transparent` (it sits on a colored surface
   // in the app). Show it inside a dashed auxiliary container so the demo area is
   // clear without the frame masquerading as the textarea's own chrome.
@@ -25,13 +46,14 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-/** Empty multi-line field. Typing emits the raw string value via `onChange`. */
+/** Empty multi-line field. Typing updates the value and emits it via `onChange`. */
 export const Default: Story = {
   play: async ({ args, canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox");
     await expect(input).toBeInTheDocument();
 
     await userEvent.type(input, "Notes");
+    await expect(input).toHaveValue("Notes");
     await expect(args.onChange).toHaveBeenCalled();
   },
 };

--- a/frontend/components/TextArrayDataInput.stories.tsx
+++ b/frontend/components/TextArrayDataInput.stories.tsx
@@ -1,12 +1,33 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn, within } from "storybook/test";
+import { ComponentProps, FC, useState } from "react";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import TextArrayDataInput from "./TextArrayDataInput";
 
+// The comma-separated `value` is controlled: hold it in state so pill
+// add/remove sticks on screen.
+const Controlled: FC<ComponentProps<typeof TextArrayDataInput>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <TextArrayDataInput
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
+
 // A Multicombobox for free-text list cells (authors, originalAuthors,
 // publishers). The comma-separated `value` renders as removable pills. Its
-// autocomplete calls the network on keystroke, so these stories stay
-// render-only — they never type into the field.
+// autocomplete calls the network on keystroke, so these stories never type
+// into the field — but pill removal is purely local and live.
 const meta = {
   title: "Publications/Text array data input",
   component: TextArrayDataInput,
@@ -18,6 +39,7 @@ const meta = {
     onChange: fn(),
     "aria-label": "Authors",
   },
+  render: (args) => <Controlled {...args} />,
   decorators: [
     (Story) => (
       <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
@@ -41,13 +63,20 @@ export const Default: Story = {
   },
 };
 
-/** A populated cell renders one removable pill per comma-separated value. */
+/** A populated cell renders one removable pill per comma-separated value —
+ * and removing one takes it off the screen. */
 export const WithValues: Story = {
   args: { value: "Helen Caldwell,Benjamin Moser" },
-  play: async ({ canvasElement }) => {
+  play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText("Helen Caldwell")).toBeInTheDocument();
     await expect(canvas.getByText("Benjamin Moser")).toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Remove Helen Caldwell" }),
+    );
+    await expect(canvas.queryByText("Helen Caldwell")).not.toBeInTheDocument();
+    await expect(args.onChange).toHaveBeenCalledWith("Benjamin Moser");
   },
 };
 

--- a/frontend/components/TextDataInput.stories.tsx
+++ b/frontend/components/TextDataInput.stories.tsx
@@ -1,7 +1,27 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps, FC, useState } from "react";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import TextDataInput from "./TextDataInput";
+
+// The cell is controlled: hold `value` in state so typing shows on screen.
+const Controlled: FC<ComponentProps<typeof TextDataInput>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <TextDataInput
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 // A thin pass-through to TextInput used for plain-text cells (title,
 // originalTitle). It takes value/error/onChange directly, so the store isn't
@@ -17,6 +37,7 @@ const meta = {
     onChange: fn(),
     "aria-label": "Title",
   },
+  render: (args) => <Controlled {...args} />,
   decorators: [
     (Story) => (
       <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
@@ -31,13 +52,14 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-/** Empty text cell — typing emits the raw string via `onChange`. */
+/** Empty text cell — typing updates the value and emits it via `onChange`. */
 export const Default: Story = {
   play: async ({ args, canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox");
     await expect(input).toBeInTheDocument();
 
     await userEvent.type(input, "x");
+    await expect(input).toHaveValue("x");
     await expect(args.onChange).toHaveBeenCalledWith("x");
   },
 };

--- a/frontend/components/TextEnumArrayDataInput.stories.tsx
+++ b/frontend/components/TextEnumArrayDataInput.stories.tsx
@@ -1,12 +1,33 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn, within } from "storybook/test";
+import { ComponentProps, FC, useState } from "react";
+import { expect, fn, userEvent, within } from "storybook/test";
 
 import TextEnumArrayDataInput from "./TextEnumArrayDataInput";
+
+// The comma-separated codes are controlled: hold them in state so pill
+// add/remove sticks on screen.
+const Controlled: FC<ComponentProps<typeof TextEnumArrayDataInput>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <TextEnumArrayDataInput
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 // A Multicombobox for the `countries` cell. The comma-separated `value` holds
 // ISO country codes; each renders as a pill labelled by its country name (via
 // Publication.describeValue). Country autocomplete resolves locally, but these
-// stories stay render-only to avoid depending on the dropdown.
+// stories avoid depending on the dropdown — pill removal is local and live.
 const meta = {
   title: "Publications/Text enum array data input",
   component: TextEnumArrayDataInput,
@@ -18,6 +39,7 @@ const meta = {
     onChange: fn(),
     "aria-label": "Countries",
   },
+  render: (args) => <Controlled {...args} />,
   decorators: [
     (Story) => (
       <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
@@ -41,13 +63,23 @@ export const Default: Story = {
   },
 };
 
-/** A selected country code renders as a pill labelled by its country name. */
+/** A selected country code renders as a pill labelled by its country name —
+ * and removing it takes it off the screen. */
 export const WithValues: Story = {
   args: { value: "US" },
-  play: async ({ canvasElement }) => {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
     await expect(
-      within(canvasElement).getByText("United States of America"),
+      canvas.getByText("United States of America"),
     ).toBeInTheDocument();
+
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Remove United States of America" }),
+    );
+    await expect(
+      canvas.queryByText("United States of America"),
+    ).not.toBeInTheDocument();
+    await expect(args.onChange).toHaveBeenCalledWith("");
   },
 };
 

--- a/frontend/components/TextEnumDataInput.stories.tsx
+++ b/frontend/components/TextEnumDataInput.stories.tsx
@@ -1,7 +1,28 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, fn, within } from "storybook/test";
+import { ComponentProps, FC, useState } from "react";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 
 import TextEnumDataInput from "./TextEnumDataInput";
+
+// The selected code is a controlled prop: hold it in state so a picked country
+// sticks in the input instead of vanishing when the menu closes.
+const Controlled: FC<ComponentProps<typeof TextEnumDataInput>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <TextEnumDataInput
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 // A single-select Select backed by autocomplete. Driven here with `countries`,
 // whose options resolve locally (no network). `value` is one country code and
@@ -17,6 +38,7 @@ const meta = {
     onChange: fn(),
     "aria-label": "Country",
   },
+  render: (args) => <Controlled {...args} />,
   decorators: [
     (Story) => (
       <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
@@ -47,6 +69,29 @@ export const WithValue: Story = {
     await expect(within(canvasElement).getByRole("combobox")).toHaveValue(
       "United States of America",
     );
+  },
+};
+
+/** Typing filters the local country options; Enter commits the highlighted one
+ * and its name sticks in the input. */
+export const SelectsOption: Story = {
+  // Floating-ui's focus guards (tabindex=0 + aria-hidden) are a deliberate
+  // pattern that axe's aria-hidden-focus rule over-reports on open menus.
+  parameters: {
+    a11y: { config: { rules: [{ id: "aria-hidden-focus", enabled: false }] } },
+  },
+  play: async ({ args, canvasElement }) => {
+    const input = within(canvasElement).getByRole("combobox");
+    await userEvent.type(input, "braz");
+
+    await waitFor(() =>
+      expect(screen.getByRole("option", { name: "Brazil" })).toBeInTheDocument(),
+    );
+    await userEvent.keyboard("{Enter}");
+
+    await expect(args.onChange).toHaveBeenCalledWith("BR");
+    // The search reset cascades over a couple of renders after the menu closes.
+    await waitFor(() => expect(input).toHaveValue("Brazil"));
   },
 };
 

--- a/frontend/components/TextEnumDataInput.stories.tsx
+++ b/frontend/components/TextEnumDataInput.stories.tsx
@@ -85,7 +85,9 @@ export const SelectsOption: Story = {
     await userEvent.type(input, "braz");
 
     await waitFor(() =>
-      expect(screen.getByRole("option", { name: "Brazil" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("option", { name: "Brazil" }),
+      ).toBeInTheDocument(),
     );
     await userEvent.keyboard("{Enter}");
 

--- a/frontend/components/TextInput.stories.tsx
+++ b/frontend/components/TextInput.stories.tsx
@@ -1,9 +1,30 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { colord, extend } from "colord";
 import a11yPlugin from "colord/plugins/a11y";
+import { ComponentProps, FC, useState } from "react";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import TextInput from "./TextInput";
+
+// TextInput is controlled: hold `value` in state so typing shows on screen —
+// otherwise onChange fires but the field never moves.
+const Controlled: FC<ComponentProps<typeof TextInput>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <TextInput
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 extend([a11yPlugin]);
 
@@ -50,6 +71,7 @@ const meta = {
   component: TextInput,
   tags: ["autodocs"],
   args: { value: "", onChange: fn(), "aria-label": "Title" },
+  render: (args) => <Controlled {...args} />,
   // The input is borderless + `bg-transparent` (it sits on a colored surface in
   // the app). Show it inside a dashed auxiliary container so the demo area is
   // clear without the frame masquerading as the input's own chrome.
@@ -67,14 +89,14 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-/** Empty text field. Typing emits the raw string value via `onChange`. */
+/** Empty text field. Typing updates the value and emits it via `onChange`. */
 export const Default: Story = {
   play: async ({ args, canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox");
     await expect(input).toBeInTheDocument();
 
-    // Controlled input (value is forced), so onChange fires per keystroke.
     await userEvent.type(input, "Dom Casmurro");
+    await expect(input).toHaveValue("Dom Casmurro");
     await expect(args.onChange).toHaveBeenCalled();
   },
 };

--- a/frontend/components/TextNumberDataInput.stories.tsx
+++ b/frontend/components/TextNumberDataInput.stories.tsx
@@ -1,7 +1,28 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { ComponentProps, FC, useState } from "react";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import TextNumberDataInput from "./TextNumberDataInput";
+
+// The cell is controlled: hold the stored string in state so typing and the
+// ▲/▼ buttons visibly move the value (its base NumberInput.stories does the same).
+const Controlled: FC<ComponentProps<typeof TextNumberDataInput>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+  return (
+    <TextNumberDataInput
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
 
 // Wraps NumberInput for the `year` cell. `value` is the stored string; typing a
 // digit parses it and `onChange` re-emits it as a string. Props are passed
@@ -17,6 +38,7 @@ const meta = {
     onChange: fn(),
     "aria-label": "Year",
   },
+  render: (args) => <Controlled {...args} />,
   decorators: [
     (Story) => (
       <div className="flex items-center justify-center w-72 aspect-square overflow-auto rounded-lg border border-dashed border-gray-300 p-8 bg-stripes-diagonal">
@@ -31,13 +53,14 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-/** Empty numeric cell — typing a digit emits the parsed value as a string. */
+/** Empty numeric cell — typing a digit shows it and emits it as a string. */
 export const Default: Story = {
   play: async ({ args, canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox");
     await expect(input).toBeInTheDocument();
 
     await userEvent.type(input, "7");
+    await expect(input).toHaveValue("7");
     await expect(args.onChange).toHaveBeenCalledWith("7");
   },
 };

--- a/frontend/e2e/admin-bulk-create.spec.ts
+++ b/frontend/e2e/admin-bulk-create.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from "./fixtures";
+import {
+  signInAsAdmin,
+  addPublicationRow,
+  addRowReferences,
+  submitWorkspace,
+  openPublicationModal,
+  indexTable,
+  expectPublicationCount,
+  expectPublicationRow,
+  PUBLICATIONS,
+} from "./helpers";
+
+const [, REFERENCED, DUPLICATED] = PUBLICATIONS;
+
+const REFERENCES = [
+  "Caldwell, Helen. The Brazilian Othello of Machado de Assis, 1960.",
+  "https://archive.org/details/domcasmurro0000mach",
+];
+
+test("an admin bulk-inserts publications with references from the workspace", async ({
+  page,
+}) => {
+  await signInAsAdmin(page);
+  await page.goto("/admin/publications/new");
+  const table = indexTable(page);
+
+  // Build up three publications in the grid before submitting anything.
+  for (const publication of PUBLICATIONS) {
+    await addPublicationRow(page, publication);
+  }
+
+  // Attach two sources to the second row through its "Sources" cell.
+  await addRowReferences(page, REFERENCED.title, REFERENCES);
+
+  // Selection tools: select the third row (via its signal cell — the row's cells
+  // are inputs), duplicate it, then delete the copy again.
+  const duplicatedRows = table.getByRole("row", { name: DUPLICATED.title });
+  await duplicatedRows.getByRole("cell").first().click();
+  await expect(page.getByRole("button", { name: "Deselect 1" })).toBeVisible();
+  await page.getByRole("button", { name: "Duplicate 1" }).click();
+  await expect(duplicatedRows).toHaveCount(2);
+
+  await duplicatedRows.nth(1).getByRole("cell").first().click();
+  await page.getByRole("button", { name: "Delete 1" }).click();
+  await expect(duplicatedRows).toHaveCount(1);
+  await expect(
+    page.getByRole("button", { name: "Reset 1 deleted" }),
+  ).toBeVisible();
+
+  // One submit persists the whole batch.
+  await submitWorkspace(page, PUBLICATIONS.length);
+
+  // All three are in the index with their full content — every field of every
+  // row round-tripped through the bulk insert — and the references rode along.
+  await page.goto("/");
+  await expectPublicationCount(page, PUBLICATIONS.length);
+  for (const publication of PUBLICATIONS) {
+    await expectPublicationRow(page, publication);
+  }
+  const dialog = await openPublicationModal(page, REFERENCED.title);
+  for (const reference of REFERENCES) {
+    await expect(dialog.getByText(reference)).toBeVisible();
+  }
+  await page.keyboard.press("Escape");
+
+  // The backfill wizard agrees: only the two unreferenced publications queue up.
+  await page.goto("/admin/publications/references");
+  const queue = page.getByRole("listbox", {
+    name: "Publications missing references",
+  });
+  await expect(queue.getByRole("option")).toHaveCount(PUBLICATIONS.length - 1);
+  await expect(
+    queue.getByRole("option", { name: REFERENCED.title }),
+  ).toHaveCount(0);
+});

--- a/frontend/e2e/admin-edit.spec.ts
+++ b/frontend/e2e/admin-edit.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from "./fixtures";
+import {
+  seedCorpus,
+  openPublicationModal,
+  indexTable,
+  addPublicationRow,
+  submitWorkspace,
+} from "./helpers";
+
+test("an admin edits a publication's title and references in a corpus", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/");
+
+  // Open one publication's detail modal and switch to the (admin-only) edit form.
+  const dialog = await openPublicationModal(page, "The Hour of the Star");
+  await dialog.getByRole("button", { name: "Edit" }).click();
+  await expect(
+    dialog.getByRole("heading", { name: "Edit publication" }),
+  ).toBeVisible();
+
+  // Change the title (validation runs on blur).
+  const title = dialog.getByRole("textbox", { name: "Title", exact: true });
+  await title.fill("The Hour of the Star (revised)");
+  await title.blur();
+
+  // The corpus reference is already listed; add a second source alongside it.
+  await expect(
+    dialog.getByRole("textbox", { name: "Reference 1" }),
+  ).toHaveValue("Pontiero, Giovanni. Afterword.");
+  await dialog.getByRole("button", { name: "Add reference" }).click();
+  await dialog
+    .getByRole("textbox", { name: "Reference 2" })
+    .fill("Moser, Benjamin. Why This World, 2009.");
+
+  const save = dialog.getByRole("button", { name: "Save" });
+  await expect(save).toBeEnabled();
+  await save.click();
+
+  // Success toast, and the modal drops back to the read view with both sources.
+  await expect(page.getByText("Publication updated.")).toBeVisible();
+  await expect(
+    dialog.getByRole("heading", { name: "Edit publication" }),
+  ).toHaveCount(0);
+  await expect(
+    dialog.getByText("Pontiero, Giovanni. Afterword."),
+  ).toBeVisible();
+  await expect(
+    dialog.getByText("Moser, Benjamin. Why This World, 2009."),
+  ).toBeVisible();
+
+  // Only that row changed; its siblings are untouched.
+  await page.keyboard.press("Escape");
+  const table = indexTable(page);
+  await expect(table.getByText("The Hour of the Star (revised)")).toBeVisible();
+  await expect(
+    table.getByText("The Hour of the Star", { exact: true }),
+  ).toHaveCount(0);
+  await expect(table.getByText("Barren Lives")).toBeVisible();
+});
+
+test("editing a publication into a copy of another is rejected as a conflict", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+
+  // A sibling that matches "Dom Casmurro" in everything but the title, so a
+  // single title edit is all it takes to collide.
+  await page.goto("/admin/publications/new");
+  await addPublicationRow(page, {
+    title: "Dom Casmurro (copy)",
+    originalTitle: "Dom Casmurro",
+    year: "1953",
+    authors: "Helen Caldwell",
+    originalAuthors: "Machado de Assis",
+    country: "United States",
+    publisher: "Noonday Press",
+  });
+  await submitWorkspace(page, 1);
+
+  await page.goto("/");
+  const dialog = await openPublicationModal(page, "Dom Casmurro (copy)");
+  await dialog.getByRole("button", { name: "Edit" }).click();
+
+  const title = dialog.getByRole("textbox", { name: "Title", exact: true });
+  await title.fill("Dom Casmurro");
+  await title.blur();
+
+  // The blur validation flags the collision with the stored publication and
+  // keeps Save disabled — the edit cannot be committed.
+  await expect(
+    dialog.getByText("A publication with this data already exists"),
+  ).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Save" })).toBeDisabled();
+});

--- a/frontend/e2e/admin-validation.spec.ts
+++ b/frontend/e2e/admin-validation.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect } from "./fixtures";
+import {
+  signInAsAdmin,
+  seedCorpus,
+  addPublicationRow,
+  submitWorkspace,
+  indexTable,
+  type PublicationInput,
+} from "./helpers";
+
+const VALID: PublicationInput = {
+  title: "The Posthumous Memoirs (E2E)",
+  originalTitle: "Memórias Póstumas de Brás Cubas",
+  year: "1997",
+  authors: "Gregory Rabassa",
+  originalAuthors: "Machado de Assis",
+  country: "Brazil",
+  publisher: "Oxford University Press",
+};
+
+// Missing its publisher — the server-side validation flags `required`.
+const INCOMPLETE = { ...VALID, title: "Incomplete (E2E)" };
+
+// An exact copy of a corpus row — the server-side validation flags `conflict`.
+const DUPLICATE: PublicationInput = {
+  title: "Dom Casmurro",
+  originalTitle: "Dom Casmurro",
+  year: "1953",
+  authors: "Helen Caldwell",
+  originalAuthors: "Machado de Assis",
+  country: "United States",
+  publisher: "Noonday Press",
+};
+
+test("an invalid row blocks submission until it is fixed", async ({ page }) => {
+  await signInAsAdmin(page);
+  await page.goto("/admin/publications/new");
+  const table = indexTable(page);
+
+  // Commit a row without its publisher: it validates as invalid, the error
+  // counter appears, and Submit stays disabled.
+  await addPublicationRow(page, { ...INCOMPLETE, publisher: "" });
+  await expect(page.getByLabel("1 invalid publications")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+  // Filling the missing field revalidates the row and unblocks the submit.
+  const row = table.getByRole("row", { name: /Incomplete \(E2E\)/ });
+  const input = row.getByPlaceholder("Publishers", { exact: true });
+  await input.click();
+  await input.pressSequentially("Oxford University Press");
+  await input.press("Enter");
+  await page.keyboard.press("Tab");
+
+  await expect(page.getByLabel("All publications are valid")).toBeVisible();
+  await submitWorkspace(page, 1);
+});
+
+test("a duplicate of an existing publication is flagged as a conflict", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/admin/publications/new");
+  const table = indexTable(page);
+
+  // One genuinely new publication, then an exact duplicate of a stored one (last,
+  // so its error tooltip doesn't hover over the draft row while it's being filled).
+  await addPublicationRow(page, VALID);
+  await addPublicationRow(page, DUPLICATE);
+
+  // The duplicate is flagged against the database before anything is submitted.
+  await expect(page.getByLabel("1 invalid publications")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+  // Drop the conflicting row. Row-selection clicks must land on the signal cell
+  // (field cells swallow them), and off its center — the centered error icon
+  // opens a hover tooltip that would swallow the click instead.
+  const duplicate = table.getByRole("row", { name: /Dom Casmurro/ });
+  await duplicate
+    .getByRole("cell")
+    .first()
+    .click({ position: { x: 4, y: 4 } });
+  await page.getByRole("button", { name: "Delete 1" }).click();
+
+  await expect(page.getByLabel("All publications are valid")).toBeVisible();
+  await submitWorkspace(page, 1);
+});

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "./fixtures";
+import { signInAsAdmin, signOut } from "./helpers";
+
+test("signed out, the footer offers Google sign-in and hides admin controls", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(
+    page.getByRole("button", { name: "Sign in with Google" }),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Admin" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Sign out" })).toHaveCount(0);
+});
+
+test("an admin signs in and out, and the footer controls follow", async ({
+  page,
+}) => {
+  await signInAsAdmin(page);
+
+  // Authenticated: admin + export controls appear.
+  await expect(page.getByRole("button", { name: "Admin" })).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Download .csv" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Sign in with Google" }),
+  ).toHaveCount(0);
+
+  await signOut(page);
+
+  // Back to the signed-out footer.
+  await expect(page.getByRole("button", { name: "Admin" })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Sign out" })).toHaveCount(0);
+});

--- a/frontend/e2e/csv.spec.ts
+++ b/frontend/e2e/csv.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from "./fixtures";
+import { seedCorpus, signInAsAdmin, indexTable } from "./helpers";
+
+test("an admin exports the corpus as a CSV, references included", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/");
+  // The button disables while the count is 0 — wait for the index to load.
+  await expect(indexTable(page).getByText("Barren Lives")).toBeVisible();
+
+  // Clicking Download drives the admin-only CSV export endpoint.
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (r) =>
+        r.url().includes("files/publications") &&
+        r.request().method() === "GET",
+    ),
+    page.getByRole("button", { name: "Download .csv" }).click(),
+  ]);
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toMatch(/csv/);
+
+  // The file carries the whole corpus, provenance included.
+  const csv = await response.text();
+  expect(csv).toContain("Gabriela, Clove and Cinnamon");
+  expect(csv).toContain("Burton, Isabel. Preface, 1886.");
+});
+
+// One row, 8 semicolon-separated columns in codec order:
+// original_authors; year; countries; original_title; title; authors; publishers; references
+const CSV_ROW =
+  "Machado de Assis;1899;BR;Dom Casmurro;Dom Casmurro (CSV);Helen Caldwell;Noonday Press;A source\n";
+
+test("an admin imports publications from a CSV, references included", async ({
+  page,
+}) => {
+  await signInAsAdmin(page);
+  await page.goto("/admin/publications/new");
+
+  await page.locator("#upload-csv").setInputFiles({
+    name: "import.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(CSV_ROW),
+  });
+
+  // The imported row populates the workspace grid — its fields are editable
+  // inputs, so match the row by accessible name — and the references column
+  // landed in the row's "Sources" cell.
+  const row = indexTable(page).getByRole("row", {
+    name: /Dom Casmurro \(CSV\)/,
+  });
+  await expect(row).toBeVisible();
+  await expect(
+    row.getByRole("button", { name: "Edit references (1)" }),
+  ).toBeVisible();
+});
+
+test("a malformed CSV is rejected with an error and imports nothing", async ({
+  page,
+}) => {
+  await signInAsAdmin(page);
+  await page.goto("/admin/publications/new");
+
+  // An unterminated quoted field — the csv parser rejects the whole file.
+  await page.locator("#upload-csv").setInputFiles({
+    name: "broken.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from('Machado de Assis;1899;BR;Dom;"unterminated\n'),
+  });
+
+  await expect(
+    page.getByText("Could not parse publications from the provided file"),
+  ).toBeVisible();
+  // Nothing was imported — the grid still holds only its header and draft row.
+  await expect(indexTable(page).getByRole("row")).toHaveCount(2);
+});

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,0 +1,33 @@
+import { test as base, expect } from "@playwright/test";
+
+const backendPort = (i: number) => 4100 + i;
+const frontendPort = (i: number) => 3100 + i;
+
+/** The backend base URL for the current worker (own database + port). */
+export const backendUrl = (parallelIndex: number) =>
+  `http://localhost:${backendPort(parallelIndex)}`;
+
+// Each test runs against its worker's stack, and that worker's database is reset
+// before every test — the DB-per-worker isolation contract.
+export const test = base.extend<{ reset: void }>({
+  // Point navigation at this worker's frontend.
+  baseURL: async ({}, use, testInfo) => {
+    await use(`http://localhost:${frontendPort(testInfo.parallelIndex)}`);
+  },
+
+  // Auto-run before every test: truncate + reseed this worker's database.
+  reset: [
+    async ({ request }, use, testInfo) => {
+      const res = await request.post(
+        `${backendUrl(testInfo.parallelIndex)}/test/reset`,
+      );
+      if (res.status() !== 204) {
+        throw new Error(`/test/reset returned ${res.status()}`);
+      }
+      await use();
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/frontend/e2e/global-setup.ts
+++ b/frontend/e2e/global-setup.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from "node:child_process";
+
+// Ensure each worker's e2e database exists and is migrated before Playwright boots
+// the stacks. Idempotent: ecto.create is tolerated if the database already exists.
+export default function globalSetup() {
+  const workers = Number(process.env.E2E_WORKERS ?? "1");
+  const asdf = `${process.env.HOME}/.asdf/shims`;
+
+  for (let i = 0; i < workers; i++) {
+    const env = {
+      ...process.env,
+      MIX_ENV: "e2e",
+      E2E_WORKER: String(i),
+      PATH: `${asdf}:${process.env.PATH}`,
+    };
+    const opts = { cwd: "../backend", env } as const;
+
+    try {
+      execFileSync("mix", ["ecto.create", "--quiet"], {
+        ...opts,
+        stdio: "pipe",
+      });
+    } catch {
+      // Already exists — fine.
+    }
+    execFileSync("mix", ["ecto.migrate", "--quiet"], {
+      ...opts,
+      stdio: "inherit",
+    });
+  }
+}

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,248 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+/** Sign in as admin via the dev-only credentials provider (no Google). */
+export async function signInAsAdmin(page: Page) {
+  await page.goto("/auth/sign-in");
+  await page.getByRole("button", { name: "Dev admin sign-in" }).click();
+  // The route handler redirects to "/"; the footer then shows authed controls.
+  await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible();
+}
+
+export type PublicationInput = {
+  title: string;
+  originalTitle: string;
+  year: string;
+  authors: string;
+  originalAuthors: string;
+  country: string;
+  publisher: string;
+};
+
+/** Commit free text into a multiselect. Comma (not Enter) makes it a pill:
+ * comma always commits the raw typed text, while Enter prefers the highlighted
+ * autocomplete option — whose debounced fetch can race the keystrokes and
+ * commit a stale suggestion from a previous fill. */
+async function commitMulti(scope: Locator, placeholder: string, value: string) {
+  const input = scope.getByPlaceholder(placeholder, { exact: true });
+  await input.click();
+  await input.pressSequentially(value);
+  await input.press(",");
+}
+
+/**
+ * Pick an option from an enum multiselect (e.g. Countries). Enum fields have no
+ * raw-text commit — the stored value is the option object — so let the async
+ * autocomplete settle (it highlights the match) before Enter commits it.
+ */
+async function selectEnumOption(
+  scope: Locator,
+  placeholder: string,
+  name: string,
+) {
+  const input = scope.getByPlaceholder(placeholder, { exact: true });
+  await input.click();
+  await input.pressSequentially(name);
+  await scope.page().waitForTimeout(500);
+  await input.press("Enter");
+}
+
+/** The workspace's draft row — the one carrying the "Add publication" button.
+ * Committed rows keep their inputs (and placeholders), so filling must scope
+ * here to stay unambiguous once the grid holds several rows. CSS-based (not
+ * getByRole) on purpose: it keeps resolving mid-fill no matter what an open
+ * popup's focus manager does to the a11y tree. */
+function draftRow(page: Page) {
+  return page
+    .locator('[role="row"]')
+    .filter({ has: page.locator('button[aria-label="Add publication"]') });
+}
+
+/**
+ * Fill the workspace draft row (fields are keyed by placeholder — the grid has no
+ * <label>s) and materialize it into the working set. Assumes the page is already
+ * on /admin/publications/new.
+ */
+export async function addPublicationRow(page: Page, pub: PublicationInput) {
+  const row = draftRow(page);
+
+  await row.getByPlaceholder("Title", { exact: true }).fill(pub.title);
+  await row
+    .getByPlaceholder("Original Title", { exact: true })
+    .fill(pub.originalTitle);
+  await row.getByPlaceholder("Year", { exact: true }).fill(pub.year);
+  await commitMulti(row, "Translators", pub.authors);
+  await commitMulti(row, "Original Authors", pub.originalAuthors);
+  await selectEnumOption(row, "Countries", pub.country);
+  await commitMulti(row, "Publishers", pub.publisher);
+
+  // Materialize the draft into the working set (async server validation runs).
+  await row.getByRole("button", { name: "Add publication" }).click();
+}
+
+/** Submit the working set and wait for the success toast. Timeouts are generous
+ * so large batches (validation + one bulk insert) fit comfortably. */
+export async function submitWorkspace(page: Page, count: number) {
+  const submit = page.getByRole("button", { name: "Submit" });
+  await expect(submit).toBeEnabled({ timeout: 15_000 });
+  await submit.click();
+  await expect(
+    page.getByText(
+      `${count} publication${count === 1 ? "" : "s"} inserted successfully`,
+    ),
+  ).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Attach references to a committed workspace row through its "Sources" cell:
+ * open the row's references modal, add each source, close, and check the count
+ * the button reports.
+ */
+export async function addRowReferences(
+  page: Page,
+  rowName: string | RegExp,
+  references: string[],
+) {
+  const row = indexTable(page).getByRole("row", { name: rowName });
+  await row.getByRole("button", { name: "Add references" }).click();
+
+  const dialog = page.getByRole("dialog", { name: "Edit references" });
+  await expect(dialog).toBeVisible();
+  for (const [index, reference] of references.entries()) {
+    await dialog.getByRole("button", { name: "Add reference" }).click();
+    await dialog
+      .getByRole("textbox", { name: `Reference ${index + 1}` })
+      .fill(reference);
+  }
+  await page.keyboard.press("Escape");
+  await expect(dialog).toHaveCount(0);
+
+  // The cell button now reports the count — the edits ride the bulk insert.
+  await expect(
+    row.getByRole("button", { name: `Edit references (${references.length})` }),
+  ).toBeVisible();
+}
+
+/** Sign out from the footer; the signed-out controls return. */
+export async function signOut(page: Page) {
+  await page.getByRole("button", { name: "Sign out" }).click();
+  await expect(
+    page.getByRole("button", { name: "Sign in with Google" }),
+  ).toBeVisible();
+}
+
+/** The index footer's running total — the UI's source of truth for "how many". */
+export async function expectPublicationCount(page: Page, n: number) {
+  await expect(
+    page.getByText(new RegExp(`^${n} publications registered so far$`)),
+  ).toBeVisible();
+}
+
+/** The desktop index table (scope every index assertion here — a mobile copy of
+ * every row also lives in the DOM). */
+export function indexTable(page: Page) {
+  return page.getByRole("table", { name: "Publications" });
+}
+
+/**
+ * Assert a publication's full content rendered in the index: every field of its
+ * row, not just its presence. Exact matches so sibling fields can't stand in
+ * for each other (e.g. a title matching for its own original title). The
+ * country holds the display label (that's what the enum stores by
+ * construction), which is also what the index renders.
+ */
+export async function expectPublicationRow(page: Page, pub: PublicationInput) {
+  const row = indexTable(page)
+    .getByRole("row")
+    .filter({ hasText: pub.title })
+    .first();
+  await row.scrollIntoViewIfNeeded();
+
+  for (const value of [
+    pub.title,
+    pub.originalTitle,
+    pub.authors,
+    pub.originalAuthors,
+    pub.year,
+    pub.country,
+    pub.publisher,
+  ]) {
+    await expect(row.getByText(value, { exact: true })).toBeVisible();
+  }
+}
+
+/** Open a publication's detail modal by clicking its row in the index. */
+export async function openPublicationModal(page: Page, title: string) {
+  await indexTable(page)
+    .getByRole("row")
+    .filter({ hasText: title })
+    .first()
+    .click();
+  const dialog = page.getByRole("dialog", { name: "Publication details" });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+/** Distinct publications for workspace journeys. Country values must match an
+ * option label (the enum field has no raw-text commit); "Brazil" throughout,
+ * since the country isn't what these tests exercise. */
+export const PUBLICATIONS: PublicationInput[] = [
+  {
+    title: "Iracema (E2E)",
+    originalTitle: "Iracema",
+    year: "1886",
+    authors: "Isabel Burton",
+    originalAuthors: "José de Alencar",
+    country: "Brazil",
+    publisher: "Bickers & Son",
+  },
+  {
+    title: "Dom Casmurro (E2E)",
+    originalTitle: "Dom Casmurro",
+    year: "1953",
+    authors: "Helen Caldwell",
+    originalAuthors: "Machado de Assis",
+    country: "Brazil",
+    publisher: "Noonday Press",
+  },
+  {
+    title: "Barren Lives (E2E)",
+    originalTitle: "Vidas Secas",
+    year: "1965",
+    authors: "Ralph Dimmick",
+    originalAuthors: "Graciliano Ramos",
+    country: "Brazil",
+    publisher: "University of Texas Press",
+  },
+];
+
+// A realistic corpus seeded in one shot via CSV bulk-import (8 columns in codec
+// order: original_authors; year; countries; original_title; title; authors;
+// publishers; references). Three works share an author (Machado de Assis) so
+// search narrows to several rows; three rows carry a reference and four don't, so
+// the backfill wizard sees a real queue.
+const CORPUS_ROWS = [
+  "Machado de Assis;1953;US;Dom Casmurro;Dom Casmurro;Helen Caldwell;Noonday Press;",
+  "Machado de Assis;1952;US;Memórias Póstumas;Epitaph of a Small Winner;William Grossman;Noonday Press;",
+  "Machado de Assis;1954;US;Quincas Borba;Philosopher or Dog?;Clotilde Wilson;Noonday Press;Caldwell, Helen. Machado de Assis.",
+  "José de Alencar;1886;GB;Iracema;Iraçéma the Honey-Lips;Isabel Burton;Bickers & Son;Burton, Isabel. Preface, 1886.",
+  "Jorge Amado;1962;US;Gabriela, Cravo e Canela;Gabriela, Clove and Cinnamon;James Taylor;Knopf;",
+  "Clarice Lispector;1986;GB;A Hora da Estrela;The Hour of the Star;Giovanni Pontiero;Carcanet;Pontiero, Giovanni. Afterword.",
+  "Graciliano Ramos;1965;US;Vidas Secas;Barren Lives;Ralph Dimmick;University of Texas Press;",
+];
+export const CORPUS_CSV = CORPUS_ROWS.join("\n") + "\n";
+export const CORPUS_SIZE = CORPUS_ROWS.length; // 7
+export const CORPUS_UNREFERENCED = 4; // rows with an empty references column
+
+/** Seed the corpus by bulk-importing it through the admin CSV upload + submit. */
+export async function seedCorpus(page: Page) {
+  await signInAsAdmin(page);
+  await page.goto("/admin/publications/new");
+
+  await page.locator("#upload-csv").setInputFiles({
+    name: "corpus.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(CORPUS_CSV),
+  });
+
+  await submitWorkspace(page, CORPUS_SIZE);
+}

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -80,16 +80,16 @@ export async function addPublicationRow(page: Page, pub: PublicationInput) {
 }
 
 /** Submit the working set and wait for the success toast. Timeouts are generous
- * so large batches (validation + one bulk insert) fit comfortably. */
+ * so large batches (validation + one bulk insert) fit even on slow CI runners. */
 export async function submitWorkspace(page: Page, count: number) {
   const submit = page.getByRole("button", { name: "Submit" });
-  await expect(submit).toBeEnabled({ timeout: 15_000 });
+  await expect(submit).toBeEnabled({ timeout: 30_000 });
   await submit.click();
   await expect(
     page.getByText(
       `${count} publication${count === 1 ? "" : "s"} inserted successfully`,
     ),
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: 30_000 });
 }
 
 /**

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -5,7 +5,11 @@ export async function signInAsAdmin(page: Page) {
   await page.goto("/auth/sign-in");
   await page.getByRole("button", { name: "Dev admin sign-in" }).click();
   // The route handler redirects to "/"; the footer then shows authed controls.
-  await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible();
+  // Generous timeout: this is the suite's longest cross-stack chain (two server
+  // hops + a full SSR reload), and the busiest tail-latency spot on CI.
+  await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible({
+    timeout: 30_000,
+  });
 }
 
 export type PublicationInput = {

--- a/frontend/e2e/permissions.spec.ts
+++ b/frontend/e2e/permissions.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from "./fixtures";
+import { seedCorpus, signOut, openPublicationModal } from "./helpers";
+
+test("a signed-out reader sees publication details read-only, references included", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  // Sign out from the home footer (the admin workspace footer has no session controls).
+  await page.goto("/");
+  await signOut(page);
+
+  const dialog = await openPublicationModal(page, "The Hour of the Star");
+  // Provenance is public: the reference shows in the read view…
+  await expect(
+    dialog.getByText("Pontiero, Giovanni. Afterword."),
+  ).toBeVisible();
+  // …but editing is admin-only.
+  await expect(dialog.getByRole("button", { name: "Edit" })).toHaveCount(0);
+});
+
+test("a signed-out visitor cannot reach the admin workspace", async ({
+  page,
+}) => {
+  await page.goto("/admin/publications/new");
+
+  // The guard bounces the visitor back to the public index.
+  await expect(page).toHaveURL("/");
+  await expect(
+    page.getByRole("heading", { name: "Add publications" }),
+  ).toHaveCount(0);
+});

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "./fixtures";
+import {
+  seedCorpus,
+  signInAsAdmin,
+  submitWorkspace,
+  indexTable,
+  expectPublicationCount,
+  CORPUS_SIZE,
+} from "./helpers";
+
+// Browse / search / columns against a seeded corpus, all through the UI.
+test("browse the corpus, search, and toggle a column", async ({ page }) => {
+  await seedCorpus(page);
+
+  await page.goto("/");
+  const table = indexTable(page);
+
+  // The whole corpus is listed.
+  await expectPublicationCount(page, CORPUS_SIZE);
+  await expect(table.getByText("Epitaph of a Small Winner")).toBeVisible();
+  await expect(table.getByText("Barren Lives")).toBeVisible();
+
+  const search = page.getByRole("textbox", { name: "Search publications" });
+
+  // Searching an author narrows to their three works.
+  await search.fill("Machado");
+  await expect(
+    table.getByRole("row").filter({ hasText: "Machado de Assis" }),
+  ).toHaveCount(3);
+  await expect(table.getByText("Iraçéma the Honey-Lips")).toHaveCount(0);
+  await expect(page).toHaveURL(/\?search=Machado/);
+
+  // A distinctive title narrows to one.
+  await search.fill("Gabriela");
+  await expect(table.getByText("Gabriela, Clove and Cinnamon")).toBeVisible();
+  await expect(table.getByText("Epitaph of a Small Winner")).toHaveCount(0);
+
+  // Clearing restores the full corpus.
+  await search.fill("");
+  await expect(table.getByText("Barren Lives")).toBeVisible();
+
+  // The Columns menu hides the Year column across every row.
+  await expect(table.getByRole("columnheader", { name: "Year" })).toBeVisible();
+  await page.getByRole("button", { name: "Columns" }).click();
+  await page.getByRole("button", { name: "Year", pressed: true }).click();
+  await expect(table.getByRole("columnheader", { name: "Year" })).toHaveCount(
+    0,
+  );
+});
+
+// 60 distinct publications, imported in one shot (titles carry the index so a
+// specific far-away row is addressable).
+const BULK_SIZE = 60;
+const BULK_CSV =
+  Array.from(
+    { length: BULK_SIZE },
+    (_, i) =>
+      `Author ${i};${1900 + i};US;Original ${i};Bulk Title ${i};Translator ${i};Publisher ${i};`,
+  ).join("\n") + "\n";
+
+test("a large index virtualizes: far rows render as they scroll into view", async ({
+  page,
+}) => {
+  await signInAsAdmin(page);
+  await page.goto("/admin/publications/new");
+  await page.locator("#upload-csv").setInputFiles({
+    name: "bulk.csv",
+    mimeType: "text/csv",
+    buffer: Buffer.from(BULK_CSV),
+  });
+  await submitWorkspace(page, BULK_SIZE);
+
+  await page.goto("/");
+  const table = indexTable(page);
+  await expectPublicationCount(page, BULK_SIZE);
+
+  // The last row exists but is virtualized: its cells are empty placeholders
+  // until scrolled into view.
+  await expect(table.getByText("Bulk Title 59")).toHaveCount(0);
+  await table.getByRole("row").last().scrollIntoViewIfNeeded();
+  await expect(table.getByText("Bulk Title 59")).toBeVisible();
+});

--- a/frontend/e2e/reader.spec.ts
+++ b/frontend/e2e/reader.spec.ts
@@ -48,9 +48,11 @@ test("browse the corpus, search, and toggle a column", async ({ page }) => {
   );
 });
 
-// 60 distinct publications, imported in one shot (titles carry the index so a
-// specific far-away row is addressable).
-const BULK_SIZE = 60;
+// Enough distinct publications to far overflow the viewport (~18 visible rows),
+// imported in one shot; titles carry the index so a far-away row is addressable.
+// Kept moderate on purpose: the backend validates rows sequentially, so seeding
+// cost scales linearly and CI runners are slow.
+const BULK_SIZE = 30;
 const BULK_CSV =
   Array.from(
     { length: BULK_SIZE },
@@ -58,9 +60,15 @@ const BULK_CSV =
       `Author ${i};${1900 + i};US;Original ${i};Bulk Title ${i};Translator ${i};Publisher ${i};`,
   ).join("\n") + "\n";
 
+const LAST_TITLE = `Bulk Title ${BULK_SIZE - 1}`;
+
 test("a large index virtualizes: far rows render as they scroll into view", async ({
   page,
 }) => {
+  // Seeding this many rows through validate + bulk insert is the suite's
+  // heaviest server work — give it triple the timeout for slow CI runners.
+  test.slow();
+
   await signInAsAdmin(page);
   await page.goto("/admin/publications/new");
   await page.locator("#upload-csv").setInputFiles({
@@ -76,7 +84,7 @@ test("a large index virtualizes: far rows render as they scroll into view", asyn
 
   // The last row exists but is virtualized: its cells are empty placeholders
   // until scrolled into view.
-  await expect(table.getByText("Bulk Title 59")).toHaveCount(0);
+  await expect(table.getByText(LAST_TITLE)).toHaveCount(0);
   await table.getByRole("row").last().scrollIntoViewIfNeeded();
-  await expect(table.getByText("Bulk Title 59")).toBeVisible();
+  await expect(table.getByText(LAST_TITLE)).toBeVisible();
 });

--- a/frontend/e2e/references-backfill.spec.ts
+++ b/frontend/e2e/references-backfill.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "./fixtures";
+import { seedCorpus, CORPUS_UNREFERENCED } from "./helpers";
+
+test("the wizard queues only unreferenced publications and sources one", async ({
+  page,
+}) => {
+  // Seven publications; three already carry a reference, so four are queued.
+  await seedCorpus(page);
+
+  await page.goto("/admin/publications/references");
+
+  const queue = page.getByRole("listbox", {
+    name: "Publications missing references",
+  });
+  await expect(queue.getByRole("option")).toHaveCount(CORPUS_UNREFERENCED);
+  await expect(page.getByText(/^1 \/ 4$/)).toBeVisible();
+  // The three already-sourced works are absent from the queue.
+  await expect(
+    queue.getByRole("option", { name: /Iraçéma the Honey-Lips/ }),
+  ).toHaveCount(0);
+
+  // Mid-queue the action promises to advance…
+  await expect(
+    page.getByRole("button", { name: "Save & next", exact: true }),
+  ).toBeVisible();
+
+  // …but on the last queued publication there is no next, so it's just "Save".
+  await queue.getByRole("option", { name: "Barren Lives" }).click();
+  const save = page.getByRole("button", { name: "Save", exact: true });
+  await expect(save).toBeVisible();
+
+  await page.getByRole("button", { name: "Add reference" }).click();
+  await page
+    .getByRole("textbox", { name: "Reference 1" })
+    .fill("Dimmick, Ralph. Translator's note, 1965.");
+
+  // Drafting alone does not mark it sourced — only a save does.
+  await expect(
+    queue.getByRole("option", { name: "Barren Lives", exact: true }),
+  ).toBeVisible();
+
+  await save.click();
+
+  // It flips to sourced (green dot / "— sourced"), which also decrements the count.
+  await expect(
+    queue.getByRole("option", { name: /Barren Lives.*sourced/ }),
+  ).toBeVisible();
+});
+
+test("skipping a publication discards its edits and moves on", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/admin/publications/references");
+
+  const queue = page.getByRole("listbox", {
+    name: "Publications missing references",
+  });
+  await expect(page.getByText(/^1 \/ 4$/)).toBeVisible();
+
+  // Draft a reference but skip instead of saving.
+  await page.getByRole("button", { name: "Add reference" }).click();
+  await page
+    .getByRole("textbox", { name: "Reference 1" })
+    .fill("A draft that should not survive the skip");
+  await page.getByRole("button", { name: "Skip" }).click();
+
+  // The wizard advanced, and the skipped publication stayed unsourced.
+  await expect(page.getByText(/^2 \/ 4$/)).toBeVisible();
+  await expect(
+    queue.getByRole("option", { name: "Dom Casmurro", exact: true }),
+  ).toBeVisible();
+
+  // Coming back to it, the drafted reference is gone.
+  await queue
+    .getByRole("option", { name: "Dom Casmurro", exact: true })
+    .click();
+  await expect(page.getByText("No references yet.")).toBeVisible();
+});

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -28,8 +28,17 @@ const eslintConfig = [
     },
   },
   {
+    // Playwright fixture callbacks take a `use` argument, which the React hooks
+    // rule mistakes for the `use` hook — E2E files aren't React components.
+    files: ["e2e/**/*.ts"],
+    rules: {
+      "react-hooks/rules-of-hooks": "off",
+    },
+  },
+  {
     ignores: [
       ".next/**",
+      ".next-e2e-*/**",
       "node_modules/**",
       "storybook-static/**",
       "**/*.config.{js,cjs,mjs,ts,mts}",

--- a/frontend/modules/publication/hooks.ts
+++ b/frontend/modules/publication/hooks.ts
@@ -21,6 +21,7 @@ import {
   publicationOrNullFamily,
   publicationReferencesFamily,
   storedFieldValueFamily,
+  storedReferencesFamily,
   totalCountAtom,
   totalIndexCountAtom,
   unreferencedCountAtom,
@@ -75,6 +76,11 @@ function usePublicationStoredField<K extends PublicationKey>(
 
 function usePublicationReferences(id: PublicationId) {
   return useAtomValue(publicationReferencesFamily(id));
+}
+
+/** The persisted references only — drafts don't show until saved. */
+function useStoredPublicationReferences(id: PublicationId) {
+  return useAtomValue(storedReferencesFamily(id));
 }
 
 function usePublicationError(id: PublicationId) {
@@ -182,6 +188,7 @@ export {
   usePublicationOverride,
   usePublicationReferences,
   usePublicationStoredField,
+  useStoredPublicationReferences,
   useTotalPublicationCount,
   useUnreferencedPublicationCount,
   useValidPublicationCount,

--- a/frontend/modules/publication/model.ts
+++ b/frontend/modules/publication/model.ts
@@ -75,12 +75,14 @@ const DEFAULT_ATTRIBUTE_VISIBILITY: Record<PublicationKey, boolean> = {
 };
 
 const ERROR_MESSAGES: Record<string, string> = {
-  conflict: "A publication with this data already exists",
-  required: "This field is required and cannot be blank",
-  integer: "This field should be an integer",
-  incorrect_row_length: "Expected a different number of columns in csv",
-  invalid_format: "Could not parse publications from the provided file",
-  alpha2: "This field should be a valid ISO 3166-1 alpha 2 country code",
+  conflict: `A publication with this data already exists`,
+  required: `This field is required and cannot be blank`,
+  integer: `This field should be an integer`,
+  incorrect_row_length: `Expected a different number of columns in csv`,
+  invalid_format: `Could not parse publications from the provided file`,
+  invalid_escape_sequence: `Could not parse publications from the provided file`,
+  stray_escape_character: `Could not parse publications from the provided file`,
+  alpha2: `This field should be a valid ISO 3166-1 alpha 2 country code`,
 };
 
 function empty(): Publication {

--- a/frontend/modules/publication/remote.ts
+++ b/frontend/modules/publication/remote.ts
@@ -207,11 +207,16 @@ async function validate(ids: PublicationId[]): Promise<void> {
 async function upload(payload: FormData): Promise<void> {
   return run(async (http) => {
     resetAll();
-    const { data } = await http.post<ValidationResult[]>(
-      "publications/validate",
-      payload,
-    );
-    setAll(data.map((entry) => ({ ...entry, id: createId() })));
+    try {
+      const { data } = await http.post<ValidationResult[]>(
+        "publications/validate",
+        payload,
+      );
+      setAll(data.map((entry) => ({ ...entry, id: createId() })));
+    } catch (error) {
+      setAll([]);
+      throw error;
+    }
   });
 }
 

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -127,13 +127,19 @@ const publicationReferencesFamily = atomFamily((id: PublicationId) =>
   atom<string[]>((get) => get(visiblePublicationFamily(id)).references ?? []),
 );
 
-/** How many loaded publications still have no references — drives the backfill
- * wizard's counter, shrinking live as sources are added (same signal as the
- * queue's sourced dots). */
+/** A publication's *persisted* provenance list — ignores in-progress drafts,
+ * the same stored-vs-visible distinction as `storedFieldValueFamily`. */
+const storedReferencesFamily = atomFamily((id: PublicationId) =>
+  atom<string[]>((get) => get(publicationFamily(id))?.references ?? []),
+);
+
+/** How many loaded publications still have no *saved* references — drives the
+ * backfill wizard's counter and queue dots, updating as saves land (drafts
+ * don't count until they're persisted). */
 const unreferencedCountAtom = atom(
   (get) =>
     get(publicationIdsAtom)?.filter(
-      (id) => get(publicationReferencesFamily(id)).length === 0,
+      (id) => get(storedReferencesFamily(id)).length === 0,
     ).length || 0,
 );
 
@@ -378,6 +384,7 @@ export {
   setPublications,
   store,
   storedFieldValueFamily,
+  storedReferencesFamily,
   totalCountAtom,
   totalIndexCountAtom,
   unreferencedCountAtom,

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -4,6 +4,10 @@ const path = require("path");
 const nextConfig = {
   reactStrictMode: true,
 
+  // Per-process build dir so parallel E2E `next dev` workers don't collide on a
+  // shared `.next` (each Playwright worker sets E2E_DIST_DIR). Defaults to `.next`.
+  distDir: process.env.E2E_DIST_DIR || ".next",
+
   // Import SVGs as React components. Turbopack (Next 16's default bundler) runs
   // the @svgr/webpack loader via turbopack.rules; the webpack block is the
   // equivalent for `next build --webpack`.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,6 +35,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@storybook/addon-a11y": "^10.5.0",
         "@storybook/addon-docs": "^10.5.2",
         "@storybook/addon-vitest": "^10.5.0",
@@ -4483,6 +4484,22 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -12862,7 +12879,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
       "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.61.1"
@@ -12881,7 +12898,7 @@
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
       "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "lint": "eslint .",
@@ -43,6 +44,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@storybook/addon-a11y": "^10.5.0",
     "@storybook/addon-docs": "^10.5.2",
     "@storybook/addon-vitest": "^10.5.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -43,6 +43,10 @@ export default defineConfig({
   workers: WORKERS,
   // Tests within a worker run serially — each needs a clean database (reset).
   fullyParallel: false,
+  // CI runners are several times slower than a dev machine (2 vCPUs shared by
+  // the stack, Postgres, and Chromium) — give tests and assertions headroom.
+  timeout: process.env.CI ? 60_000 : 30_000,
+  expect: { timeout: process.env.CI ? 15_000 : 5_000 },
   forbidOnly: !!process.env.CI,
   reporter: process.env.CI
     ? [["list"], ["html", { open: "never" }]]

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig } from "@playwright/test";
+
+// DB-per-worker isolation: each Playwright worker gets its own (backend, frontend)
+// stack on distinct ports, backed by its own database (richard_burton_e2e{i}). A
+// worker resets its database between tests via POST /test/reset. See
+// docs/planning/22 and backend/config/e2e.exs.
+const WORKERS = Number(process.env.E2E_WORKERS ?? "1");
+const backendPort = (i: number) => 4100 + i;
+const frontendPort = (i: number) => 3100 + i;
+const asdf = `${process.env.HOME}/.asdf/shims`;
+
+// One backend + one frontend per worker, each pointed at that worker's database.
+// `next dev` reads the API URLs at runtime, so a single build can't serve several
+// workers — hence a frontend per worker (kept small; scale via E2E_WORKERS).
+const stacks = Array.from({ length: WORKERS }, (_, i) => [
+  {
+    command: `export PATH="${asdf}:$PATH" && cd ../backend && MIX_ENV=e2e E2E_WORKER=${i} PHX_CONSUMER_URL=http://localhost:${frontendPort(i)} mix phx.server`,
+    port: backendPort(i),
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  {
+    command: `npm run dev -- --port ${frontendPort(i)}`,
+    port: frontendPort(i),
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      NEXT_PUBLIC_API_URL: `http://localhost:${backendPort(i)}/api`,
+      NEXT_INTERNAL_API_URL: `http://localhost:${backendPort(i)}/api`,
+      NEXT_PUBLIC_FILES_URL: `http://localhost:${backendPort(i)}/files`,
+      // A private build dir per worker so parallel `next dev`s don't share `.next`.
+      E2E_DIST_DIR: `.next-e2e-${i}`,
+      // Provided here so the harness doesn't depend on a local .env (absent in CI).
+      // Google's public reCAPTCHA test key; the journeys don't submit the form.
+      NEXT_PUBLIC_GOOGLE_RECAPTCHA_SITEKEY:
+        "6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI",
+    },
+  },
+]).flat();
+
+export default defineConfig({
+  testDir: "./e2e",
+  workers: WORKERS,
+  // Tests within a worker run serially — each needs a clean database (reset).
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI
+    ? [["list"], ["html", { open: "never" }]]
+    : [["list"]],
+  globalSetup: "./e2e/global-setup.ts",
+  webServer: stacks,
+  use: {
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -47,6 +47,10 @@ export default defineConfig({
   // the stack, Postgres, and Chromium) — give tests and assertions headroom.
   timeout: process.env.CI ? 60_000 : 30_000,
   expect: { timeout: process.env.CI ? 15_000 : 5_000 },
+  // One retry on CI absorbs tail-latency flakes; the per-test database reset
+  // makes a retry start from the same clean state as any run, and retried
+  // passes are reported as "flaky" so they stay visible.
+  retries: process.env.CI ? 1 : 0,
   forbidOnly: !!process.env.CI,
   reporter: process.env.CI
     ? [["list"], ["html", { open: "never" }]]

--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import magicalSvg from "vite-plugin-magical-svg";
 import tsconfigPaths from "vite-tsconfig-paths";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 const dir = dirname(fileURLToPath(import.meta.url));
 
@@ -34,6 +34,8 @@ export default defineConfig({
           environment: "jsdom",
           globals: true,
           include: ["**/*.spec.{ts,tsx}"],
+          // Playwright specs (frontend/e2e) run under `npm run test:e2e`, not Vitest.
+          exclude: [...configDefaults.exclude, "e2e/**"],
         },
       },
       {


### PR DESCRIPTION
Stand up a Playwright harness where each worker runs its own backend, frontend, and database — a dedicated :e2e Mix env plus an e2e-only POST /test/reset — so tests are isolated and can run in parallel, locally and in a new CI workflow.

Cover the app's journeys end-to-end through the real UI: bulk workspace insert with references and selection tools, editing, validation and conflict flagging, auth and admin gating, CSV import/export, the references backfill wizard, search, column toggling, and index virtualization.

Fix what the suite surfaced: guard /admin routes server-side, restore the workspace after a failed CSV upload, map the csv parser's escape errors to a friendly message, make combobox popups non-modal per the ARIA pattern, mark backfill queue items sourced only once their references are actually saved, and label the wizard's last step "Save" since there is no next. The backfill stories are now fully interactive with local state.