### PR TITLE
Move the search-index refresh off the write path

### DIFF
--- a/backend/config/config.exs
+++ b/backend/config/config.exs
@@ -10,6 +10,11 @@ import Config
 config :richard_burton,
   ecto_repos: [RichardBurton.Repo]
 
+# Search-index maintenance strategy (see Publication.Index.Refresher): rebuild
+# the materialized views once per burst of writes, concurrently, off the write
+# path. Test and e2e override this with synchronous strategies for determinism.
+config :richard_burton, search_index_refresh: {:debounced, 2_000}
+
 # Configures Postgrex
 config :richard_burton, RichardBurton.Repo,
   timeout: String.to_integer(System.get_env("POSTGREX_TIMEOUT", "15000"))

--- a/backend/config/e2e.exs
+++ b/backend/config/e2e.exs
@@ -24,6 +24,10 @@ config :richard_burton,
   jwks_provider: RichardBurton.Auth.JWKS.Stub,
   mailer_adapter: Swoosh.Adapters.Test
 
+# Rebuild the search index inline so browser tests see writes deterministically,
+# but with CONCURRENTLY — the same SQL path production's debounced mode runs.
+config :richard_burton, search_index_refresh: :sync_concurrent
+
 config :richard_burton, RichardBurton.Repo,
   username: "postgres",
   password: "postgres",

--- a/backend/config/test.exs
+++ b/backend/config/test.exs
@@ -12,6 +12,10 @@ config :richard_burton,
   # connection (see RichardBurton.Mailer.SMTP).
   mailer_adapter: Swoosh.Adapters.Test
 
+# Rebuild the search index inline (plain REFRESH): tests need writes visible to
+# search immediately, and the sandbox's transactions forbid CONCURRENTLY.
+config :richard_burton, search_index_refresh: :sync
+
 # Configure your database
 #
 # The MIX_TEST_PARTITION environment variable can be used

--- a/backend/lib/mix/tasks/load_data.ex
+++ b/backend/lib/mix/tasks/load_data.ex
@@ -16,7 +16,11 @@ defmodule Mix.Tasks.Rb.LoadData do
       {:ok, publications} ->
         publications
         |> Publication.Codec.nest()
-        |> Enum.map(&Publication.insert/1)
+        |> Enum.each(&Publication.insert/1)
+
+        # Single inserts don't signal the refresher (that's the callers' job,
+        # once per logical operation) — this seed is one such operation.
+        Publication.Index.Refresher.refresh()
 
       {:error, error} ->
         IO.puts("Operation failed with error #{error}")

--- a/backend/lib/richard_burton/application.ex
+++ b/backend/lib/richard_burton/application.ex
@@ -18,7 +18,10 @@ defmodule RichardBurton.Application do
       RichardBurtonWeb.Endpoint,
       # Start the JWKS key store. Its provider is configured via :jwks_provider
       # (Google in dev/prod; a stub under test, so no network calls are made).
-      RichardBurton.Auth.KeyStore
+      RichardBurton.Auth.KeyStore,
+      # Coalesces search-index rebuild signals from the write paths (in the
+      # debounced strategy; the sync strategies rebuild inline and bypass it).
+      RichardBurton.Publication.Index.Refresher
     ]
 
     # Set missing runtime config from Application env

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -9,6 +9,7 @@ defmodule RichardBurton.Publication do
 
   alias RichardBurton.Country
   alias RichardBurton.Publication
+  alias RichardBurton.Publication.Index
   alias RichardBurton.Publisher
   alias RichardBurton.Reference
   alias RichardBurton.Repo
@@ -123,8 +124,12 @@ defmodule RichardBurton.Publication do
         |> link_assocs()
         |> Repo.update()
         |> case do
-          {:ok, updated} -> {:ok, preload(updated)}
-          {:error, changeset} -> {:error, Validation.get_errors(changeset)}
+          {:ok, updated} ->
+            Index.Refresher.refresh()
+            {:ok, preload(updated)}
+
+          {:error, changeset} ->
+            {:error, Validation.get_errors(changeset)}
         end
     end
   end
@@ -146,27 +151,20 @@ defmodule RichardBurton.Publication do
   def insert_all(attrs_list) do
     result =
       Repo.transaction(fn ->
-        # Skip the per-statement search-index rebuild for the whole batch — the
-        # trigger would otherwise rebuild both materialized views for every
-        # inserted row. One rebuild below covers the entire transaction.
-        Repo.query!("SET LOCAL richard_burton.skip_search_refresh = 'on'")
         Enum.map(attrs_list, &insert_or_rollback/1)
       end)
 
     case result do
       {:ok, _publications} ->
-        refresh_search_index()
+        # One signal for the whole batch — never per row, so the synchronous
+        # refresh strategies don't rebuild N times.
+        Index.Refresher.refresh()
         result
 
       error ->
         # Rolled back: nothing changed, so the index needs no refresh.
         error
     end
-  end
-
-  defp refresh_search_index do
-    Repo.query!("REFRESH MATERIALIZED VIEW search_documents")
-    Repo.query!("REFRESH MATERIALIZED VIEW search_keywords")
   end
 
   defp insert_or_rollback(attrs) do

--- a/backend/lib/richard_burton/publication_index_refresher.ex
+++ b/backend/lib/richard_burton/publication_index_refresher.ex
@@ -1,0 +1,111 @@
+defmodule RichardBurton.Publication.Index.Refresher do
+  @moduledoc """
+  Owns search-index maintenance: write paths call `refresh/0` once per logical
+  operation (a bulk insert, an update), and the refresher rebuilds the
+  `search_documents` and `search_keywords` materialized views.
+
+  The strategy comes from `config :richard_burton, :search_index_refresh`:
+
+    * `{:debounced, ms}` (default — dev and prod): signals coalesce; the views
+      rebuild once after a quiet window, outside any transaction, with
+      `REFRESH MATERIALIZED VIEW CONCURRENTLY` so searches never block and
+      writes never wait. Search lags a write by up to the window — the
+      documented trade-off.
+    * `:sync_concurrent` (e2e): rebuild inline before `refresh/0` returns —
+      deterministic for browser tests while exercising the same CONCURRENTLY
+      path production runs.
+    * `:sync` (test): rebuild inline with a plain `REFRESH` — the ExUnit
+      sandbox wraps tests in transactions, where CONCURRENTLY is not allowed.
+
+  In debounced mode the refresher also rebuilds once on boot, covering signals
+  lost to a restart and data seeded while the app was down.
+  """
+
+  use GenServer
+
+  alias RichardBurton.Repo
+
+  # Quiet window before a coalesced rebuild, unless configured otherwise.
+  @default_debounce_ms 2_000
+
+  @doc "Signal that the index is stale. Returns after the rebuild in sync modes."
+  def refresh do
+    case strategy() do
+      :sync -> rebuild(:blocking)
+      :sync_concurrent -> rebuild(:concurrent)
+      {:debounced, _ms} -> GenServer.cast(__MODULE__, :dirty)
+    end
+
+    :ok
+  end
+
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name, __MODULE__)
+
+    if name do
+      GenServer.start_link(__MODULE__, opts, name: name)
+    else
+      # Unnamed instances let tests exercise the scheduling in isolation.
+      GenServer.start_link(__MODULE__, opts)
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    state = %{
+      timer: nil,
+      debounce_ms: Keyword.get(opts, :debounce_ms, configured_debounce_ms()),
+      # Injectable for coalescing tests; the real rebuild everywhere else.
+      rebuild: Keyword.get(opts, :rebuild, fn -> rebuild(:concurrent) end)
+    }
+
+    # Catch up on anything written while the refresher wasn't running.
+    if Keyword.get(opts, :refresh_on_boot, debounced?()), do: send(self(), :rebuild)
+
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_cast(:dirty, state) do
+    # Trailing-edge debounce: every signal restarts the quiet window.
+    if state.timer, do: Process.cancel_timer(state.timer)
+    {:noreply, %{state | timer: Process.send_after(self(), :rebuild, state.debounce_ms)}}
+  end
+
+  @impl true
+  def handle_info(:rebuild, state) do
+    # Signals cast during this rebuild wait in the mailbox and coalesce into
+    # the next window — a burst never yields more than one trailing rebuild.
+    state.rebuild.()
+    {:noreply, %{state | timer: nil}}
+  end
+
+  defp rebuild(:blocking) do
+    Repo.query!("REFRESH MATERIALIZED VIEW search_documents", [], timeout: :infinity)
+    Repo.query!("REFRESH MATERIALIZED VIEW search_keywords", [], timeout: :infinity)
+  end
+
+  defp rebuild(:concurrent) do
+    Repo.query!("REFRESH MATERIALIZED VIEW CONCURRENTLY search_documents", [], timeout: :infinity)
+    Repo.query!("REFRESH MATERIALIZED VIEW CONCURRENTLY search_keywords", [], timeout: :infinity)
+  end
+
+  defp strategy do
+    Application.get_env(
+      :richard_burton,
+      :search_index_refresh,
+      {:debounced, @default_debounce_ms}
+    )
+  end
+
+  defp debounced? do
+    match?({:debounced, _}, strategy())
+  end
+
+  defp configured_debounce_ms do
+    case strategy() do
+      {:debounced, ms} -> ms
+      _ -> @default_debounce_ms
+    end
+  end
+end

--- a/backend/priv/repo/migrations/20260724130000_offload_search_index_refresh.exs
+++ b/backend/priv/repo/migrations/20260724130000_offload_search_index_refresh.exs
@@ -1,0 +1,58 @@
+defmodule RichardBurton.Repo.Migrations.OffloadSearchIndexRefresh do
+  use Ecto.Migration
+
+  @moduledoc """
+  Move search-index maintenance off the write path.
+
+  The per-statement triggers rebuilt both materialized views synchronously
+  inside every writing transaction — with an ACCESS EXCLUSIVE lock, so
+  searches blocked and bulk writes crawled. Maintenance now lives in
+  `Publication.Index.Refresher`, which the write paths signal; it rebuilds
+  with `REFRESH ... CONCURRENTLY`, which needs a unique index on each view.
+
+  This also retires the `skip_search_refresh` guard (20260724010000) — with
+  the triggers gone there is nothing to skip.
+  """
+
+  @tables ["publications", "translated_books", "original_books", "authors"]
+
+  def up do
+    execute("CREATE UNIQUE INDEX search_documents_id_index ON search_documents (id)")
+    execute("CREATE UNIQUE INDEX search_keywords_word_index ON search_keywords (word)")
+
+    Enum.each(@tables, fn table ->
+      execute("DROP TRIGGER #{table}_refresh_search_index ON #{table}")
+    end)
+
+    execute("DROP FUNCTION refresh_search_index")
+  end
+
+  def down do
+    execute("""
+    CREATE FUNCTION refresh_search_index()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+    AS
+    $$ BEGIN
+      IF current_setting('richard_burton.skip_search_refresh', true) = 'on' THEN
+        RETURN NULL;
+      END IF;
+      REFRESH MATERIALIZED VIEW search_documents;
+      REFRESH MATERIALIZED VIEW search_keywords;
+      RETURN NULL;
+    END $$;
+    """)
+
+    Enum.each(@tables, fn table ->
+      execute("""
+      CREATE TRIGGER #{table}_refresh_search_index
+      AFTER INSERT OR UPDATE
+      ON #{table}
+      EXECUTE PROCEDURE refresh_search_index()
+      """)
+    end)
+
+    execute("DROP INDEX search_keywords_word_index")
+    execute("DROP INDEX search_documents_id_index")
+  end
+end

--- a/backend/test/richard_burton/publication_index_refresher_test.exs
+++ b/backend/test/richard_burton/publication_index_refresher_test.exs
@@ -1,0 +1,56 @@
+defmodule RichardBurton.Publication.Index.RefresherTest do
+  use ExUnit.Case, async: true
+
+  alias RichardBurton.Publication.Index.Refresher
+
+  # Exercises the debounced scheduling in isolation: unnamed instances with an
+  # injected rebuild that reports to the test instead of touching the database.
+  # (The synchronous strategies are covered end-to-end by the index tests, which
+  # search right after their seed's refresh.)
+
+  defp start_refresher(debounce_ms) do
+    test = self()
+
+    start_supervised!(
+      {Refresher,
+       name: nil,
+       debounce_ms: debounce_ms,
+       refresh_on_boot: false,
+       rebuild: fn -> send(test, :rebuilt) end}
+    )
+  end
+
+  test "a burst of signals coalesces into a single rebuild" do
+    refresher = start_refresher(50)
+
+    for _ <- 1..5, do: GenServer.cast(refresher, :dirty)
+
+    assert_receive :rebuilt, 500
+    refute_receive :rebuilt, 200
+  end
+
+  test "every signal restarts the quiet window (trailing-edge debounce)" do
+    refresher = start_refresher(200)
+
+    GenServer.cast(refresher, :dirty)
+    Process.sleep(120)
+    refute_received :rebuilt
+
+    # A second signal inside the window pushes the rebuild out again.
+    GenServer.cast(refresher, :dirty)
+    Process.sleep(120)
+    refute_received :rebuilt
+
+    assert_receive :rebuilt, 500
+  end
+
+  test "signals arriving after a rebuild schedule another one" do
+    refresher = start_refresher(50)
+
+    GenServer.cast(refresher, :dirty)
+    assert_receive :rebuilt, 500
+
+    GenServer.cast(refresher, :dirty)
+    assert_receive :rebuilt, 500
+  end
+end

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -214,6 +214,10 @@ defmodule RichardBurton.Publication.IndexTest do
     |> Publication.Codec.nest()
     |> Enum.map(&Publication.insert/1)
 
+    # Single inserts don't signal the refresher (callers do, once per logical
+    # operation) — this seed is one such operation, and search needs the index.
+    Publication.Index.Refresher.refresh()
+
     []
   end
 


### PR DESCRIPTION
Replace the per-statement refresh triggers with a Refresher process the write paths signal once per logical operation. In dev and prod it coalesces bursts of signals and rebuilds both materialized views concurrently after a quiet window — writes no longer wait on rebuilds and searches no longer block behind them, at the cost of search lagging a write by up to ~2s. It also rebuilds on boot, covering seeds and signals lost to a restart.

Tests rebuild inline and stay deterministic: plain refreshes under the test sandbox, and the same CONCURRENTLY path production runs in the e2e environment, so the browser suite exercises it end to end.

The unique indexes CONCURRENTLY requires ride along, and the batch-skip guard from the previous fix is deleted — with the triggers gone there is nothing to skip.