### PR TITLE
Read the admin pages on the server

### DIFF
--- a/frontend/app/admin/publications/deleted/Trash.tsx
+++ b/frontend/app/admin/publications/deleted/Trash.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import DeletedPublications from "components/DeletedPublications";
+import type {
+  DeletedPublicationEntry,
+  PublicationId,
+} from "modules/publication/model";
+import { restore } from "modules/publication/remote";
+import { useRouter } from "next/navigation";
+import { FC } from "react";
+
+/**
+ * The interactive half of the trash: the page reads what is currently deleted
+ * on the server, so the browser only has to dispatch a restore and ask for the
+ * list again.
+ *
+ * `router.refresh()` rather than dropping the row locally — a failed restore
+ * (the record was imported again while it sat here) must leave the list exactly
+ * as it was, and re-reading is the only account of that which cannot drift.
+ */
+const Trash: FC<{ entries: DeletedPublicationEntry[] }> = ({ entries }) => {
+  const router = useRouter();
+
+  async function handleRestore(id: PublicationId) {
+    if (await restore(id)) router.refresh();
+  }
+
+  return <DeletedPublications entries={entries} onRestore={handleRestore} />;
+};
+
+export default Trash;

--- a/frontend/app/admin/publications/deleted/page.tsx
+++ b/frontend/app/admin/publications/deleted/page.tsx
@@ -1,15 +1,10 @@
-"use client";
-
 import Breadcrumb from "components/Breadcrumb";
-import DeletedPublications from "components/DeletedPublications";
 import Layout from "components/Layout";
 import PageHeader from "components/PageHeader";
-import type {
-  DeletedPublicationEntry,
-  PublicationId,
-} from "modules/publication/model";
-import { deleted, restore } from "modules/publication/remote";
-import { useEffect, useState } from "react";
+import type { DeletedPublicationEntry } from "modules/publication/model";
+
+import { read } from "app/api";
+import Trash from "./Trash";
 
 const BREADCRUMB_ITEMS = [
   { label: "Home", href: "/" },
@@ -17,26 +12,10 @@ const BREADCRUMB_ITEMS = [
   { label: "Deleted publications" },
 ];
 
-export default function DeletedPublicationsPage() {
-  const [entries, setEntries] = useState<DeletedPublicationEntry[]>();
-
-  useEffect(() => {
-    // `run` already surfaces a notification on failure.
-    deleted()
-      .then(setEntries)
-      .catch(() => {});
-  }, []);
-
-  // Which row is spinning is the list's own state; this only does the work and
-  // drops the row on success. A failed restore — the record was imported again
-  // while it sat here — leaves the list alone, and `run` has already said so.
-  async function handleRestore(id: PublicationId) {
-    if (await restore(id)) {
-      setEntries((current) =>
-        current?.filter(({ publication }) => publication.id !== id),
-      );
-    }
-  }
+export default async function DeletedPublicationsPage() {
+  const { entries } = await read<{ entries: DeletedPublicationEntry[] }>(
+    "/publications/deleted",
+  );
 
   return (
     <Layout
@@ -50,13 +29,7 @@ export default function DeletedPublicationsPage() {
         </>
       }
       measure="centered"
-      content={
-        entries === undefined ? (
-          <p className="text-sm text-gray-600">Loading…</p>
-        ) : (
-          <DeletedPublications entries={entries} onRestore={handleRestore} />
-        )
-      }
+      content={<Trash entries={entries} />}
     />
   );
 }

--- a/frontend/app/admin/publications/history/HistoryFeed.tsx
+++ b/frontend/app/admin/publications/history/HistoryFeed.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import PublicationHistoryFeed from "components/PublicationHistoryFeed";
+import type { WithChanges } from "modules/publication/history";
+import type { FullHistoryEntry } from "modules/publication/model";
+import { undo } from "modules/publication/remote";
+import { useRouter } from "next/navigation";
+import { FC } from "react";
+
+/**
+ * The interactive half of the history page: the page itself is a server
+ * component and reads the log, so all that has to run in the browser is
+ * dispatching an undo and asking the server for the log again.
+ *
+ * `router.refresh()` rather than a re-fetch — the server render is the source
+ * of the data now, so re-running it is how the feed learns what the undo
+ * changed, including which *other* entries stopped being undoable.
+ */
+const HistoryFeed: FC<{ entries: WithChanges<FullHistoryEntry>[] }> = ({
+  entries,
+}) => {
+  const router = useRouter();
+
+  async function handleUndo(entry: FullHistoryEntry) {
+    if (await undo(entry.publicationId, entry.version)) router.refresh();
+  }
+
+  return <PublicationHistoryFeed entries={entries} onUndo={handleUndo} />;
+};
+
+export default HistoryFeed;

--- a/frontend/app/admin/publications/history/page.tsx
+++ b/frontend/app/admin/publications/history/page.tsx
@@ -1,13 +1,11 @@
-"use client";
-
 import Breadcrumb from "components/Breadcrumb";
 import Layout from "components/Layout";
 import PageHeader from "components/PageHeader";
-import PublicationHistoryFeed from "components/PublicationHistoryFeed";
-import type { WithChanges } from "modules/publication/history";
+import { withChanges } from "modules/publication/history";
 import type { FullHistoryEntry } from "modules/publication/model";
-import { fullHistory, undo } from "modules/publication/remote";
-import { useEffect, useState } from "react";
+
+import { read } from "app/api";
+import HistoryFeed from "./HistoryFeed";
 
 const BREADCRUMB_ITEMS = [
   { label: "Home", href: "/" },
@@ -15,28 +13,10 @@ const BREADCRUMB_ITEMS = [
   { label: "History" },
 ];
 
-export default function PublicationHistoryPage() {
-  const [entries, setEntries] = useState<WithChanges<FullHistoryEntry>[]>();
-
-  useEffect(() => {
-    // `run` already surfaces a notification on failure.
-    fullHistory()
-      .then(setEntries)
-      .catch(() => {});
-  }, []);
-
-  // Name the entry and let the server work out which action compensates it.
-  // On success reload the feed: the undo is itself a new entry, and it may have
-  // changed what else is still undoable. Awaited, not fired and forgotten — the
-  // feed keeps the row spinning until this resolves, so the button never goes
-  // idle over a stale list.
-  async function handleUndo(entry: FullHistoryEntry) {
-    if (await undo(entry.publicationId, entry.version)) {
-      await fullHistory()
-        .then(setEntries)
-        .catch(() => {});
-    }
-  }
+export default async function PublicationHistoryPage() {
+  const { entries } = await read<{ entries: FullHistoryEntry[] }>(
+    "/publications/history",
+  );
 
   return (
     <Layout
@@ -50,13 +30,7 @@ export default function PublicationHistoryPage() {
         </>
       }
       measure="centered"
-      content={
-        entries === undefined ? (
-          <p className="text-sm text-gray-600">Loading…</p>
-        ) : (
-          <PublicationHistoryFeed entries={entries} onUndo={handleUndo} />
-        )
-      }
+      content={<HistoryFeed entries={withChanges(entries)} />}
     />
   );
 }

--- a/frontend/app/api.ts
+++ b/frontend/app/api.ts
@@ -1,0 +1,27 @@
+import { SESSION_COOKIE } from "modules/api";
+import HTTP from "modules/http";
+import { cookies } from "next/headers";
+
+const api = HTTP.client({ baseURL: process.env.NEXT_INTERNAL_API_URL });
+
+/**
+ * Read from the backend inside a server component, as the signed-in user.
+ *
+ * The browser's `rb-session` is httpOnly, so a server render has to forward it
+ * explicitly — the same move `getSession` makes, and the reason a page can be
+ * rendered on the server at all without losing who is asking. Admin endpoints
+ * answer 401 without it, which surfaces as a thrown error and so as the route's
+ * error boundary rather than a page that renders empty and lies.
+ *
+ * Responses come back camelCased, since this is the same client the browser
+ * uses.
+ */
+export async function read<T>(path: string): Promise<T> {
+  const cookie = (await cookies()).get(SESSION_COOKIE);
+
+  const { data } = await api.get<T>(path, {
+    headers: cookie ? { Cookie: `${cookie.name}=${cookie.value}` } : {},
+  });
+
+  return data;
+}


### PR DESCRIPTION
The history feed and the trash each fetched themselves on mount, behind a loading branch. Both are a page's own content, so they are now read where the page is rendered.

`app/api.ts` is the one server reader: it forwards the httpOnly session cookie, so an admin page can be rendered on the server without losing who is asking. Each page hands its rows to the view it already had.

