### PR TITLE
Read a publication, and its log, from its address

### DIFF
--- a/frontend/app/Home.tsx
+++ b/frontend/app/Home.tsx
@@ -17,6 +17,7 @@ import {
 import PublicationSearch from "components/PublicationSearch";
 import SignInButton from "components/SignInButton";
 import SignOutButton from "components/SignOutButton";
+import type { PublicationView } from "app/publications/read";
 import { usePublicationIndexCount } from "modules/publication/hooks";
 import { usePublicationIndex } from "modules/publication/remote";
 import { resetAll } from "modules/publication/store";
@@ -25,7 +26,13 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
-export default function Home() {
+export default function Home({
+  opened,
+}: {
+  /** The publication the URL names, read on the server. Unawaited, so the
+   * overlay can open before it arrives. */
+  opened?: Promise<PublicationView | null>;
+}) {
   const index = usePublicationIndex();
   const isAuthenticated = useIsAuthenticated();
   const count = usePublicationIndexCount() || 0;
@@ -55,7 +62,7 @@ export default function Home() {
           <div className="sm:hidden">
             <PublicationIndexList onItemClick={handleRowClick} />
           </div>
-          <PublicationModal />
+          <PublicationModal view={opened} />
         </>
       }
       subheader={

--- a/frontend/app/admin/layout.tsx
+++ b/frontend/app/admin/layout.tsx
@@ -12,7 +12,7 @@ export default async function AdminLayout({
   children: ReactNode;
 }) {
   const session = await getSession();
-  if (!session || !User.isAdmin(session.role)) redirect("/");
+  if (!User.administers(session)) redirect("/");
 
   return children;
 }

--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -16,7 +16,7 @@ export default function AdminPage() {
           <PageHeader title="Admin tools" />
         </>
       }
-      measure="centered"
+      measure="aligned"
       content={<AdminMenu />}
     />
   );

--- a/frontend/app/admin/publications/deleted/page.tsx
+++ b/frontend/app/admin/publications/deleted/page.tsx
@@ -28,7 +28,7 @@ export default async function DeletedPublicationsPage() {
           />
         </>
       }
-      measure="centered"
+      measure="aligned"
       content={<DeletedPublications entries={entries} />}
     />
   );

--- a/frontend/app/admin/publications/history/page.tsx
+++ b/frontend/app/admin/publications/history/page.tsx
@@ -29,7 +29,7 @@ export default async function PublicationHistoryPage() {
           />
         </>
       }
-      measure="centered"
+      measure="aligned"
       content={<PublicationHistoryFeed entries={withChanges(entries)} />}
     />
   );

--- a/frontend/app/api/auth/callback/[provider]/route.ts
+++ b/frontend/app/api/auth/callback/[provider]/route.ts
@@ -84,7 +84,7 @@ export async function GET(
   }
 
   // Admin gate: only admins may sign in.
-  if (!user || !User.isAdmin(user.role)) {
+  if (!User.administers(user)) {
     return finish("/auth/error?error=AccessDenied");
   }
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,13 +1,25 @@
 import { Suspense } from "react";
 import Home from "./Home";
+import { readPublication } from "./publications/read";
 
 // Server Component shell — the interactive index lives in the client `Home`,
 // Suspense-wrapped because it reads `useSearchParams()` (App Router requires the
 // boundary so static rendering can bail to the client cleanly).
-export default function Page() {
+//
+// The publication the URL names is read here, from the address rather than from
+// whatever the index happens to have loaded. The promise is handed over
+// unawaited: the overlay opens on the URL alone and the record streams into it,
+// so a click is answered at once.
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ publication?: string }>;
+}) {
+  const { publication } = await searchParams;
+
   return (
     <Suspense>
-      <Home />
+      <Home opened={publication ? readPublication(publication) : undefined} />
     </Suspense>
   );
 }

--- a/frontend/app/publications/[id]/page.tsx
+++ b/frontend/app/publications/[id]/page.tsx
@@ -35,7 +35,7 @@ export default async function PublicationPage({
 
   return (
     <Layout
-      measure="centered"
+      measure="aligned"
       subheader={
         <>
           <Breadcrumb

--- a/frontend/app/publications/[id]/page.tsx
+++ b/frontend/app/publications/[id]/page.tsx
@@ -3,28 +3,22 @@ import Layout from "components/Layout";
 import PublicationDetail, {
   PublicationHeading,
 } from "components/PublicationDetail";
-import type { Publication } from "modules/publication/model";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
-import { cache } from "react";
 
-import { get } from "app/api";
+import { readPublication } from "../read";
 
-const publication = cache(async (id: string): Promise<Publication> => {
-  try {
-    return await get<Publication>(`/publications/${id}`);
-  } catch {
-    notFound();
-  }
-});
+async function read(id: string) {
+  return (await readPublication(id)) ?? notFound();
+}
 
 export async function generateMetadata({
   params,
 }: {
   params: Promise<{ id: string }>;
 }): Promise<Metadata> {
-  const { title, authors, originalTitle, originalAuthors, year } =
-    await publication((await params).id);
+  const { publication } = await read((await params).id);
+  const { title, authors, originalTitle, originalAuthors, year } = publication;
 
   return {
     title,
@@ -37,7 +31,7 @@ export default async function PublicationPage({
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const record = await publication((await params).id);
+  const { publication, history } = await read((await params).id);
 
   return (
     <Layout
@@ -45,14 +39,16 @@ export default async function PublicationPage({
       subheader={
         <>
           <Breadcrumb
-            items={[{ label: "Home", href: "/" }, { label: record.title }]}
+            items={[{ label: "Home", href: "/" }, { label: publication.title }]}
           />
           <div className="py-2">
-            <PublicationHeading publication={record} />
+            <PublicationHeading publication={publication} />
           </div>
         </>
       }
-      content={<PublicationDetail publication={record} />}
+      content={
+        <PublicationDetail publication={publication} history={history} />
+      }
     />
   );
 }

--- a/frontend/app/publications/read.ts
+++ b/frontend/app/publications/read.ts
@@ -36,7 +36,7 @@ export const readPublication = cache(
     // The log is admin-only, so asking for it as anyone else would only earn a
     // 401. Read it alongside the record rather than on a click: a change is part
     // of what the record *is*, not a detail to go fetch.
-    if (!session || !User.isAdmin(session.role)) return { publication };
+    if (!User.administers(session)) return { publication };
 
     const { entries } = await get<{ entries: PublicationHistoryEntry[] }>(
       `/publications/${id}/history`,

--- a/frontend/app/publications/read.ts
+++ b/frontend/app/publications/read.ts
@@ -23,9 +23,6 @@ export type PublicationView = {
  * Read a publication as the signed-in user, or `null` when there is nothing to
  * show — the record never existed, or has been deleted. Callers decide what that
  * means: a page answers 404, an overlay says the link is stale.
- *
- * `cache` memoises for the lifetime of the render, so a page, its metadata, and
- * its heading asking the same question cost one round trip.
  */
 export const readPublication = cache(
   async (id: string): Promise<PublicationView | null> => {

--- a/frontend/app/publications/read.ts
+++ b/frontend/app/publications/read.ts
@@ -1,0 +1,50 @@
+import { get } from "app/api";
+import { getSession } from "app/session";
+import { withChanges, type WithChanges } from "modules/publication/history";
+import type {
+  Publication,
+  PublicationHistoryEntry,
+} from "modules/publication/model";
+import { User } from "modules/users";
+import { cache } from "react";
+
+/**
+ * One publication with everything its reader is allowed to see: the record, and
+ * for an admin the mutation log behind it. Both are read together so a view
+ * renders complete instead of filling in after it is on screen.
+ */
+export type PublicationView = {
+  publication: Publication;
+  /** Present only for an admin — nobody else may read the log. */
+  history?: WithChanges<PublicationHistoryEntry>[];
+};
+
+/**
+ * Read a publication as the signed-in user, or `null` when there is nothing to
+ * show — the record never existed, or has been deleted. Callers decide what that
+ * means: a page answers 404, an overlay says the link is stale.
+ *
+ * `cache` memoises for the lifetime of the render, so a page, its metadata, and
+ * its heading asking the same question cost one round trip.
+ */
+export const readPublication = cache(
+  async (id: string): Promise<PublicationView | null> => {
+    const [publication, session] = await Promise.all([
+      get<Publication>(`/publications/${id}`).catch(() => null),
+      getSession(),
+    ]);
+
+    if (!publication) return null;
+
+    // The log is admin-only, so asking for it as anyone else would only earn a
+    // 401. Read it alongside the record rather than on a click: a change is part
+    // of what the record *is*, not a detail to go fetch.
+    if (!session || !User.isAdmin(session.role)) return { publication };
+
+    const { entries } = await get<{ entries: PublicationHistoryEntry[] }>(
+      `/publications/${id}/history`,
+    );
+
+    return { publication, history: withChanges(entries) };
+  },
+);

--- a/frontend/app/session.ts
+++ b/frontend/app/session.ts
@@ -2,13 +2,15 @@ import { SESSION_COOKIE } from "modules/api";
 import HTTP from "modules/http";
 import type { User } from "modules/users";
 import { cookies } from "next/headers";
+import { cache } from "react";
 
 const api = HTTP.client({ baseURL: process.env.NEXT_INTERNAL_API_URL });
 
 // Read the httpOnly rb-session cookie server-side and ask the backend who the
-// user is (GET /users/me → user or null). Fetched in the root layout (provided
-// app-wide via SessionProvider) and re-checked by the admin layout guard.
-export async function getSession(): Promise<User | null> {
+// user is (GET /users/me → user or null). Asked for in several places while one
+// page renders — the root layout, the admin guard, a record deciding whether to
+// read its log — and answered once.
+export const getSession = cache(async (): Promise<User | null> => {
   const cookie = (await cookies()).get(SESSION_COOKIE);
   if (!cookie) return null;
 
@@ -20,4 +22,4 @@ export async function getSession(): Promise<User | null> {
   } catch {
     return null;
   }
-}
+});

--- a/frontend/components/CopyLink.mdx
+++ b/frontend/components/CopyLink.mdx
@@ -13,20 +13,25 @@ no use to them.
 It earns its place where the address is not already on screen. Inside the
 [publication modal](?path=/docs/publications-publication-modal--docs) the URL
 bar still shows the index underneath, so a reader has nothing to select; the
-button copies the publication's own page
+control copies the publication's own page
 (`/publications/:id`) instead of whatever the overlay left in the address.
+
+It is drawn as a **bare icon**, sitting in the heading beside whatever it
+addresses: sharing is an aside to reading, so it should be reachable without
+competing with the record itself. The label is carried by the accessible name
+and a tooltip rather than by visible text.
 
 ## Props
 
 - `href` — the path to copy, made absolute against the current origin.
-- `label` — defaults to "Copy link".
+- `label` — defaults to "Copy link"; used as the accessible name and tooltip.
 
 ## Feedback
 
-Two confirmations, deliberately: the button itself says **Copied** for a couple
-of seconds, because that is where the reader is already looking, and a
-notification carries the URL for anyone who wants to see what was taken. A
-browser that refuses the clipboard says so and shows the address rather than
-failing silently.
+Two confirmations, deliberately: the icon turns green and renames itself
+**Copied** for a couple of seconds, because that is where the reader is already
+looking, and a notification carries the URL for anyone who wants to see what was
+taken. A browser that refuses the clipboard says so and shows the address rather
+than failing silently.
 
 <Canvas of={CopyLinkStories.Default} />

--- a/frontend/components/CopyLink.tsx
+++ b/frontend/components/CopyLink.tsx
@@ -3,7 +3,7 @@
 import CopyIcon from "assets/copy.svg";
 import { notify } from "components/Notifications";
 import { FC, useState } from "react";
-import Button from "./Button";
+import Tooltip from "./Tooltip";
 
 /**
  * Copy a link to the current record, absolute so it can be sent to someone
@@ -34,14 +34,21 @@ const CopyLink: FC<{ href: string; label?: string }> = ({
   }
 
   return (
-    <Button
-      label={copied ? "Copied" : label}
-      variant="outline"
-      width="fit"
-      size="medium"
-      Icon={CopyIcon}
-      onClick={handleCopy}
-    />
+    <Tooltip variant="info" message={copied ? "Copied" : label}>
+      <button
+        type="button"
+        aria-label={copied ? "Copied" : label}
+        data-copied={copied}
+        className="
+          flex p-1.5 rounded transition-colors shrink-0 focus-ring
+          text-gray-400 hover:text-indigo-600 hover:bg-indigo-50
+          data-[copied=true]:text-emerald-600
+        "
+        onClick={handleCopy}
+      >
+        <CopyIcon className="w-4 aspect-square" />
+      </button>
+    </Tooltip>
   );
 };
 

--- a/frontend/components/Layout.mdx
+++ b/frontend/components/Layout.mdx
@@ -19,6 +19,17 @@ pinned.
 - `leftAside` — an optional left rail beside the content.
 - `footer` — an optional sticky footer.
 
+## Measure
+
+- `full` (default) — the content fills the viewport. What the index and the bulk
+  workspace need from their tables.
+- `aligned` — the subheader and the content share one column of readable width,
+  both starting at the page's own gutter, where the header's content begins. The
+  pairing is the point: a page's breadcrumb and title line up with what they
+  introduce, instead of a narrow column floating in the middle of an empty page.
+
+<Canvas of={LayoutStories.AlignedMeasure} />
+
 ## Sticky column headers
 
 The header publishes its measured height as the `--app-header-h` CSS variable,

--- a/frontend/components/Layout.stories.tsx
+++ b/frontend/components/Layout.stories.tsx
@@ -59,14 +59,14 @@ export const AllSlots: Story = {
 };
 
 /**
- * `measure="centered"` holds the subheader and the content to one column, so a
- * page's breadcrumb and title line up with what they introduce. Without it a
- * narrow page reads as misaligned: the heading sits at the viewport edge while
- * the content floats in the middle.
+ * `measure="aligned"` holds the subheader and the content to one column of
+ * readable width, starting both at the page's gutter — where the header's own
+ * content begins. Without it a narrow page reads as misaligned: the heading sits
+ * at the viewport edge while the content floats in the middle.
  */
-export const CenteredMeasure: Story = {
+export const AlignedMeasure: Story = {
   args: {
-    measure: "centered",
+    measure: "aligned",
     subheader: <div data-testid="subheader">Breadcrumb and title</div>,
     content: <div data-testid="content">Page content</div>,
   },

--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -16,13 +16,13 @@ type Props = {
   leftAside?: ReactNode;
   /**
    * How the page is laid out across the viewport. `full` fills it, which is
-   * what the index and the bulk workspace need from their tables. `centered`
-   * holds the subheader and the content to one column and centres both — the
-   * pairing is the point, so a page's breadcrumb and title line up with what
-   * they introduce instead of drifting to the edge while the content sits in
-   * the middle.
+   * what the index and the bulk workspace need from their tables. `aligned`
+   * holds the subheader and the content to one column of readable width and
+   * starts both at the page's own gutter — so a page's breadcrumb, its title and
+   * what they introduce all begin where the header's content begins, instead of
+   * a narrow column floating in the middle of an empty page.
    */
-  measure?: "full" | "centered";
+  measure?: "full" | "aligned";
 };
 
 const HEADING_TEXT = "Richard & Isabel Burton Platform";
@@ -82,7 +82,7 @@ const Layout: FC<Props> = ({
         </h1>
         <div
           data-measure={measure}
-          className="data-[measure=centered]:mx-auto data-[measure=centered]:w-full data-[measure=centered]:max-w-3xl"
+          className="data-[measure=aligned]:w-full data-[measure=aligned]:max-w-5xl"
         >
           {subheader}
         </div>
@@ -91,7 +91,7 @@ const Layout: FC<Props> = ({
         {leftAside && <aside>{leftAside}</aside>}
         <main
           data-measure={measure}
-          className="relative grow pb-4 data-[measure=centered]:mx-auto data-[measure=centered]:w-full data-[measure=centered]:max-w-3xl"
+          className="relative grow pb-4 data-[measure=aligned]:w-full data-[measure=aligned]:max-w-5xl"
         >
           {content}
         </main>

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -95,7 +95,10 @@ const Modal: FC<Props> = ({ children, isOpen, onClose, label = "Dialog" }) => {
     }
   }
 
-  useHotkey(Key.ESCAPE, onClose);
+  // Only while open: a closed modal that still answers ESC does not just waste a
+  // press — a URL-driven one rewrites the whole query from its own reading of it,
+  // so it would put back the parameter the modal that *is* open just removed.
+  useHotkey(Key.ESCAPE, onClose, isOpen);
 
   const isWiderThanSmall = useMediaQuery({ query: "(min-width: 640px)" });
 

--- a/frontend/components/PublicationDetail.mdx
+++ b/frontend/components/PublicationDetail.mdx
@@ -13,27 +13,33 @@ by the stored code (`US`, not "United States of America").
 
 It takes the **record**, not an id. That is the point of it: whoever renders
 this decides where the publication came from — a page that read it on the
-server, or an overlay opened over the index — and the view itself neither
-fetches nor reads a store. Before this existed, the detail view could only show
-a publication the index had already loaded, so a link naming a record outside
-the current search rendered an empty dialog.
+server, or an overlay opened over the index — and the view itself does not
+fetch. Before this existed, the detail view could only show a publication the
+index had already loaded, so a link naming a record outside the current search
+rendered an empty dialog.
+
+An admin also gets the publication's mutation log and the controls to correct or
+remove it. Who may do what is settled here rather than by each caller, so the
+same publication offers the same affordances wherever it is read.
 
 <Canvas of={PublicationDetailStories.Default} />
 
 ## Props
 
 - `publication` — the record to show.
-- `actions` — admin affordances (edit, delete, the mutation log), passed in
-  rather than decided here. A signed-out reader and an admin get the same view;
-  only this slot differs.
 - `onNavigate` — called when a search link is followed. An overlay uses it to
   close itself; a page has nothing to close and omits it.
+- `onDeleted` — called once the record is gone. Defaults to leaving for the
+  index, which is what a page showing only this publication has to do; an
+  overlay closes instead and leaves the catalogue behind it in place.
 
 ## States
 
-- **Default** — a fully sourced record.
+- **Default** — a fully sourced record, read by anyone.
 - **Without references** — the section is omitted rather than shown empty.
-- **With actions** — the admin slot filled.
+- **As admin** — the history section and the edit/delete controls.
+- **Editing** — the form the Edit control opens, in place.
+- **Delete confirmation** — the guard in front of the destructive action.
 - **Notifies on navigate** — following a link tells the caller.
 
 <Canvas of={PublicationDetailStories.WithoutReferences} />

--- a/frontend/components/PublicationDetail.stories.tsx
+++ b/frontend/components/PublicationDetail.stories.tsx
@@ -1,9 +1,21 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { empty } from "modules/publication/model";
-import { expect, fn, screen, userEvent } from "storybook/test";
+import type { Decorator, Meta, StoryObj } from "@storybook/react";
+import { withChanges } from "modules/publication/history";
+import { empty, type PublicationHistoryEntry } from "modules/publication/model";
+import { resetAll } from "modules/publication/store";
+import { SessionProvider } from "modules/session";
+import { expect, fn, screen, userEvent, waitFor } from "storybook/test";
 
-import Button from "./Button";
 import PublicationDetail from "./PublicationDetail";
+
+const ADMIN = { email: "admin@rb.test", role: "admin" as const };
+
+/** Admin affordances are role-gated inside the view, so a story asks for them
+ * by signing in rather than by passing a prop. */
+const asAdmin: Decorator = (Story) => (
+  <SessionProvider session={ADMIN}>
+    <Story />
+  </SessionProvider>
+);
 
 const DOM_CASMURRO = {
   ...empty(),
@@ -20,6 +32,31 @@ const DOM_CASMURRO = {
     "Gledson, John. Deceptive Realism, 1984.",
   ],
 };
+
+// The log an admin's read brings back with the record.
+const LOG: PublicationHistoryEntry[] = [
+  {
+    version: 2,
+    undoable: true,
+    action: "updated",
+    actor: "curator@rb.test",
+    timestamp: "2026-07-15T11:00:00",
+    snapshot: { ...DOM_CASMURRO, year: 1953 },
+    diff: {
+      fields: { year: { from: "1952", to: "1953" } },
+      references: null,
+    },
+  },
+  {
+    version: 1,
+    undoable: false,
+    action: "created",
+    actor: "admin@rb.test",
+    timestamp: "2026-07-01T10:00:00",
+    snapshot: { ...DOM_CASMURRO, year: 1952 },
+    diff: null,
+  },
+];
 
 const meta = {
   title: "Publications/Publication detail",
@@ -66,15 +103,72 @@ export const WithoutReferences: Story = {
 };
 
 /**
- * Admin affordances are passed in rather than decided here, so the view is the
- * same one a signed-out reader gets.
+ * An admin gets the record's history and the controls to correct or remove it.
+ * The gate is here rather than in each caller, so the publication offers the
+ * same affordances wherever it is read.
  */
-export const WithActions: Story = {
-  args: {
-    actions: <Button label="Edit" variant="outline-primary" width="fit" />,
-  },
+export const AsAdmin: Story = {
+  args: { history: withChanges(LOG) },
+  decorators: [asAdmin],
   play: async () => {
     await expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
+    await expect(screen.getByRole("button", { name: "Delete" })).toBeVisible();
+
+    // The log came with the record: its entries are in the document while the
+    // section is still collapsed, so expanding it fetches nothing.
+    await expect(screen.getByText(/Year:/)).toHaveTextContent(
+      "Year: 1952 → 1953",
+    );
+    await userEvent.click(screen.getByText("History"));
+    await expect(screen.getByText("created")).toBeVisible();
+  },
+};
+
+/**
+ * Editing happens in place, over the record it is about to change — there is no
+ * separate screen to navigate to and come back from.
+ */
+export const Editing: Story = {
+  decorators: [asAdmin],
+  beforeEach: () => resetAll(),
+  play: async () => {
+    await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    // The fields open on the record as it stands, not empty.
+    await waitFor(() =>
+      expect(screen.getByLabelText("Title")).toHaveValue("Dom Casmurro"),
+    );
+    await expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+
+    // Backing out returns the reader's view untouched.
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Edit" })).toBeVisible(),
+    );
+  },
+};
+
+/**
+ * Deleting is guarded: the control opens a confirmation naming the publication,
+ * and cancelling backs out without consequence. (The confirmed path needs the
+ * real backend — the E2E suite covers it.)
+ */
+export const DeleteConfirmation: Story = {
+  decorators: [asAdmin],
+  play: async () => {
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    const confirmation = await screen.findByRole("dialog", {
+      name: "Delete this publication?",
+    });
+    await expect(confirmation).toHaveTextContent(/Dom Casmurro.*1953/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "Delete this publication?" }),
+      ).not.toBeInTheDocument(),
+    );
   },
 };
 

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -200,11 +200,6 @@ const PublicationEditForm: FC<{
     if (saved) onSaved();
   }
 
-  function handleCancel() {
-    discardEdit(id);
-    onCancel();
-  }
-
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-5 w-full">
       <SectionHeading>Edit publication</SectionHeading>
@@ -224,7 +219,7 @@ const PublicationEditForm: FC<{
           variant="outline"
           width="fit"
           size="medium"
-          onClick={handleCancel}
+          onClick={onCancel}
         />
         <Button
           label="Save"

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -1,14 +1,40 @@
 "use client";
 
-import { Publication, type PublicationKey } from "modules/publication/model";
+import type { WithChanges } from "modules/publication/history";
+import {
+  useIsPublicationValid,
+  usePublicationErrorDescription,
+  usePublicationField,
+  usePublicationFieldError,
+  usePublicationReferences,
+} from "modules/publication/hooks";
+import {
+  Publication,
+  type PublicationHistoryEntry,
+  type PublicationId,
+  type PublicationKey,
+} from "modules/publication/model";
+import {
+  deletePublication,
+  update,
+  validateUpdate,
+} from "modules/publication/remote";
+import {
+  discardEdit,
+  overrideReferences,
+  remember,
+} from "modules/publication/store";
+import { useIsAdmin } from "modules/session";
 import Link from "next/link";
-import { FC, ReactNode } from "react";
+import { useRouter } from "next/navigation";
+import { FC, SubmitEvent, useEffect, useState } from "react";
+import Button from "./Button";
+import ConfirmationModal from "./ConfirmationModal";
+import DataInput from "./DataInput";
+import { useModal } from "./Modal";
+import PublicationHistory from "./PublicationHistory";
+import ReferencesEditor from "./ReferencesEditor";
 import Tooltip from "./Tooltip";
-
-/**
- * A publication as a reader sees it: the title and its translators, a sentence
- * placing it, and its sources.
- */
 
 const Searchable: FC<{
   label: string;
@@ -89,12 +115,16 @@ const PublicationDescription: FC<{
   );
 };
 
+const SectionHeading: FC<{ children: string }> = ({ children }) => (
+  <h2 className="text-sm font-medium tracking-wide text-gray-500 uppercase">
+    {children}
+  </h2>
+);
+
 const PublicationReferences: FC<{ references: string[] }> = ({ references }) =>
   references.length === 0 ? null : (
     <section className="space-y-2">
-      <h2 className="text-sm font-medium tracking-wide text-gray-500 uppercase">
-        References
-      </h2>
+      <SectionHeading>References</SectionHeading>
       <ul className="space-y-1.5 text-sm text-gray-700">
         {references.map((reference, index) => (
           <li key={index} className="flex gap-2.5 items-baseline">
@@ -109,19 +139,220 @@ const PublicationReferences: FC<{ references: string[] }> = ({ references }) =>
     </section>
   );
 
+/**
+ * The record's mutation log, collapsed. The entries arrive with the record, so
+ * expanding it costs nothing and shows everything at once.
+ */
+const PublicationHistorySection: FC<{
+  entries: WithChanges<PublicationHistoryEntry>[];
+}> = ({ entries }) => (
+  <details className="space-y-2">
+    <summary className="text-sm font-medium tracking-wide text-gray-500 uppercase cursor-pointer select-none">
+      History
+    </summary>
+    <PublicationHistory entries={entries} />
+  </details>
+);
+
+const EditField: FC<{ id: PublicationId; attribute: PublicationKey }> = ({
+  id,
+  attribute,
+}) => {
+  const value = usePublicationField(id, attribute);
+  const error = usePublicationFieldError(id, attribute);
+
+  return (
+    <div className="flex flex-col gap-1 text-sm">
+      <span className="text-gray-500">
+        {Publication.ATTRIBUTE_LABELS[attribute]}
+      </span>
+      <DataInput
+        rowId={id}
+        colId={attribute}
+        value={value}
+        error={error}
+        aria-label={Publication.ATTRIBUTE_LABELS[attribute]}
+        bordered
+        autoValidated
+        // A form has room to say what is wrong, in place.
+        errorDisplay="inline"
+        onValidate={() => validateUpdate(id)}
+      />
+    </div>
+  );
+};
+
+const PublicationEditForm: FC<{
+  id: PublicationId;
+  onSaved: () => void;
+  onCancel: () => void;
+}> = ({ id, onSaved, onCancel }) => {
+  const [saving, setSaving] = useState(false);
+  const error = usePublicationErrorDescription(id);
+  const isValid = useIsPublicationValid(id);
+  const references = usePublicationReferences(id);
+
+  async function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    const saved = await update(id);
+    setSaving(false);
+    if (saved) onSaved();
+  }
+
+  function handleCancel() {
+    discardEdit(id);
+    onCancel();
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-5 w-full">
+      <SectionHeading>Edit publication</SectionHeading>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {Publication.ATTRIBUTES.map((attribute) => (
+          <EditField key={attribute} id={id} attribute={attribute} />
+        ))}
+      </div>
+      <ReferencesEditor
+        value={references}
+        onChange={(next) => overrideReferences(id, next)}
+      />
+      {error && <p className="text-sm text-red-600">{error}</p>}
+      <div className="flex gap-3 justify-end">
+        <Button
+          label="Cancel"
+          variant="outline"
+          width="fit"
+          size="medium"
+          onClick={handleCancel}
+        />
+        <Button
+          label="Save"
+          type="submit"
+          width="fit"
+          size="medium"
+          loading={saving}
+          // Nothing to gain from a round-trip we know the server will reject.
+          // `saving` is included because Button lets an explicit `disabled`
+          // override its own `loading`-implies-disabled.
+          disabled={!isValid || saving}
+        />
+      </div>
+    </form>
+  );
+};
+
+/**
+ * A publication as a reader sees it: the title and its translators, a sentence
+ * placing it, and its sources — plus, for an admin, its history and the controls
+ * to correct or remove it.
+ *
+ * Takes the record — and the log behind it — rather than an id, so whoever
+ * renders it decides where those came from, and the view is complete the moment
+ * it appears instead of filling in afterwards. Who may do what is settled here
+ * rather than by each caller, so the same publication offers the same
+ * affordances wherever it is read.
+ *
+ * A save asks the server to render again: the heading, the breadcrumb, and the
+ * page title are drawn from the same record by whoever placed this view, and
+ * re-reading is the only way they cannot disagree with the body.
+ */
 const PublicationDetail: FC<{
   publication: Publication;
+  /**
+   * The record's mutation log, read alongside it. Present only for an admin,
+   * who is the only reader allowed it.
+   */
+  history?: WithChanges<PublicationHistoryEntry>[];
   /** Run when a search link is followed — an overlay uses it to close itself. */
   onNavigate?: () => void;
-  /** Controls the caller adds beneath the record — sharing, and admin affordances. */
-  actions?: ReactNode;
-}> = ({ publication, onNavigate, actions }) => (
-  <div className="space-y-6">
-    <PublicationDescription publication={publication} onNavigate={onNavigate} />
-    <PublicationReferences references={publication.references} />
-    {actions}
-  </div>
-);
+  /**
+   * Run once the record is gone. Defaults to leaving for the index, which is
+   * what a page showing only this publication has to do; an overlay closes
+   * instead and leaves the catalogue behind it in place.
+   */
+  onDeleted?: () => void;
+}> = ({ publication, history, onNavigate, onDeleted }) => {
+  const id = publication.id!;
+  const isAdmin = useIsAdmin();
+  const router = useRouter();
+
+  const [editing, setEditing] = useState(false);
+  const deleteConfirmation = useModal();
+  const [deleting, setDeleting] = useState(false);
+
+  // An edit abandoned by closing the view is dropped, not kept: the overlay it
+  // writes to is the same one the row behind it reads around.
+  useEffect(() => (editing ? () => discardEdit(id) : undefined), [editing, id]);
+
+  function startEditing() {
+    // The form edits the store's copy of the record, so a view that read it on
+    // the server has to hand it over before the fields can show anything.
+    remember(publication);
+    setEditing(true);
+  }
+
+  function handleSaved() {
+    setEditing(false);
+    router.refresh();
+  }
+
+  async function handleDelete() {
+    setDeleting(true);
+    const removed = await deletePublication(id);
+    setDeleting(false);
+    deleteConfirmation.close();
+    if (removed) (onDeleted ?? (() => router.replace("/")))();
+  }
+
+  return (
+    <div className="space-y-6">
+      {editing ? (
+        <PublicationEditForm
+          id={id}
+          onSaved={handleSaved}
+          onCancel={() => setEditing(false)}
+        />
+      ) : (
+        <>
+          <PublicationDescription
+            publication={publication}
+            onNavigate={onNavigate}
+          />
+          <PublicationReferences references={publication.references} />
+          {history && <PublicationHistorySection entries={history} />}
+          {isAdmin && (
+            <div className="flex gap-3">
+              <Button
+                label="Edit"
+                variant="outline-primary"
+                width="fit"
+                size="medium"
+                onClick={startEditing}
+              />
+              <Button
+                label="Delete"
+                variant="danger"
+                width="fit"
+                size="medium"
+                onClick={() => deleteConfirmation.open()}
+              />
+            </div>
+          )}
+        </>
+      )}
+      <ConfirmationModal
+        isOpen={deleteConfirmation.isOpen}
+        title="Delete this publication?"
+        message={`“${publication.title}” (${publication.year}) will be removed from the catalogue, its index, and search results.`}
+        confirmLabel="Delete"
+        loading={deleting}
+        onConfirm={handleDelete}
+        onCancel={deleteConfirmation.close}
+      />
+    </div>
+  );
+};
 
 export default PublicationDetail;
 export { PublicationHeading };

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -115,10 +115,11 @@ const PublicationDescription: FC<{
   );
 };
 
+const SECTION_HEADING =
+  "text-sm font-medium tracking-wide text-gray-500 uppercase";
+
 const SectionHeading: FC<{ children: string }> = ({ children }) => (
-  <h2 className="text-sm font-medium tracking-wide text-gray-500 uppercase">
-    {children}
-  </h2>
+  <h2 className={SECTION_HEADING}>{children}</h2>
 );
 
 const PublicationReferences: FC<{ references: string[] }> = ({ references }) =>
@@ -147,7 +148,7 @@ const PublicationHistorySection: FC<{
   entries: WithChanges<PublicationHistoryEntry>[];
 }> = ({ entries }) => (
   <details className="space-y-2">
-    <summary className="text-sm font-medium tracking-wide text-gray-500 uppercase cursor-pointer select-none">
+    <summary className={`${SECTION_HEADING} cursor-pointer select-none`}>
       History
     </summary>
     <PublicationHistory entries={entries} />

--- a/frontend/components/PublicationModal.mdx
+++ b/frontend/components/PublicationModal.mdx
@@ -6,40 +6,53 @@ import * as PublicationModalStories from "./PublicationModal.stories";
 
 # Publication modal
 
-A read-only detail view for a single publication, shown in a dialog. It's
-**URL-driven**: open state and which publication to show both come from the
-`?publication=<id>` query (via `useURLQueryModal`), and the record itself is read
-from the publication store (`usePublication`). No props — dropping `<PublicationModal />`
-into a page is enough; links elsewhere open it by setting the query.
+A detail view for a single publication, shown in a dialog. It's **URL-driven**:
+open state and which publication to show both come from the `?publication=<id>`
+query (via `useURLQueryModal`), so links elsewhere open it by setting the query.
+
+The record is **read on the server** from that address — the index page hands the
+promise over unawaited, and the overlay opens on the URL alone while the record
+streams into it. Two consequences: a click is answered at once rather than after
+a round trip, and a link to a publication outside the current search opens it all
+the same. (Before, the record came from the publication store, so such a link
+rendered an empty dialog.)
 
 ## What it renders
 
 The publication is laid out as a searchable [`Article`](?path=/docs/components-article--docs):
 the title and translators as the heading, and a prose description whose fields
 (original title, authors, countries, publishers) are `Searchable` links that
-navigate to a filtered index. Closing it clears the query param.
+navigate to a filtered index. The view itself is
+[`PublicationDetail`](?path=/docs/publications-publication-detail--docs), the same
+one the publication's own page renders; the overlay adds the heading and a subtle
+[copy link](?path=/docs/components-copy-link--docs) beside it, since the URL bar
+is still showing the catalogue underneath. Closing it clears the query param.
 
 <Canvas of={PublicationModalStories.Default} />
 
+## Props
+
+- `view` — a promise of the record read for that address, or of `null` when there
+  is nothing there. Unawaited on purpose; the overlay suspends on it.
+
 ## States
 
-- **Open** — with `?publication=<id>` present and that id in the store, the dialog
-  shows the publication (above).
-- **Closed** — without the query param the modal renders nothing (see the
-  [Closed](?path=/story/publications-publication-modal--closed) story).
+- **Open** — with `?publication=<id>` present, the dialog shows the record
+  (above).
+- **Closed** — without the query param the modal renders nothing.
+- **With history** — an admin's read brings the mutation log with the record.
+- **Missing** — a link to a deleted record says so instead of opening empty.
 
 ## Admin actions
 
-For admins the article gains an action row: **Edit** switches the dialog to an
+For an admin the view gains an action row: **Edit** switches the dialog to an
 inline edit form (`PUT /publications/:id` on save), and **Delete** removes the
 record server-side — guarded by a
 [confirmation](?path=/docs/components-confirmation-modal--docs) that names the
 publication before anything happens. Cancelling the confirmation backs out
 without consequence; confirming closes the dialog and drops the row from the
-index.
-
-Admins also get a collapsed **History** section — the record's
-[mutation log](?path=/docs/publications-publication-history--docs), fetched
-lazily on first expand.
+index. An admin also gets a collapsed **History** section — the record's
+[mutation log](?path=/docs/publications-publication-history--docs), read together
+with the record rather than fetched on expand.
 
 <Canvas of={PublicationModalStories.DeleteConfirmation} />

--- a/frontend/components/PublicationModal.stories.tsx
+++ b/frontend/components/PublicationModal.stories.tsx
@@ -1,5 +1,9 @@
-import type { Meta, StoryObj } from "@storybook/react";
-import { Publication } from "modules/publication/model";
+import type { Decorator, Meta, StoryObj } from "@storybook/react";
+import { withChanges } from "modules/publication/history";
+import {
+  Publication,
+  type PublicationHistoryEntry,
+} from "modules/publication/model";
 import { resetAll, setAll } from "modules/publication/store";
 import { SessionProvider } from "modules/session";
 import { expect, screen, userEvent, waitFor } from "storybook/test";
@@ -8,29 +12,67 @@ import { PublicationModal } from "./PublicationModal";
 
 const ADMIN = { email: "admin@rb.test", role: "admin" as const };
 
-const DOM_CASMURRO = {
+const asAdmin: Decorator = (Story) => (
+  <SessionProvider session={ADMIN}>
+    <Story />
+  </SessionProvider>
+);
+
+const PUBLICATION = {
+  ...Publication.empty(),
   id: 1,
-  publication: {
-    ...Publication.empty(),
-    title: "Dom Casmurro",
-    authors: "Helen Caldwell",
-    originalTitle: "Dom Casmurro",
-    originalAuthors: "Machado de Assis",
-    year: "1953",
-    countries: "US",
-    publishers: "Noonday Press",
-    references: [
-      "Caldwell, Helen. Introduction to Dom Casmurro. Noonday Press, 1953.",
-    ],
-  },
-  errors: null,
+  title: "Dom Casmurro",
+  authors: "Helen Caldwell",
+  originalTitle: "Dom Casmurro",
+  originalAuthors: "Machado de Assis",
+  year: "1953",
+  countries: "US",
+  publishers: "Noonday Press",
+  references: [
+    "Caldwell, Helen. Introduction to Dom Casmurro. Noonday Press, 1953.",
+  ],
 };
 
+const DOM_CASMURRO = { id: 1, publication: PUBLICATION, errors: null };
+
+const LOG: PublicationHistoryEntry[] = [
+  {
+    version: 2,
+    undoable: true,
+    action: "updated",
+    actor: "curator@rb.test",
+    timestamp: "2026-07-15T11:00:00",
+    snapshot: { ...PUBLICATION, year: 1953 },
+    diff: {
+      fields: { title: { from: "Dom Casmurro (draft)", to: "Dom Casmurro" } },
+      references: null,
+    },
+  },
+  {
+    version: 1,
+    undoable: false,
+    action: "created",
+    actor: "admin@rb.test",
+    timestamp: "2026-07-01T10:00:00",
+    snapshot: { ...PUBLICATION, title: "Dom Casmurro (draft)", year: 1953 },
+    diff: null,
+  },
+];
+
+// The record the URL names, read on the server and handed over unawaited. A
+// story stands in for that read with a promise of its own.
+const READER_VIEW = Promise.resolve({ publication: PUBLICATION });
+const ADMIN_VIEW = Promise.resolve({
+  publication: PUBLICATION,
+  history: withChanges(LOG),
+});
+
 // A URL-driven modal: it opens when the `?publication=<id>` query is present and
-// renders that publication (read from the store) as a searchable article.
+// shows the record read for that address as a searchable article.
 const meta = {
   title: "Publications/Publication modal",
   component: PublicationModal,
+  args: { view: READER_VIEW },
   parameters: { layout: "fullscreen" },
 } satisfies Meta<typeof PublicationModal>;
 
@@ -43,6 +85,46 @@ export const Closed: Story = {
   beforeEach: () => resetAll(),
   play: async () => {
     await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  },
+};
+
+/**
+ * An admin also gets the record's mutation log — and gets it *with* the record:
+ * the entries are already in the document while the section is still collapsed,
+ * so opening it fetches nothing.
+ */
+export const WithHistory: Story = {
+  args: { view: ADMIN_VIEW },
+  decorators: [asAdmin],
+  parameters: {
+    nextjs: { navigation: { query: { publication: "1" } } },
+    docs: { story: { inline: false, height: "30rem" } },
+  },
+  play: async () => {
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    await expect(screen.getByText(/Title:/)).toHaveTextContent(
+      "Title: Dom Casmurro (draft) → Dom Casmurro",
+    );
+    await expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+  },
+};
+
+/**
+ * A link to a record that has since been deleted says so, rather than opening
+ * an empty overlay.
+ */
+export const Missing: Story = {
+  args: { view: Promise.resolve(null) },
+  parameters: {
+    nextjs: { navigation: { query: { publication: "404" } } },
+    docs: { story: { inline: false, height: "20rem" } },
+  },
+  play: async () => {
+    await waitFor(() =>
+      expect(
+        screen.getByRole("heading", { name: "This publication is not here" }),
+      ).toBeInTheDocument(),
+    );
   },
 };
 
@@ -69,13 +151,7 @@ export const Default: Story = {
 
 export const Editing: Story = {
   beforeEach: () => setAll([DOM_CASMURRO]),
-  decorators: [
-    (Story) => (
-      <SessionProvider session={ADMIN}>
-        <Story />
-      </SessionProvider>
-    ),
-  ],
+  decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
     docs: { story: { inline: false, height: "30rem" } },
@@ -102,13 +178,7 @@ export const Editing: Story = {
  */
 export const EditingReferences: Story = {
   beforeEach: () => setAll([DOM_CASMURRO]),
-  decorators: [
-    (Story) => (
-      <SessionProvider session={ADMIN}>
-        <Story />
-      </SessionProvider>
-    ),
-  ],
+  decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
     docs: { story: { inline: false, height: "40rem" } },
@@ -147,13 +217,7 @@ export const EditingReferences: Story = {
  */
 export const EditingWithErrors: Story = {
   beforeEach: () => setAll([{ ...DOM_CASMURRO, errors: "conflict" }]),
-  decorators: [
-    (Story) => (
-      <SessionProvider session={ADMIN}>
-        <Story />
-      </SessionProvider>
-    ),
-  ],
+  decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
     docs: { story: { inline: false, height: "30rem" } },
@@ -177,13 +241,7 @@ export const EditingWithErrors: Story = {
  */
 export const DeleteConfirmation: Story = {
   beforeEach: () => setAll([DOM_CASMURRO]),
-  decorators: [
-    (Story) => (
-      <SessionProvider session={ADMIN}>
-        <Story />
-      </SessionProvider>
-    ),
-  ],
+  decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
     docs: { story: { inline: false, height: "30rem" } },
@@ -224,13 +282,7 @@ export const DeleteConfirmation: Story = {
  */
 export const EditingMenuAboveModal: Story = {
   beforeEach: () => setAll([DOM_CASMURRO]),
-  decorators: [
-    (Story) => (
-      <SessionProvider session={ADMIN}>
-        <Story />
-      </SessionProvider>
-    ),
-  ],
+  decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
     docs: { story: { inline: false, height: "30rem" } },

--- a/frontend/components/PublicationModal.tsx
+++ b/frontend/components/PublicationModal.tsx
@@ -1,249 +1,89 @@
 "use client";
 
-import type { WithChanges } from "modules/publication/history";
-import {
-  useIsPublicationValid,
-  usePublication,
-  usePublicationErrorDescription,
-  usePublicationField,
-  usePublicationFieldError,
-  usePublicationReferences,
-} from "modules/publication/hooks";
-import {
-  Publication,
-  type PublicationHistoryEntry,
-  type PublicationId,
-  type PublicationKey,
-} from "modules/publication/model";
-import {
-  deletePublication,
-  history,
-  update,
-  validateUpdate,
-} from "modules/publication/remote";
-import { discardEdit, overrideReferences } from "modules/publication/store";
-import { useIsAdmin } from "modules/session";
-import { FC, SubmitEvent, SyntheticEvent, useState } from "react";
-import { z } from "zod";
+import type { PublicationView } from "app/publications/read";
+import { FC, Suspense, use } from "react";
 import { Article } from "./Article";
-import Button from "./Button";
-import ConfirmationModal from "./ConfirmationModal";
 import CopyLink from "./CopyLink";
-import DataInput from "./DataInput";
-import { Modal, useModal, useURLQueryModal } from "./Modal";
+import { Modal, useURLQueryModal } from "./Modal";
 import PublicationDetail, { PublicationHeading } from "./PublicationDetail";
-import PublicationHistory from "./PublicationHistory";
-import ReferencesEditor from "./ReferencesEditor";
 
 const PUBLICATION_MODAL_KEY = "publication";
 
-const Param = z.string().regex(/^\d+$/).transform(Number).optional();
-type Param = z.infer<typeof Param>;
+const Loading: FC = () => (
+  <div className="p-8 w-full text-gray-400">Loading…</div>
+);
+
+const Missing: FC = () => (
+  <div className="p-8 w-full space-y-2">
+    <h1 className="text-2xl font-normal">This publication is not here</h1>
+    <p className="text-gray-700">
+      It has been removed from the catalogue, or the link names a record that
+      never existed.
+    </p>
+  </div>
+);
+
+const Opened: FC<{
+  view: Promise<PublicationView | null>;
+  onClose: () => void;
+}> = ({ view, onClose }) => {
+  const opened = use(view);
+
+  return opened === null ? (
+    <Missing />
+  ) : (
+    <Article
+      heading={
+        <>
+          <PublicationHeading publication={opened.publication} />
+          <CopyLink href={`/publications/${opened.publication.id}`} />
+        </>
+      }
+      content={
+        <PublicationDetail
+          publication={opened.publication}
+          history={opened.history}
+          onNavigate={onClose}
+          onDeleted={onClose}
+        />
+      }
+    />
+  );
+};
 
 /**
- * Admin-only, lazily loaded: the mutation log is fetched on first expand, so
- * opening the modal costs nothing extra and the section works offline in
- * Storybook (nothing fetches until a user opens it).
+ * A publication read over the index, addressed by the URL so the view survives
+ * a reload and can be linked to.
+ *
+ * The record is read on the server from the address itself, not taken from the
+ * index behind it — so a link to a publication outside the current search opens
+ * it all the same, and the mutation log arrives with it rather than after a
+ * click. The view is `PublicationDetail`, the same one the publication's own
+ * page renders; all this adds is the overlay and the address to copy, since the
+ * URL bar is still showing the catalogue underneath.
+ *
+ * The overlay opens on the URL alone and the record streams into it, so a click
+ * is answered at once instead of waiting on the server.
  */
-const PublicationHistorySection: FC<{ id: PublicationId }> = ({ id }) => {
-  const [entries, setEntries] =
-    useState<WithChanges<PublicationHistoryEntry>[]>();
-
-  async function handleToggle(event: SyntheticEvent<HTMLDetailsElement>) {
-    if (event.currentTarget.open && entries === undefined) {
-      setEntries(await history(id));
-    }
-  }
+const PublicationModal: FC<{ view?: Promise<PublicationView | null> }> = ({
+  view,
+}) => {
+  const modal = useURLQueryModal(PUBLICATION_MODAL_KEY);
 
   return (
-    <details className="space-y-2" onToggle={handleToggle}>
-      <summary className="text-sm font-medium tracking-wide text-gray-500 uppercase cursor-pointer select-none">
-        History
-      </summary>
-      {entries === undefined ? (
-        <p className="text-sm text-gray-400">Loading…</p>
+    <Modal
+      isOpen={modal.isOpen}
+      onClose={modal.close}
+      label="Publication details"
+    >
+      {view ? (
+        <Suspense fallback={<Loading />}>
+          <Opened view={view} onClose={modal.close} />
+        </Suspense>
       ) : (
-        <PublicationHistory entries={entries} />
+        <Loading />
       )}
-    </details>
-  );
-};
-
-const EditField: FC<{ id: PublicationId; attribute: PublicationKey }> = ({
-  id,
-  attribute,
-}) => {
-  const value = usePublicationField(id, attribute);
-  const error = usePublicationFieldError(id, attribute);
-
-  return (
-    <div className="flex flex-col gap-1 text-sm">
-      <span className="text-gray-500">
-        {Publication.ATTRIBUTE_LABELS[attribute]}
-      </span>
-      <DataInput
-        rowId={id}
-        colId={attribute}
-        value={value}
-        error={error}
-        aria-label={Publication.ATTRIBUTE_LABELS[attribute]}
-        bordered
-        autoValidated
-        // A form has room to say what is wrong, in place.
-        errorDisplay="inline"
-        onValidate={() => validateUpdate(id)}
-      />
-    </div>
-  );
-};
-
-const PublicationEditForm: FC<{ id: PublicationId; onDone: () => void }> = ({
-  id,
-  onDone,
-}) => {
-  const [saving, setSaving] = useState(false);
-  const error = usePublicationErrorDescription(id);
-  const isValid = useIsPublicationValid(id);
-  const references = usePublicationReferences(id);
-
-  async function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
-    event.preventDefault();
-    setSaving(true);
-    const saved = await update(id);
-    setSaving(false);
-    if (saved) onDone();
-  }
-
-  function handleCancel() {
-    discardEdit(id);
-    onDone();
-  }
-
-  return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-5 p-8 w-full">
-      <h1 className="text-2xl font-normal">Edit publication</h1>
-      <div className="grid gap-4 sm:grid-cols-2">
-        {Publication.ATTRIBUTES.map((attribute) => (
-          <EditField key={attribute} id={id} attribute={attribute} />
-        ))}
-      </div>
-      <ReferencesEditor
-        value={references}
-        onChange={(next) => overrideReferences(id, next)}
-      />
-      {error && <p className="text-sm text-red-600">{error}</p>}
-      <div className="flex gap-3 justify-end">
-        <Button
-          label="Cancel"
-          variant="outline"
-          width="fit"
-          size="medium"
-          onClick={handleCancel}
-        />
-        <Button
-          label="Save"
-          type="submit"
-          width="fit"
-          size="medium"
-          loading={saving}
-          // Nothing to gain from a round-trip we know the server will reject.
-          // `saving` is included because Button lets an explicit `disabled`
-          // override its own `loading`-implies-disabled.
-          disabled={!isValid || saving}
-        />
-      </div>
-    </form>
-  );
-};
-
-const PublicationModal: FC = () => {
-  const { value, ...modal } = useURLQueryModal(PUBLICATION_MODAL_KEY);
-
-  const publicationId = Param.parse(value);
-
-  const publication = usePublication(publicationId);
-  const isAdmin = useIsAdmin();
-
-  const [editingId, setEditingId] = useState<PublicationId>();
-  const editing = editingId !== undefined && editingId === publicationId;
-
-  const deleteConfirmation = useModal();
-  const [deleting, setDeleting] = useState(false);
-
-  function close() {
-    if (editing && publicationId !== undefined) discardEdit(publicationId);
-    modal.close();
-  }
-
-  async function handleDelete() {
-    if (publicationId === undefined) return;
-    setDeleting(true);
-    const removed = await deletePublication(publicationId);
-    setDeleting(false);
-    deleteConfirmation.close();
-    if (removed) modal.close();
-  }
-
-  return (
-    <>
-      <Modal isOpen={modal.isOpen} onClose={close} label="Publication details">
-        {publication &&
-          publicationId !== undefined &&
-          (editing ? (
-            <PublicationEditForm
-              id={publicationId}
-              onDone={() => setEditingId(undefined)}
-            />
-          ) : (
-            <Article
-              heading={<PublicationHeading publication={publication} />}
-              content={
-                <PublicationDetail
-                  publication={publication}
-                  onNavigate={modal.close}
-                  actions={
-                    <>
-                      <CopyLink href={`/publications/${publicationId}`} />
-                      {isAdmin && (
-                        <>
-                          <PublicationHistorySection id={publicationId} />
-                          <div className="flex gap-3">
-                            <Button
-                              label="Edit"
-                              variant="outline-primary"
-                              width="fit"
-                              size="medium"
-                              onClick={() => setEditingId(publicationId)}
-                            />
-                            <Button
-                              label="Delete"
-                              variant="danger"
-                              width="fit"
-                              size="medium"
-                              onClick={() => deleteConfirmation.open()}
-                            />
-                          </div>
-                        </>
-                      )}
-                    </>
-                  }
-                />
-              }
-            />
-          ))}
-      </Modal>
-      {publication && (
-        <ConfirmationModal
-          isOpen={deleteConfirmation.isOpen}
-          title="Delete this publication?"
-          message={`“${publication.title}” (${publication.year}) will be removed from the catalogue, its index, and search results.`}
-          confirmLabel="Delete"
-          loading={deleting}
-          onConfirm={handleDelete}
-          onCancel={deleteConfirmation.close}
-        />
-      )}
-    </>
+    </Modal>
   );
 };
 

--- a/frontend/e2e/correct-a-publication.spec.ts
+++ b/frontend/e2e/correct-a-publication.spec.ts
@@ -57,11 +57,15 @@ test("an admin edits a publication's title and references in a corpus", async ({
   await expect(
     dialog.getByRole("heading", { name: "Edit publication" }),
   ).toHaveCount(0);
+  // `exact`: the history section is in the document from the start now, and its
+  // diff names the same reference with a "+ " in front.
   await expect(
-    dialog.getByText("Pontiero, Giovanni. Afterword."),
+    dialog.getByText("Pontiero, Giovanni. Afterword.", { exact: true }),
   ).toBeVisible();
   await expect(
-    dialog.getByText("Moser, Benjamin. Why This World, 2009."),
+    dialog.getByText("Moser, Benjamin. Why This World, 2009.", {
+      exact: true,
+    }),
   ).toBeVisible();
 
   // The edit landed in the history log: expanding the (admin-only) History
@@ -158,4 +162,58 @@ test("editing a publication into a copy of another is rejected as a conflict", a
     dialog.getByText("A publication with this data already exists"),
   ).toBeVisible();
   await expect(dialog.getByRole("button", { name: "Save" })).toBeDisabled();
+});
+
+test("an admin arrives by link and corrects the publication on its own page", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/");
+
+  // Take the record's address from the index, then arrive the way a link does.
+  await openPublicationModal(page, "Barren Lives");
+  const id = new URL(page.url()).searchParams.get("publication");
+  await page.goto(`/publications/${id}`);
+
+  // The page offers what the overlay offers, with no catalogue behind it.
+  await expect(page.getByRole("dialog")).toHaveCount(0);
+  await expect(page.getByText("Iraçéma the Honey-Lips")).toHaveCount(0);
+
+  await page.getByRole("button", { name: "Edit" }).click();
+  const year = page.getByRole("textbox", { name: "Year", exact: true });
+  await year.fill("1972");
+  await year.blur();
+  await page.getByRole("button", { name: "Save" }).click();
+
+  // The body, the heading and the breadcrumb agree after the save: the page
+  // re-reads the record rather than patching what it already drew.
+  await expect(
+    page.getByRole("heading", { name: "Edit publication" }),
+  ).toHaveCount(0);
+  await expect(
+    page.getByText(/in 1972 by University of Texas Press/),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("navigation", { name: "Breadcrumb" }),
+  ).toContainText("Barren Lives");
+
+  // The mutation log is here too, naming the change just made.
+  await page.getByText("History", { exact: true }).click();
+  await expect(page.getByText("Year: 1965 → 1972")).toBeVisible();
+
+  // Deleting from a page that shows only this record leaves for the index,
+  // since there is nothing left to show.
+  await page.getByRole("button", { name: "Delete" }).click();
+  await page
+    .getByRole("dialog", { name: "Delete this publication?" })
+    .getByRole("button", { name: "Delete" })
+    .click();
+
+  const table = indexTable(page);
+  await expect(table.getByText("Dom Casmurro").first()).toBeVisible();
+  await expect(table.getByText("Barren Lives")).toHaveCount(0);
+
+  // The link now says the record is gone rather than rendering an empty page.
+  const response = await page.goto(`/publications/${id}`);
+  expect(response?.status()).toBe(404);
 });

--- a/frontend/modules/publication/remote.spec.ts
+++ b/frontend/modules/publication/remote.spec.ts
@@ -8,8 +8,6 @@ import { empty } from "./model";
 import {
   bulk,
   deletePublication,
-  fullHistory,
-  history,
   index,
   restore,
   undo,
@@ -268,55 +266,6 @@ describe("remove", () => {
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ level: "warning" }),
     );
-  });
-});
-
-describe("history", () => {
-  test("GETs the publication's mutation log", async () => {
-    const entries = [
-      { version: 1, action: "created", actor: "importer@rb.test", diff: null },
-    ];
-    http.get.mockResolvedValue({ data: { entries } });
-
-    const result = await history(7);
-
-    expect(http.get).toHaveBeenCalledWith("publications/7/history");
-    expect(result).toEqual([{ ...entries[0], changes: [] }]);
-  });
-
-  test("resolves each entry's changes from the server's diff", async () => {
-    const entries = [
-      {
-        version: 2,
-        action: "updated",
-        actor: "admin@rb.test",
-        diff: {
-          fields: { title: { from: "Before", to: "After" } },
-          references: null,
-        },
-      },
-    ];
-    http.get.mockResolvedValue({ data: { entries } });
-
-    const [entry] = await history(7);
-
-    expect(entry.changes).toEqual([
-      { kind: "field", label: "Title", from: "Before", to: "After" },
-    ]);
-  });
-});
-
-describe("fullHistory", () => {
-  test("GETs the catalogue-wide feed", async () => {
-    const entries = [
-      { publicationId: 7, version: 1, action: "created", diff: null },
-    ];
-    http.get.mockResolvedValue({ data: { entries } });
-
-    const result = await fullHistory();
-
-    expect(http.get).toHaveBeenCalledWith("publications/history");
-    expect(result).toEqual([{ ...entries[0], changes: [] }]);
   });
 });
 

--- a/frontend/modules/publication/remote.ts
+++ b/frontend/modules/publication/remote.ts
@@ -7,14 +7,7 @@ import hash from "object-hash";
 import { useCallback } from "react";
 import useDebounce from "utils/useDebounce";
 
-import { withChanges } from "./history";
-import type { WithChanges } from "./history";
-import type {
-  DeletedPublicationEntry,
-  FullHistoryEntry,
-  Publication,
-  PublicationHistoryEntry,
-} from "./model";
+import type { Publication, PublicationHistoryEntry } from "./model";
 import {
   PublicationError,
   PublicationId,
@@ -201,46 +194,6 @@ async function deletePublication(id: PublicationId): Promise<boolean> {
 }
 
 /**
- * A publication's mutation log (admin), newest first.
- *
- * Both history calls resolve each entry's changes here, on the way in, so views
- * render a ready list instead of diffing during paint.
- */
-async function history(
-  id: PublicationId,
-): Promise<WithChanges<PublicationHistoryEntry>[]> {
-  return run(async (http) => {
-    const { data } = await http.get<{ entries: PublicationHistoryEntry[] }>(
-      `publications/${id}/history`,
-    );
-    return withChanges(data.entries);
-  });
-}
-
-/** Every recorded change across the catalogue (admin), newest first. */
-async function fullHistory(): Promise<WithChanges<FullHistoryEntry>[]> {
-  return run(async (http) => {
-    const { data } = await http.get<{ entries: FullHistoryEntry[] }>(
-      "publications/history",
-    );
-    return withChanges(data.entries);
-  });
-}
-
-/**
- * The publications that are currently deleted (admin), most recently deleted
- * first — the trash's own state, not the log's record of deletion events.
- */
-async function deleted(): Promise<DeletedPublicationEntry[]> {
-  return run(async (http) => {
-    const { data } = await http.get<{ entries: DeletedPublicationEntry[] }>(
-      "publications/deleted",
-    );
-    return data.entries;
-  });
-}
-
-/**
  * Undo one recorded change (admin), naming the entry rather than describing the
  * result: the server decides which action compensates it and what state that
  * produces. A new entry lands in the log — history is never rewritten — so the
@@ -388,9 +341,6 @@ function usePublicationIndex() {
 
 export {
   bulk,
-  deleted,
-  fullHistory,
-  history,
   index,
   deletePublication,
   restore,

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -281,6 +281,16 @@ function hydrate(publications: Publication[]): PublicationId[] {
   return ids;
 }
 
+/**
+ * Make one saved publication known to the store without claiming it is the
+ * working set — the counterpart of `forget`, and what a surface showing a single
+ * record (a publication's own page) needs before it can be edited, since the
+ * form edits the store's copy.
+ */
+function remember(publication: Publication): void {
+  store.set(publicationFamily(publication.id!), publication);
+}
+
 function setAll(entries: PublicationEntry[]): void {
   store.set(
     publicationIdsAtom,
@@ -482,6 +492,7 @@ export {
   publicationIdsAtom,
   publicationOrNullFamily,
   publicationReferencesFamily,
+  remember,
   removePublication,
   resetAll,
   resetAttributes,

--- a/frontend/modules/session.tsx
+++ b/frontend/modules/session.tsx
@@ -31,6 +31,5 @@ export function useIsAuthenticated(): boolean {
 }
 
 export function useIsAdmin(): boolean {
-  const session = useSession();
-  return session != null && User.isAdmin(session.role);
+  return User.administers(useSession());
 }

--- a/frontend/modules/users.ts
+++ b/frontend/modules/users.ts
@@ -5,6 +5,8 @@ interface UserModule {
   isAdmin(role: UserRole): role is "admin";
   isReader(role: UserRole): role is "reader";
   isContributor(role: UserRole): role is "contributor";
+  /** Whether a session — possibly none at all — may administer the catalogue. */
+  administers(session: User | null | undefined): boolean;
 }
 
 // Pure, server-safe user helpers — usable from route handlers / Server
@@ -21,6 +23,10 @@ const User: UserModule = {
 
   isContributor(role): role is "contributor" {
     return role === "contributor";
+  },
+
+  administers(session) {
+    return session != null && User.isAdmin(session.role);
   },
 };
 

--- a/frontend/utils/useHotkey.spec.ts
+++ b/frontend/utils/useHotkey.spec.ts
@@ -61,4 +61,32 @@ describe("useHotkey", () => {
 
     expect(handle).toHaveBeenCalledTimes(2);
   });
+  test("a disabled hotkey does not answer the press", () => {
+    const handle = vi.fn();
+    renderHook(() => useHotkey(Key.ESCAPE, handle, false));
+
+    fireEvent.keyDown(document, { key: Key.ESCAPE });
+
+    expect(handle).not.toHaveBeenCalled();
+  });
+
+  test("enabling and disabling follows the flag, so a hidden component stops answering", () => {
+    const handle = vi.fn();
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useHotkey(Key.ESCAPE, handle, enabled),
+      { initialProps: { enabled: true } },
+    );
+
+    fireEvent.keyDown(document, { key: Key.ESCAPE });
+    expect(handle).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: false });
+    fireEvent.keyDown(document, { key: Key.ESCAPE });
+    expect(handle).toHaveBeenCalledTimes(1);
+
+    rerender({ enabled: true });
+    fireEvent.keyDown(document, { key: Key.ESCAPE });
+    expect(handle).toHaveBeenCalledTimes(2);
+  });
 });

--- a/frontend/utils/useHotkey.ts
+++ b/frontend/utils/useHotkey.ts
@@ -1,13 +1,25 @@
 import isHotkey from "is-hotkey";
 import { useEffect } from "react";
 
+/**
+ * Run `handle` when the hotkey is pressed anywhere in the document.
+ *
+ * `enabled` takes a component out of the running without unmounting it: a
+ * key press belongs to whatever is on screen, so a hidden component must not
+ * answer for it. Several listeners can match one press, and they all run — so
+ * one that should be dormant is not merely useless, it can undo the work of the
+ * one that should have acted.
+ */
 function useHotkey(
   hotkey: string | string[],
   handle: (event: KeyboardEvent) => void,
+  enabled = true,
 ) {
   const hotkeys = Array.isArray(hotkey) ? hotkey : [hotkey];
 
   useEffect(() => {
+    if (!enabled) return;
+
     function handleKeyDown(event: KeyboardEvent) {
       if (isHotkey(hotkeys, { byKey: true })(event)) handle(event);
     }
@@ -18,7 +30,7 @@ function useHotkey(
       document.removeEventListener("keydown", handleKeyDown);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [...hotkeys, handle]);
+  }, [...hotkeys, handle, enabled]);
 }
 
 export { useHotkey };


### PR DESCRIPTION
The overlay showed whatever the index had already loaded and asked for the record's mutation log only once a reader expanded it — so part of the record arrived after the rest.

Both now come from the address, read together on the server. The index page hands the overlay an unawaited promise, which the client unwraps inside a Suspense boundary: the overlay still opens on the click, and the record streams into it. The view itself owns everything a publication offers — its log, and for an admin the controls to correct or remove it — rather than taking them from each caller, so the overlay and the publication's page offer the same thing.

Two smaller changes ride along. Escape had stopped closing the modal: every mounted modal was listening, and each URL-driven one rewrites the whole query from its own reading of it, so a closed one put back the parameter the open one had just removed. And a page's column now starts at the page's own gutter instead of floating in the middle of an empty page.

Stacked on #390.
