### PR TITLE
Give each workspace its own publication state

### DIFF
--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -6,11 +6,6 @@ import "../styles/globals.css";
 import "./preview.css";
 
 const preview: Preview = {
-  // Every story runs inside a publication workspace, so components that read or
-  // write publication state work as they do in the app. It is handed one shared
-  // store rather than a fresh one per story, because a story seeds its state in
-  // `beforeEach` — before the tree exists — and has to name the store it seeds
-  // (see modules/publication/fixtures).
   decorators: [
     (Story) => (
       <PublicationStoreProvider store={store}>

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,18 +1,21 @@
 import type { Preview } from "@storybook/nextjs-vite";
-import { Provider } from "jotai";
+import { PublicationStoreProvider } from "modules/publication/workspace";
 import { store } from "modules/store";
 
 import "../styles/globals.css";
 import "./preview.css";
 
 const preview: Preview = {
-  // Every story runs inside the app's Jotai store, so publication components can
-  // be seeded with the store's actions (see modules/publication/fixtures).
+  // Every story runs inside a publication workspace, so components that read or
+  // write publication state work as they do in the app. It is handed one shared
+  // store rather than a fresh one per story, because a story seeds its state in
+  // `beforeEach` — before the tree exists — and has to name the store it seeds
+  // (see modules/publication/fixtures).
   decorators: [
     (Story) => (
-      <Provider store={store}>
+      <PublicationStoreProvider store={store}>
         <Story />
-      </Provider>
+      </PublicationStoreProvider>
     ),
   ],
   parameters: {

--- a/frontend/app/Home.tsx
+++ b/frontend/app/Home.tsx
@@ -19,30 +19,40 @@ import SignInButton from "components/SignInButton";
 import SignOutButton from "components/SignOutButton";
 import type { PublicationView } from "app/publications/read";
 import { usePublicationIndexCount } from "modules/publication/hooks";
-import { usePublicationStore } from "modules/publication/workspace";
 import { usePublicationIndex } from "modules/publication/remote";
-import { resetAll } from "modules/publication/store";
+import { PublicationStoreProvider } from "modules/publication/workspace";
 import { useIsAuthenticated } from "modules/session";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
-export default function Home({
-  opened,
-}: {
+type Props = {
   /** The publication the URL names, read on the server. Unawaited, so the
    * overlay can open before it arrives. */
   opened?: Promise<PublicationView | null>;
-}) {
-  const store = usePublicationStore();
+};
+
+/**
+ * The catalogue: the index and everything that acts on it — search, the column
+ * menu, the counter, the export, and the overlay for one publication. They read
+ * and write one working set, so the state they share is held here, around all of
+ * them, rather than asked of whatever renders this.
+ */
+export default function Home(props: Props) {
+  return (
+    <PublicationStoreProvider>
+      <Catalogue {...props} />
+    </PublicationStoreProvider>
+  );
+}
+
+function Catalogue({ opened }: Props) {
   const index = usePublicationIndex();
   const isAuthenticated = useIsAuthenticated();
   const count = usePublicationIndexCount() || 0;
 
   const searchParams = useSearchParams();
   const search = searchParams?.get("search") ?? undefined;
-
-  useEffect(() => resetAll(store), [store]);
 
   useEffect(() => {
     index({ search });

--- a/frontend/app/Home.tsx
+++ b/frontend/app/Home.tsx
@@ -19,6 +19,7 @@ import SignInButton from "components/SignInButton";
 import SignOutButton from "components/SignOutButton";
 import type { PublicationView } from "app/publications/read";
 import { usePublicationIndexCount } from "modules/publication/hooks";
+import { usePublicationStore } from "modules/publication/workspace";
 import { usePublicationIndex } from "modules/publication/remote";
 import { resetAll } from "modules/publication/store";
 import { useIsAuthenticated } from "modules/session";
@@ -33,6 +34,7 @@ export default function Home({
    * overlay can open before it arrives. */
   opened?: Promise<PublicationView | null>;
 }) {
+  const store = usePublicationStore();
   const index = usePublicationIndex();
   const isAuthenticated = useIsAuthenticated();
   const count = usePublicationIndexCount() || 0;
@@ -40,7 +42,7 @@ export default function Home({
   const searchParams = useSearchParams();
   const search = searchParams?.get("search") ?? undefined;
 
-  useEffect(() => resetAll(), []);
+  useEffect(() => resetAll(store), [store]);
 
   useEffect(() => {
     index({ search });

--- a/frontend/app/Home.tsx
+++ b/frontend/app/Home.tsx
@@ -32,12 +32,6 @@ type Props = {
   opened?: Promise<PublicationView | null>;
 };
 
-/**
- * The catalogue: the index and everything that acts on it — search, the column
- * menu, the counter, the export, and the overlay for one publication. They read
- * and write one working set, so the state they share is held here, around all of
- * them, rather than asked of whatever renders this.
- */
 export default function Home(props: Props) {
   return (
     <PublicationStoreProvider>

--- a/frontend/app/admin/publications/new/page.tsx
+++ b/frontend/app/admin/publications/new/page.tsx
@@ -34,11 +34,6 @@ const BREADCRUMB_ITEMS = [
   { label: "Add publications" },
 ];
 
-/**
- * How this workspace starts: an empty working set — so the draft row is there to
- * type into rather than a loading skeleton — with every column shown, since a
- * contributor is filling all of them.
- */
 function startEmpty(store: Store) {
   setAll(store, []);
   setAttributesVisible(store, Publication.ATTRIBUTES);
@@ -48,8 +43,6 @@ function NewPublications() {
   const store = usePublicationStore();
   const isSelectionEmpty = useIsSelectionEmpty();
 
-  // The store goes with this page, but the atom *caches* are module-level and
-  // outlive it — so drop what this workspace put in them on the way out.
   useEffect(() => () => resetAll(store), [store]);
 
   return (

--- a/frontend/app/admin/publications/new/page.tsx
+++ b/frontend/app/admin/publications/new/page.tsx
@@ -23,6 +23,7 @@ import {
 } from "modules/publication/store";
 import ClearSelection from "listeners/ClearSelection";
 import { PublicationStoreProvider } from "modules/publication/workspace";
+import type { Store } from "modules/store";
 import { useIsSelectionEmpty } from "modules/selection";
 import { useEffect } from "react";
 
@@ -32,12 +33,22 @@ const BREADCRUMB_ITEMS = [
   { label: "Add publications" },
 ];
 
+/**
+ * How this workspace starts: an empty working set — so the draft row is there to
+ * type into rather than a loading skeleton — with every column shown, since a
+ * contributor is filling all of them.
+ */
+function startEmpty(store: Store) {
+  setAll(store, []);
+  setAttributesVisible(store, Publication.ATTRIBUTES);
+}
+
 function NewPublications() {
   const store = usePublicationStore();
   const isSelectionEmpty = useIsSelectionEmpty();
 
-  useEffect(() => setAll(store, []), [store]);
-  useEffect(() => setAttributesVisible(store, Publication.ATTRIBUTES), [store]);
+  // The store goes with this page, but the atom *caches* are module-level and
+  // outlive it — so drop what this workspace put in them on the way out.
   useEffect(() => () => resetAll(store), [store]);
 
   return (
@@ -84,7 +95,7 @@ function NewPublications() {
 
 export default function NewPublicationsPage() {
   return (
-    <PublicationStoreProvider>
+    <PublicationStoreProvider initialize={startEmpty}>
       <NewPublications />
     </PublicationStoreProvider>
   );

--- a/frontend/app/admin/publications/new/page.tsx
+++ b/frontend/app/admin/publications/new/page.tsx
@@ -15,14 +15,15 @@ import ResetDiscarded from "components/ResetDiscarded";
 import ResetOverridden from "components/ResetOverridden";
 import RowIdToggle from "components/RowIdToggle";
 import { Publication } from "modules/publication/model";
-import { usePublicationStore } from "modules/publication/workspace";
 import {
   resetAll,
   setAll,
   setAttributesVisible,
 } from "modules/publication/store";
-import ClearSelection from "listeners/ClearSelection";
-import { PublicationStoreProvider } from "modules/publication/workspace";
+import {
+  PublicationStoreProvider,
+  usePublicationStore,
+} from "modules/publication/workspace";
 import type { Store } from "modules/store";
 import { useIsSelectionEmpty } from "modules/selection";
 import { useEffect } from "react";
@@ -62,12 +63,7 @@ function NewPublications() {
           />
         </>
       }
-      content={
-        <>
-          <ClearSelection store={store} />
-          <PublicationWorkspace />
-        </>
-      }
+      content={<PublicationWorkspace />}
       footer={
         <div className="flex space-x-2">
           {isSelectionEmpty ? (

--- a/frontend/app/admin/publications/new/page.tsx
+++ b/frontend/app/admin/publications/new/page.tsx
@@ -15,11 +15,14 @@ import ResetDiscarded from "components/ResetDiscarded";
 import ResetOverridden from "components/ResetOverridden";
 import RowIdToggle from "components/RowIdToggle";
 import { Publication } from "modules/publication/model";
+import { usePublicationStore } from "modules/publication/workspace";
 import {
   resetAll,
   setAll,
   setAttributesVisible,
 } from "modules/publication/store";
+import ClearSelection from "listeners/ClearSelection";
+import { PublicationStoreProvider } from "modules/publication/workspace";
 import { useIsSelectionEmpty } from "modules/selection";
 import { useEffect } from "react";
 
@@ -29,12 +32,13 @@ const BREADCRUMB_ITEMS = [
   { label: "Add publications" },
 ];
 
-export default function NewPublications() {
+function NewPublications() {
+  const store = usePublicationStore();
   const isSelectionEmpty = useIsSelectionEmpty();
 
-  useEffect(() => setAll([]), []);
-  useEffect(() => setAttributesVisible(Publication.ATTRIBUTES), []);
-  useEffect(() => resetAll, []);
+  useEffect(() => setAll(store, []), [store]);
+  useEffect(() => setAttributesVisible(store, Publication.ATTRIBUTES), [store]);
+  useEffect(() => () => resetAll(store), [store]);
 
   return (
     <Layout
@@ -47,7 +51,12 @@ export default function NewPublications() {
           />
         </>
       }
-      content={<PublicationWorkspace />}
+      content={
+        <>
+          <ClearSelection store={store} />
+          <PublicationWorkspace />
+        </>
+      }
       footer={
         <div className="flex space-x-2">
           {isSelectionEmpty ? (
@@ -70,5 +79,13 @@ export default function NewPublications() {
         </div>
       }
     />
+  );
+}
+
+export default function NewPublicationsPage() {
+  return (
+    <PublicationStoreProvider>
+      <NewPublications />
+    </PublicationStoreProvider>
   );
 }

--- a/frontend/app/admin/publications/references/page.tsx
+++ b/frontend/app/admin/publications/references/page.tsx
@@ -4,7 +4,6 @@ import Breadcrumb from "components/Breadcrumb";
 import Layout from "components/Layout";
 import PageHeader from "components/PageHeader";
 import ReferencesBackfill from "components/ReferencesBackfill";
-import { PublicationStoreProvider } from "modules/publication/workspace";
 
 const BREADCRUMB_ITEMS = [
   { label: "Home", href: "/" },
@@ -24,11 +23,7 @@ export default function ReferencesBackfillPage() {
           />
         </>
       }
-      content={
-        <PublicationStoreProvider>
-          <ReferencesBackfill />
-        </PublicationStoreProvider>
-      }
+      content={<ReferencesBackfill />}
     />
   );
 }

--- a/frontend/app/admin/publications/references/page.tsx
+++ b/frontend/app/admin/publications/references/page.tsx
@@ -4,6 +4,7 @@ import Breadcrumb from "components/Breadcrumb";
 import Layout from "components/Layout";
 import PageHeader from "components/PageHeader";
 import ReferencesBackfill from "components/ReferencesBackfill";
+import { PublicationStoreProvider } from "modules/publication/workspace";
 
 const BREADCRUMB_ITEMS = [
   { label: "Home", href: "/" },
@@ -23,7 +24,11 @@ export default function ReferencesBackfillPage() {
           />
         </>
       }
-      content={<ReferencesBackfill />}
+      content={
+        <PublicationStoreProvider>
+          <ReferencesBackfill />
+        </PublicationStoreProvider>
+      }
     />
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,4 @@
+import { PublicationStoreProvider } from "modules/publication/workspace";
 import { Suspense } from "react";
 import Home from "./Home";
 import { readPublication } from "./publications/read";
@@ -19,7 +20,9 @@ export default async function Page({
 
   return (
     <Suspense>
-      <Home opened={publication ? readPublication(publication) : undefined} />
+      <PublicationStoreProvider>
+        <Home opened={publication ? readPublication(publication) : undefined} />
+      </PublicationStoreProvider>
     </Suspense>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,3 @@
-import { PublicationStoreProvider } from "modules/publication/workspace";
 import { Suspense } from "react";
 import Home from "./Home";
 import { readPublication } from "./publications/read";
@@ -20,9 +19,7 @@ export default async function Page({
 
   return (
     <Suspense>
-      <PublicationStoreProvider>
-        <Home opened={publication ? readPublication(publication) : undefined} />
-      </PublicationStoreProvider>
+      <Home opened={publication ? readPublication(publication) : undefined} />
     </Suspense>
   );
 }

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -2,7 +2,6 @@
 
 import Notifications from "components/Notifications";
 import { Provider } from "jotai";
-import ClearSelection from "listeners/ClearSelection";
 import { SessionProvider } from "modules/session";
 import { store } from "modules/store";
 import type { User } from "modules/users";
@@ -22,7 +21,6 @@ export function Providers({
     <SessionProvider session={session}>
       <Provider store={store}>
         <Notifications />
-        <ClearSelection />
         {children}
       </Provider>
     </SessionProvider>

--- a/frontend/app/publications/[id]/page.tsx
+++ b/frontend/app/publications/[id]/page.tsx
@@ -3,6 +3,7 @@ import Layout from "components/Layout";
 import PublicationDetail, {
   PublicationHeading,
 } from "components/PublicationDetail";
+import { PublicationStoreProvider } from "modules/publication/workspace";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
@@ -47,7 +48,9 @@ export default async function PublicationPage({
         </>
       }
       content={
-        <PublicationDetail publication={publication} history={history} />
+        <PublicationStoreProvider>
+          <PublicationDetail publication={publication} history={history} />
+        </PublicationStoreProvider>
       }
     />
   );

--- a/frontend/app/publications/[id]/page.tsx
+++ b/frontend/app/publications/[id]/page.tsx
@@ -3,7 +3,6 @@ import Layout from "components/Layout";
 import PublicationDetail, {
   PublicationHeading,
 } from "components/PublicationDetail";
-import { PublicationStoreProvider } from "modules/publication/workspace";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
@@ -48,9 +47,7 @@ export default async function PublicationPage({
         </>
       }
       content={
-        <PublicationStoreProvider>
-          <PublicationDetail publication={publication} history={history} />
-        </PublicationStoreProvider>
+        <PublicationDetail publication={publication} history={history} />
       }
     />
   );

--- a/frontend/components/ColumnMenu.stories.tsx
+++ b/frontend/components/ColumnMenu.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { resetAttributes } from "modules/publication/store";
 import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 
@@ -7,7 +8,7 @@ import ColumnMenu from "./ColumnMenu";
 const meta = {
   title: "Publications/Column menu",
   component: ColumnMenu,
-  beforeEach: () => resetAttributes(),
+  beforeEach: () => resetAttributes(store),
   decorators: [
     (Story) => (
       <div className="flex justify-center p-8">

--- a/frontend/components/ColumnMenu.tsx
+++ b/frontend/components/ColumnMenu.tsx
@@ -19,6 +19,7 @@ import {
   useIsAttributeVisible,
 } from "modules/publication/hooks";
 import { Publication, type PublicationKey } from "modules/publication/model";
+import { usePublicationStore } from "modules/publication/workspace";
 import {
   resetAttributes,
   setAttributesVisible,
@@ -34,12 +35,13 @@ const TOGGLEABLE_ATTRIBUTES = Publication.ATTRIBUTES.filter(
 // (`aria-pressed`) so the popover stays a plain focusable group, no menu keyboard
 // model to implement — Tab moves between rows, the checkbox square is decorative.
 const ColumnToggle: FC<{ colId: PublicationKey }> = ({ colId }) => {
+  const store = usePublicationStore();
   const visible = useIsAttributeVisible(colId);
   return (
     <button
       type="button"
       aria-pressed={visible}
-      onClick={() => setAttributesVisible([colId], !visible)}
+      onClick={() => setAttributesVisible(store, [colId], !visible)}
       className="flex gap-2 items-center px-2 py-1.5 text-xs text-left text-gray-700 rounded cursor-pointer hover:text-indigo-700 hover:bg-indigo-100"
     >
       <span
@@ -61,6 +63,7 @@ const ColumnToggle: FC<{ colId: PublicationKey }> = ({ colId }) => {
 // columns. Replaces the in-place collapse-to-strip UI — hidden columns simply don't
 // render, so there's no `grid-template-columns` animation to lag on large lists.
 const ColumnMenu: FC = () => {
+  const store = usePublicationStore();
   const [isOpen, setIsOpen] = useState(false);
   const hiddenCount = useHiddenAttributes().filter(
     (key) => Publication.ATTRIBUTE_IS_TOGGLEABLE[key],
@@ -120,7 +123,7 @@ const ColumnMenu: FC = () => {
               ))}
               <button
                 type="button"
-                onClick={() => resetAttributes()}
+                onClick={() => resetAttributes(store)}
                 className="px-2 py-1.5 mt-1 text-xs text-left text-gray-500 rounded border-t border-gray-200 cursor-pointer hover:text-indigo-700 hover:bg-indigo-100"
               >
                 Show all

--- a/frontend/components/DataInput.stories.tsx
+++ b/frontend/components/DataInput.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { seed } from "modules/publication/fixtures";
 import { ComponentProps, FC, useState } from "react";
 import { expect, fn, screen, userEvent, within } from "storybook/test";
@@ -48,7 +49,7 @@ type Story = StoryObj<typeof meta>;
 
 /** A text column renders a plain, editable text cell. */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   args: { colId: "title", value: "Dom Casmurro" },
   play: async ({ canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox");
@@ -61,7 +62,7 @@ export const Default: Story = {
 
 /** A numeric column (year) renders the number cell (a styled text input). */
 export const Number: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   args: { colId: "year", value: "1953" },
   play: async ({ canvasElement }) => {
     await expect(within(canvasElement).getByRole("textbox")).toHaveValue(
@@ -76,7 +77,7 @@ export const Number: Story = {
  * grid — so the tinted cell is the signal and hovering gives the detail.
  */
 export const WithError: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   args: { colId: "title", value: "", error: "is required" },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -96,7 +97,7 @@ export const WithError: Story = {
  * nobody reads.
  */
 export const InlineError: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   args: {
     colId: "title",
     value: "",
@@ -123,7 +124,7 @@ export const InlineError: Story = {
  * was touched.
  */
 export const ValidatesOnSelection: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   args: {
     colId: "countries",
     value: "",
@@ -152,7 +153,7 @@ export const ValidatesOnSelection: Story = {
  * two-column grid, its neighbour.
  */
 export const ErrorDoesNotShiftLayout: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   args: {
     colId: "title",
     value: "",
@@ -178,7 +179,7 @@ export const ErrorDoesNotShiftLayout: Story = {
  * forwards it to the underlying input, which draws a visible box.
  */
 export const Bordered: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   args: { colId: "title", value: "Dom Casmurro", bordered: true },
   play: async ({ canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox");

--- a/frontend/components/DataInput.tsx
+++ b/frontend/components/DataInput.tsx
@@ -7,6 +7,7 @@ import {
   type PublicationKeyType,
 } from "modules/publication/model";
 import { validate } from "modules/publication/remote";
+import { usePublicationStore } from "modules/publication/workspace";
 import { overrideField } from "modules/publication/store";
 import { FC, FocusEvent, HTMLProps, Ref, forwardRef } from "react";
 import TextArrayDataInput from "./TextArrayDataInput";
@@ -80,14 +81,15 @@ const DataInput = forwardRef<HTMLElement, Props>(function DataInput(
   const Component = COMPONENTS_PER_TYPE[type];
   const placeholder = Publication.ATTRIBUTE_LABELS[colId];
 
-  const validateRow = onValidate ?? (() => validate([rowId]));
+  const store = usePublicationStore();
+  const validateRow = onValidate ?? (() => validate(store, [rowId]));
 
   function doValidate() {
     if (autoValidated) validateRow();
   }
 
   function handleChange(value: string) {
-    overrideField(rowId, colId, value);
+    overrideField(store, rowId, colId, value);
     if (VALIDATES_ON_CHANGE.includes(type)) {
       doValidate();
     }

--- a/frontend/components/PublicationCounter.stories.tsx
+++ b/frontend/components/PublicationCounter.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { resetAll } from "modules/publication/store";
 import { seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
@@ -17,7 +18,7 @@ type Story = StoryObj<typeof meta>;
 
 /** With the 3 sample publications loaded, the counter reads "3". */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     await expect(
       within(canvasElement).getByRole("button", { name: "3" }),
@@ -27,7 +28,7 @@ export const Default: Story = {
 
 /** A single publication — the button shows the count "1". */
 export const Single: Story = {
-  beforeEach: () => seed([{ title: "Dom Casmurro" }]),
+  beforeEach: () => seed(store, [{ title: "Dom Casmurro" }]),
   play: async ({ canvasElement }) => {
     await expect(
       within(canvasElement).getByRole("button", { name: "1" }),
@@ -37,7 +38,7 @@ export const Single: Story = {
 
 /** Nothing loaded — the counter hides itself entirely. */
 export const Empty: Story = {
-  beforeEach: () => resetAll(),
+  beforeEach: () => resetAll(store),
   play: async ({ canvasElement }) => {
     await expect(within(canvasElement).queryByRole("button")).toBeNull();
   },

--- a/frontend/components/PublicationDeselect.tsx
+++ b/frontend/components/PublicationDeselect.tsx
@@ -2,10 +2,12 @@
 
 import DeselectIcon from "assets/deselect.svg";
 import { FC } from "react";
+import { usePublicationStore } from "modules/publication/workspace";
 import { clearSelection, useSelectionSize } from "modules/selection";
 import Button from "./Button";
 
 const PublicationDeselect: FC = () => {
+  const store = usePublicationStore();
   const selectionSize = useSelectionSize();
 
   return (
@@ -14,7 +16,7 @@ const PublicationDeselect: FC = () => {
       width="fit"
       label={`Deselect ${selectionSize}`}
       Icon={DeselectIcon}
-      onClick={clearSelection}
+      onClick={() => clearSelection(store)}
     />
   );
 };

--- a/frontend/components/PublicationDetail.stories.tsx
+++ b/frontend/components/PublicationDetail.stories.tsx
@@ -1,4 +1,5 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { withChanges } from "modules/publication/history";
 import { empty, type PublicationHistoryEntry } from "modules/publication/model";
 import { resetAll } from "modules/publication/store";
@@ -130,7 +131,7 @@ export const AsAdmin: Story = {
  */
 export const Editing: Story = {
   decorators: [asAdmin],
-  beforeEach: () => resetAll(),
+  beforeEach: () => resetAll(store),
   play: async () => {
     await userEvent.click(screen.getByRole("button", { name: "Edit" }));
 

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -276,11 +276,6 @@ type PublicationDetailProps = {
   onDeleted?: () => void;
 };
 
-/**
- * Editing needs somewhere to keep what is being typed, so the view brings it:
- * inside the catalogue's overlay it joins the catalogue's, and the row behind it
- * changes as this one is saved; on a publication's own page it owns one.
- */
 const PublicationDetail: FC<PublicationDetailProps> = (props) => (
   <PublicationStoreProvider>
     <Detail {...props} />

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -24,7 +24,10 @@ import {
   overrideReferences,
   remember,
 } from "modules/publication/store";
-import { usePublicationStore } from "modules/publication/workspace";
+import {
+  PublicationStoreProvider,
+  usePublicationStore,
+} from "modules/publication/workspace";
 import { useIsAdmin } from "modules/session";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -256,7 +259,7 @@ const PublicationEditForm: FC<{
  * page title are drawn from the same record by whoever placed this view, and
  * re-reading is the only way they cannot disagree with the body.
  */
-const PublicationDetail: FC<{
+type PublicationDetailProps = {
   publication: Publication;
   /**
    * The record's mutation log, read alongside it. Present only for an admin,
@@ -271,7 +274,25 @@ const PublicationDetail: FC<{
    * instead and leaves the catalogue behind it in place.
    */
   onDeleted?: () => void;
-}> = ({ publication, history, onNavigate, onDeleted }) => {
+};
+
+/**
+ * Editing needs somewhere to keep what is being typed, so the view brings it:
+ * inside the catalogue's overlay it joins the catalogue's, and the row behind it
+ * changes as this one is saved; on a publication's own page it owns one.
+ */
+const PublicationDetail: FC<PublicationDetailProps> = (props) => (
+  <PublicationStoreProvider>
+    <Detail {...props} />
+  </PublicationStoreProvider>
+);
+
+const Detail: FC<PublicationDetailProps> = ({
+  publication,
+  history,
+  onNavigate,
+  onDeleted,
+}) => {
   const id = publication.id!;
   const store = usePublicationStore();
   const isAdmin = useIsAdmin();

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -24,6 +24,7 @@ import {
   overrideReferences,
   remember,
 } from "modules/publication/store";
+import { usePublicationStore } from "modules/publication/workspace";
 import { useIsAdmin } from "modules/session";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -159,6 +160,7 @@ const EditField: FC<{ id: PublicationId; attribute: PublicationKey }> = ({
   id,
   attribute,
 }) => {
+  const store = usePublicationStore();
   const value = usePublicationField(id, attribute);
   const error = usePublicationFieldError(id, attribute);
 
@@ -177,7 +179,7 @@ const EditField: FC<{ id: PublicationId; attribute: PublicationKey }> = ({
         autoValidated
         // A form has room to say what is wrong, in place.
         errorDisplay="inline"
-        onValidate={() => validateUpdate(id)}
+        onValidate={() => validateUpdate(store, id)}
       />
     </div>
   );
@@ -188,6 +190,7 @@ const PublicationEditForm: FC<{
   onSaved: () => void;
   onCancel: () => void;
 }> = ({ id, onSaved, onCancel }) => {
+  const store = usePublicationStore();
   const [saving, setSaving] = useState(false);
   const error = usePublicationErrorDescription(id);
   const isValid = useIsPublicationValid(id);
@@ -196,7 +199,7 @@ const PublicationEditForm: FC<{
   async function handleSubmit(event: SubmitEvent<HTMLFormElement>) {
     event.preventDefault();
     setSaving(true);
-    const saved = await update(id);
+    const saved = await update(store, id);
     setSaving(false);
     if (saved) onSaved();
   }
@@ -211,7 +214,7 @@ const PublicationEditForm: FC<{
       </div>
       <ReferencesEditor
         value={references}
-        onChange={(next) => overrideReferences(id, next)}
+        onChange={(next) => overrideReferences(store, id, next)}
       />
       {error && <p className="text-sm text-red-600">{error}</p>}
       <div className="flex gap-3 justify-end">
@@ -270,6 +273,7 @@ const PublicationDetail: FC<{
   onDeleted?: () => void;
 }> = ({ publication, history, onNavigate, onDeleted }) => {
   const id = publication.id!;
+  const store = usePublicationStore();
   const isAdmin = useIsAdmin();
   const router = useRouter();
 
@@ -279,12 +283,15 @@ const PublicationDetail: FC<{
 
   // An edit abandoned by closing the view is dropped, not kept: the overlay it
   // writes to is the same one the row behind it reads around.
-  useEffect(() => (editing ? () => discardEdit(id) : undefined), [editing, id]);
+  useEffect(
+    () => (editing ? () => discardEdit(store, id) : undefined),
+    [editing, id, store],
+  );
 
   function startEditing() {
     // The form edits the store's copy of the record, so a view that read it on
     // the server has to hand it over before the fields can show anything.
-    remember(publication);
+    remember(store, publication);
     setEditing(true);
   }
 
@@ -295,7 +302,7 @@ const PublicationDetail: FC<{
 
   async function handleDelete() {
     setDeleting(true);
-    const removed = await deletePublication(id);
+    const removed = await deletePublication(store, id);
     setDeleting(false);
     deleteConfirmation.close();
     if (removed) (onDeleted ?? (() => router.replace("/")))();

--- a/frontend/components/PublicationDiscard.stories.tsx
+++ b/frontend/components/PublicationDiscard.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
 
@@ -19,7 +20,7 @@ type Story = StoryObj<typeof meta>;
  * still renders and reads "Discard 0" (a safe no-op on click).
  */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     await expect(
       within(canvasElement).getByRole("button", { name: /Discard 0/ }),

--- a/frontend/components/PublicationDiscard.tsx
+++ b/frontend/components/PublicationDiscard.tsx
@@ -2,6 +2,7 @@
 
 import TrashIcon from "assets/trash.svg";
 import { setDiscarded } from "modules/publication/store";
+import { usePublicationStore } from "modules/publication/workspace";
 import { FC } from "react";
 import {
   clearSelection,
@@ -13,11 +14,13 @@ import Button from "./Button";
 const PublicationDiscard: FC = () => {
   const selectionSize = useSelectionSize();
 
+  const store = usePublicationStore();
+
   const discardSelected = () => {
-    const selectedIds = [...getSelection()] as number[];
+    const selectedIds = [...getSelection(store)] as number[];
     if (selectedIds.length > 0) {
-      setDiscarded(selectedIds);
-      clearSelection();
+      setDiscarded(store, selectedIds);
+      clearSelection(store);
     }
   };
 

--- a/frontend/components/PublicationDownload.mdx
+++ b/frontend/components/PublicationDownload.mdx
@@ -18,7 +18,11 @@ attributes (`useVisibleAttributes`) to build the export's `select` — omitted
 when every column is shown, otherwise the snake-cased visible columns. It also
 pulls the current `search` from the router query so the export respects the
 active filter. Clicking issues a GET for the file blob and triggers a hidden
-anchor to save it. In stories the store is seeded through the shared fixtures:
+anchor to save it, under the name the server gave in `content-disposition` —
+falling back to `publications.csv` if that header is missing or unreadable,
+since a file that arrived is not a failed download. Only a request that failed
+raises a notification. In stories the store is seeded through the shared
+fixtures:
 
 ```tsx
 import { seed } from "modules/publication/fixtures";

--- a/frontend/components/PublicationDownload.spec.ts
+++ b/frontend/components/PublicationDownload.spec.ts
@@ -1,0 +1,29 @@
+import { FALLBACK_FILENAME, filenameFrom } from "./PublicationDownload";
+
+describe("filenameFrom", () => {
+  test("takes the name the server gave the file", () => {
+    expect(
+      filenameFrom('attachment; filename="publications-machado.csv"'),
+    ).toBe("publications-machado.csv");
+  });
+
+  test("accepts an unquoted name", () => {
+    expect(filenameFrom("attachment; filename=publications.csv")).toBe(
+      "publications.csv",
+    );
+  });
+
+  test("falls back when the header is missing", () => {
+    // What the header reads as when it is absent — and what it read as for every
+    // download while the client looked for it under the wrong name.
+    expect(filenameFrom(undefined)).toBe(FALLBACK_FILENAME);
+  });
+
+  test("falls back when the header says nothing about a name", () => {
+    expect(filenameFrom("attachment")).toBe(FALLBACK_FILENAME);
+  });
+
+  test("falls back when the name is empty", () => {
+    expect(filenameFrom('attachment; filename=""')).toBe(FALLBACK_FILENAME);
+  });
+});

--- a/frontend/components/PublicationDownload.stories.tsx
+++ b/frontend/components/PublicationDownload.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
 
@@ -16,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 /** Enabled when there are visible publications to export as .csv. */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const button = within(canvasElement).getByRole("button", {
       name: /Download \.csv/,
@@ -29,7 +30,7 @@ export const Default: Story = {
 
 /** Nothing to download — the button is disabled when the list is empty. */
 export const Empty: Story = {
-  beforeEach: () => seed([]),
+  beforeEach: () => seed(store, []),
   play: async ({ canvasElement }) => {
     await expect(
       within(canvasElement).getByRole("button", { name: /Download \.csv/ }),

--- a/frontend/components/PublicationDownload.tsx
+++ b/frontend/components/PublicationDownload.tsx
@@ -12,8 +12,34 @@ import { useSearchParams } from "next/navigation";
 import qs from "qs";
 import { FC, useRef } from "react";
 import Button from "./Button";
+import { useNotify } from "./Notifications";
+
+// Raw, not camelCased: the client leaves response header names alone (see
+// modules/http). Reading `contentDisposition` was always `undefined`.
+const CONTENT_DISPOSITION = "content-disposition";
+
+/** What the file is called when the server does not say. */
+const FALLBACK_FILENAME = "publications.csv";
+
+/**
+ * The name the server gave the file, or a sensible one.
+ *
+ * A header that is missing or unparseable is not a failed download — the bytes
+ * are already here — so it must not throw. It used to: the match was asserted
+ * non-null, so a header this could not read took the whole download down with
+ * it, before the click that saves the file.
+ */
+function filenameFrom(disposition: unknown): string {
+  const filename =
+    typeof disposition === "string"
+      ? /filename[^;=\n]*=([^;\n]*)/.exec(disposition)?.[1]
+      : undefined;
+
+  return filename?.replace(/"/g, "").trim() || FALLBACK_FILENAME;
+}
 
 const PublicationDownload: FC = () => {
+  const notify = useNotify();
   const visibleCount = useVisiblePublicationCount();
   const visibleAttributes = useVisibleAttributes();
   const areAllAttributesVisible =
@@ -29,9 +55,11 @@ const PublicationDownload: FC = () => {
     ? undefined
     : visibleAttributes.map(snakeCase);
 
-  const download = () => {
-    request(async (http) => {
-      if (anchor.current) {
+  const download = async () => {
+    try {
+      await request(async (http) => {
+        if (!anchor.current) return;
+
         const query = qs.stringify(
           { search, select },
           { encode: false, arrayFormat: "brackets" },
@@ -42,15 +70,19 @@ const PublicationDownload: FC = () => {
           { responseType: "blob" },
         );
 
-        const filename = /filename[^;=\n]*=([^;\n]*)/
-          .exec(headers.contentDisposition)![1]
-          .replace(/"/g, "");
-
         anchor.current.href = URL.createObjectURL(data);
-        anchor.current.download = filename;
+        anchor.current.download = filenameFrom(headers[CONTENT_DISPOSITION]);
         anchor.current.click();
-      }
-    });
+      });
+    } catch {
+      // Only a request that failed says so — a file that arrived and saved is a
+      // success whatever its header said.
+      notify({
+        message: "Could not download the .csv",
+        detail: "Nothing was saved. Check your connection and try again.",
+        level: "warning",
+      });
+    }
   };
 
   return (
@@ -70,3 +102,4 @@ const PublicationDownload: FC = () => {
 };
 
 export default PublicationDownload;
+export { FALLBACK_FILENAME, filenameFrom };

--- a/frontend/components/PublicationDownload.tsx
+++ b/frontend/components/PublicationDownload.tsx
@@ -14,8 +14,6 @@ import { FC, useRef } from "react";
 import Button from "./Button";
 import { useNotify } from "./Notifications";
 
-// Raw, not camelCased: the client leaves response header names alone (see
-// modules/http). Reading `contentDisposition` was always `undefined`.
 const CONTENT_DISPOSITION = "content-disposition";
 
 /** What the file is called when the server does not say. */
@@ -75,8 +73,6 @@ const PublicationDownload: FC = () => {
         anchor.current.click();
       });
     } catch {
-      // Only a request that failed says so — a file that arrived and saved is a
-      // success whatever its header said.
       notify({
         message: "Could not download the .csv",
         detail: "Nothing was saved. Check your connection and try again.",

--- a/frontend/components/PublicationDuplicate.stories.tsx
+++ b/frontend/components/PublicationDuplicate.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
 
@@ -19,7 +20,7 @@ type Story = StoryObj<typeof meta>;
  * still renders and reads "Duplicate 0" (a safe no-op on click).
  */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     await expect(
       within(canvasElement).getByRole("button", { name: /Duplicate 0/ }),

--- a/frontend/components/PublicationDuplicate.tsx
+++ b/frontend/components/PublicationDuplicate.tsx
@@ -2,6 +2,7 @@
 
 import CopyIcon from "assets/copy.svg";
 import { duplicate } from "modules/publication/store";
+import { usePublicationStore } from "modules/publication/workspace";
 import { validate } from "modules/publication/remote";
 import { FC } from "react";
 import {
@@ -14,12 +15,14 @@ import Button from "./Button";
 const PublicationDuplicate: FC = () => {
   const selectionSize = useSelectionSize();
 
+  const store = usePublicationStore();
+
   const duplicateSelected = () => {
-    const selectedIds = getSelection() as Set<number>;
+    const selectedIds = getSelection(store) as Set<number>;
     if (selectedIds.size > 0) {
-      const newIds = duplicate(selectedIds);
-      validate(newIds);
-      clearSelection();
+      const newIds = duplicate(store, selectedIds);
+      validate(store, newIds);
+      clearSelection(store);
     }
   };
 

--- a/frontend/components/PublicationErrorCounter.stories.tsx
+++ b/frontend/components/PublicationErrorCounter.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { resetAll } from "modules/publication/store";
 import { fieldErrors, seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
@@ -18,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 /** One invalid row among valid ones — the counter shows "1". */
 export const Default: Story = {
   beforeEach: () =>
-    seed([
+    seed(store, [
       { title: "", errors: fieldErrors({ title: "required" }) },
       { title: "Dom Casmurro" },
       { title: "The Hour of the Star" },
@@ -35,7 +36,7 @@ export const Default: Story = {
 /** Two invalid rows — the counter shows "2". */
 export const MultipleErrors: Story = {
   beforeEach: () =>
-    seed([
+    seed(store, [
       { title: "", errors: fieldErrors({ title: "required" }) },
       { year: "abc", errors: fieldErrors({ year: "integer" }) },
       { title: "The Hour of the Star" },
@@ -51,7 +52,7 @@ export const MultipleErrors: Story = {
 
 /** All rows valid — a green check instead of a red count. */
 export const AllValid: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
@@ -63,7 +64,7 @@ export const AllValid: Story = {
 
 /** Nothing loaded — the counter hides entirely. */
 export const Empty: Story = {
-  beforeEach: () => resetAll(),
+  beforeEach: () => resetAll(store),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.queryByRole("button")).toBeNull();

--- a/frontend/components/PublicationErrorCounter.tsx
+++ b/frontend/components/PublicationErrorCounter.tsx
@@ -8,11 +8,13 @@ import {
   useVisiblePublicationCount,
 } from "modules/publication/hooks";
 import { focusNextInvalid } from "modules/publication/store";
+import { usePublicationStore } from "modules/publication/workspace";
 import { FC } from "react";
 import Button from "./Button";
 import Tooltip from "./Tooltip";
 
 const PublicationErrorCounter: FC = () => {
+  const store = usePublicationStore();
   const publicationCount = useVisiblePublicationCount();
   const validPublicationCount = useValidPublicationCount();
   const invalidPublicationCount = publicationCount - validPublicationCount;
@@ -49,7 +51,7 @@ const PublicationErrorCounter: FC = () => {
         Icon={ErrorCircleIcon}
         label={toString(invalidPublicationCount)}
         aria-label={`${invalidPublicationCount} invalid publications`}
-        onClick={focusNextInvalid}
+        onClick={() => focusNextInvalid(store)}
       />
     </Tooltip>
   );

--- a/frontend/components/PublicationIndexList.stories.tsx
+++ b/frontend/components/PublicationIndexList.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { resetAll } from "modules/publication/store";
 import { seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
@@ -18,7 +19,7 @@ type Story = StoryObj<typeof meta>;
 
 /** The mobile list populated with a few publications. */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(
@@ -29,10 +30,10 @@ export const Default: Story = {
 
 /** A search that matched nothing. */
 export const Empty: Story = {
-  beforeEach: () => seed([]),
+  beforeEach: () => seed(store, []),
 };
 
 /** Ids not loaded yet — the skeleton placeholder. */
 export const Loading: Story = {
-  beforeEach: () => resetAll(),
+  beforeEach: () => resetAll(store),
 };

--- a/frontend/components/PublicationIndexTable.stories.tsx
+++ b/frontend/components/PublicationIndexTable.stories.tsx
@@ -5,8 +5,8 @@ import {
   resetAll,
   resetAttributes,
   setAttributesVisible,
-  store,
 } from "modules/publication/store";
+import { store } from "modules/store";
 import { sampleManyPublications, seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
 
@@ -17,7 +17,7 @@ const meta = {
   component: PublicationIndexTable,
   // Normalize column visibility before every story so hidden-column state doesn't
   // leak between them (the store is a module singleton).
-  beforeEach: () => resetAttributes(),
+  beforeEach: () => resetAttributes(store),
   decorators: [
     (Story) => (
       <div className="p-4 overflow-x-auto">
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>;
 
 /** The index populated with a few publications. */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // 3 seeded publications → 3 body rows (+ the header row). Cell contents are
@@ -50,9 +50,9 @@ export const Default: Story = {
  */
 export const IgnoresPendingEdits: Story = {
   beforeEach: () => {
-    seed();
+    seed(store);
     const [id] = store.get(publicationIdsAtom)!;
-    overrideField(id, "title", "Edited in the modal");
+    overrideField(store, id, "title", "Edited in the modal");
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -70,14 +70,14 @@ export const IgnoresPendingEdits: Story = {
 
 /** A search that matched nothing (ids loaded, but empty). */
 export const Empty: Story = {
-  beforeEach: () => seed([]),
+  beforeEach: () => seed(store, []),
 };
 
 /** Ids not loaded yet — the skeleton placeholder. */
 export const Loading: Story = {
   beforeEach: () => {
-    resetAll();
-    resetAttributes();
+    resetAll(store);
+    resetAttributes(store);
   },
 };
 
@@ -88,7 +88,7 @@ export const Loading: Story = {
  * subscribe their cells until they scroll into view.
  */
 export const ManyRows: Story = {
-  beforeEach: () => seed(sampleManyPublications(100)),
+  beforeEach: () => seed(store, sampleManyPublications(100)),
   decorators: [
     (Story) => (
       <div className="h-[420px] overflow-auto rounded border border-gray-200">
@@ -109,8 +109,8 @@ export const ManyRows: Story = {
  */
 export const HiddenColumns: Story = {
   beforeEach: () => {
-    seed(sampleManyPublications(20));
-    setAttributesVisible(["publishers", "year"], false);
+    seed(store, sampleManyPublications(20));
+    setAttributesVisible(store, ["publishers", "year"], false);
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/frontend/components/PublicationIndexTable.tsx
+++ b/frontend/components/PublicationIndexTable.tsx
@@ -117,7 +117,6 @@ const Column: FC<{
   focused?: boolean;
   invalid?: boolean;
   selected?: boolean;
-  selectable?: boolean;
 }> = ({
   rowId,
   colId,
@@ -125,7 +124,6 @@ const Column: FC<{
   focused = false,
   invalid = false,
   selected = false,
-  selectable = false,
 }) => {
   // `truncate` sets overflow:hidden, which zeroes the grid item's auto min-width so
   // the fixed-width track never expands to fit the content.
@@ -133,7 +131,6 @@ const Column: FC<{
     <Aria.Cell
       className="px-2 py-1 text-sm truncate transition-colors group-hover:bg-indigo-100 error:group-hover:bg-red-100 error:focused:bg-red-100 selected:bg-amber-100 selected:focused:error:bg-amber-100"
       data-selected={selected}
-      data-selectable={selectable}
       data-error={invalid}
       data-focused={focused}
     >
@@ -218,25 +215,31 @@ const Row = forwardRef<HTMLDivElement, RowProps>(function Row(
   );
 });
 
+/**
+ * The row's leading cell: its signal (invalid, focused) and its handle. Where a
+ * row is selectable this is *the* place to click for it — the other cells may
+ * hold a field, and a click there belongs to the field.
+ */
 const SignalColumn: FC<{
   rowId: RowId;
   focused?: boolean;
   invalid?: boolean;
   selected?: boolean;
-  selectable?: boolean;
+  /** Clicking this cell selects the row. */
+  selectsRow?: boolean;
   children?: ReactNode;
 }> = ({
   focused = false,
   invalid = false,
   selected = false,
-  selectable = false,
+  selectsRow = false,
   children,
 }) => {
   return (
     <Aria.Cell
       className="flex sticky left-0 z-10 justify-center items-center px-2 bg-gray-100 group-hover:bg-indigo-100 error:group-hover:bg-red-100 error:focused:bg-red-100 selected:bg-amber-100 selected:focused:error:bg-amber-100"
       data-selected={selected}
-      data-selectable={selectable}
+      data-selects-row={selectsRow}
       data-error={invalid}
       data-focused={focused}
     >
@@ -254,6 +257,8 @@ interface Props {
   ExtendedTrailingColumn?: FC<{ rowId: RowId }>;
   ExtraRow?: FC;
   onRowClick?: (id: RowId) => (event: MouseEvent) => void;
+  /** Whether the *text* in the table can be selected. Off while rows are
+   * selected, so dragging across them does not highlight their content. */
   selectable?: boolean;
   collapsible?: boolean;
 }

--- a/frontend/components/PublicationModal.stories.tsx
+++ b/frontend/components/PublicationModal.stories.tsx
@@ -1,4 +1,5 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { withChanges } from "modules/publication/history";
 import {
   Publication,
@@ -82,7 +83,7 @@ type Story = StoryObj<typeof meta>;
 
 /** No `?publication=` query — the modal stays closed. */
 export const Closed: Story = {
-  beforeEach: () => resetAll(),
+  beforeEach: () => resetAll(store),
   play: async () => {
     await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   },
@@ -130,7 +131,7 @@ export const Missing: Story = {
 
 /** Opened by a `?publication=1` URL query, showing that publication's details. */
 export const Default: Story = {
-  beforeEach: () => setAll([DOM_CASMURRO]),
+  beforeEach: () => setAll(store, [DOM_CASMURRO]),
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
     // Full-screen portalled modal — bound it in the docs page.
@@ -150,7 +151,7 @@ export const Default: Story = {
 };
 
 export const Editing: Story = {
-  beforeEach: () => setAll([DOM_CASMURRO]),
+  beforeEach: () => setAll(store, [DOM_CASMURRO]),
   decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
@@ -177,7 +178,7 @@ export const Editing: Story = {
  * references load as rows, and "Add reference" appends an empty one.
  */
 export const EditingReferences: Story = {
-  beforeEach: () => setAll([DOM_CASMURRO]),
+  beforeEach: () => setAll(store, [DOM_CASMURRO]),
   decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
@@ -216,7 +217,7 @@ export const EditingReferences: Story = {
  * from a round-trip the server will reject.
  */
 export const EditingWithErrors: Story = {
-  beforeEach: () => setAll([{ ...DOM_CASMURRO, errors: "conflict" }]),
+  beforeEach: () => setAll(store, [{ ...DOM_CASMURRO, errors: "conflict" }]),
   decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
@@ -240,7 +241,7 @@ export const EditingWithErrors: Story = {
  * confirmed path needs the real backend — the E2E suite covers it.)
  */
 export const DeleteConfirmation: Story = {
-  beforeEach: () => setAll([DOM_CASMURRO]),
+  beforeEach: () => setAll(store, [DOM_CASMURRO]),
   decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },
@@ -281,7 +282,7 @@ export const DeleteConfirmation: Story = {
  * Countries field, which autocompletes from a static list (no backend).
  */
 export const EditingMenuAboveModal: Story = {
-  beforeEach: () => setAll([DOM_CASMURRO]),
+  beforeEach: () => setAll(store, [DOM_CASMURRO]),
   decorators: [asAdmin],
   parameters: {
     nextjs: { navigation: { query: { publication: "1" } } },

--- a/frontend/components/PublicationSearch.stories.tsx
+++ b/frontend/components/PublicationSearch.stories.tsx
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof meta>;
 
 /** The search input renders and is initially empty. */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox", {
       name: "Search publications",
@@ -31,7 +31,7 @@ export const Default: Story = {
 /** A `?search=` param (e.g. following a keyword link) is mirrored into the box. */
 export const FromUrlParam: Story = {
   parameters: { nextjs: { navigation: { query: { search: "Machado" } } } },
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox", {
       name: "Search publications",
@@ -43,7 +43,7 @@ export const FromUrlParam: Story = {
 /** While a search is in flight, the keyword line becomes an animated status. */
 export const Searching: Story = {
   beforeEach: () => {
-    seed();
+    seed(store);
     store.set(isIndexLoadingAtom, true);
   },
   play: async ({ canvasElement }) => {
@@ -55,7 +55,7 @@ export const Searching: Story = {
 
 /** Typing into the input updates its value (debounces to the index endpoint). */
 export const Typing: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const input = within(canvasElement).getByRole("textbox", {
       name: "Search publications",

--- a/frontend/components/PublicationSubmit.stories.tsx
+++ b/frontend/components/PublicationSubmit.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { fieldErrors, seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
 
@@ -16,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 /** Enabled when every visible publication is valid — the happy path. */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const button = within(canvasElement).getByRole("button", {
       name: "Submit",
@@ -29,7 +30,7 @@ export const Default: Story = {
 
 /** Nothing to submit — the button is disabled when there are no publications. */
 export const Empty: Story = {
-  beforeEach: () => seed([]),
+  beforeEach: () => seed(store, []),
   play: async ({ canvasElement }) => {
     await expect(
       within(canvasElement).getByRole("button", { name: "Submit" }),
@@ -40,7 +41,7 @@ export const Empty: Story = {
 /** An invalid row blocks submission — the button stays disabled. */
 export const WithInvalidRow: Story = {
   beforeEach: () =>
-    seed([
+    seed(store, [
       { title: "Dom Casmurro", authors: "Helen Caldwell", year: "1953" },
       { title: "", errors: fieldErrors({ title: "required" }) },
     ]),

--- a/frontend/components/PublicationSubmit.tsx
+++ b/frontend/components/PublicationSubmit.tsx
@@ -6,6 +6,7 @@ import {
   useVisiblePublicationCount,
 } from "modules/publication/hooks";
 import { setAll } from "modules/publication/store";
+import { usePublicationStore } from "modules/publication/workspace";
 import { bulk } from "modules/publication/remote";
 import { FC, useCallback } from "react";
 import Button from "./Button";
@@ -13,11 +14,12 @@ import { useNotify } from "./Notifications";
 import Tooltip from "./Tooltip";
 
 const PublicationSubmit: FC = () => {
+  const store = usePublicationStore();
   const notify = useNotify();
 
   const handleSubmit = useCallback(() => {
-    bulk().then((publications) => {
-      setAll([]);
+    bulk(store).then((publications) => {
+      setAll(store, []);
       notify({
         message: `${publications.length} ${
           publications.length === 1 ? "publication" : "publications"
@@ -25,7 +27,7 @@ const PublicationSubmit: FC = () => {
         level: "success",
       });
     });
-  }, [notify]);
+  }, [notify, store]);
 
   const publicationCount = useVisiblePublicationCount();
   const validPublicationCount = useValidPublicationCount();

--- a/frontend/components/PublicationUpload.stories.tsx
+++ b/frontend/components/PublicationUpload.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
 
@@ -16,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 /** The upload trigger — a button that opens a hidden file input. */
 export const Default: Story = {
-  beforeEach: () => seed([]),
+  beforeEach: () => seed(store, []),
   play: async ({ canvasElement }) => {
     // The visible affordance is the button; the file input is hidden.
     const button = within(canvasElement).getByRole("button", {
@@ -35,7 +36,7 @@ export const Default: Story = {
 
 /** With existing data, the button warns (via tooltip) that it will be replaced. */
 export const WithExistingData: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     await expect(
       within(canvasElement).getByRole("button", { name: /Upload\.csv/ }),

--- a/frontend/components/PublicationUpload.tsx
+++ b/frontend/components/PublicationUpload.tsx
@@ -2,12 +2,14 @@
 
 import UploadIcon from "assets/upload.svg";
 import { useTotalPublicationCount } from "modules/publication/hooks";
+import { usePublicationStore } from "modules/publication/workspace";
 import { upload } from "modules/publication/remote";
 import { ChangeEvent, FC, useRef, useState } from "react";
 import Button from "./Button";
 import Tooltip from "./Tooltip";
 
 const PublicationUpload: FC = () => {
+  const store = usePublicationStore();
   const totalPublications = useTotalPublicationCount();
 
   const [key, setKey] = useState(1);
@@ -19,7 +21,7 @@ const PublicationUpload: FC = () => {
       payload.append("csv", file);
 
       try {
-        await upload(payload);
+        await upload(store, payload);
       } catch {
         // The remote layer already surfaced a notification; just reset the
         // input so the same file can be re-selected.

--- a/frontend/components/PublicationWorkspace.mdx
+++ b/frontend/components/PublicationWorkspace.mdx
@@ -18,13 +18,29 @@ Each injected piece overrides one part of the read-only table:
 - **`ExtendedContent`** — replaces each read-only cell with a `DataInput` that
   writes edits back to the store and re-validates.
 - **`ExtendedSignalColumn`** — a per-row validity signal: an error icon when
-  invalid, plus the optional row id.
+  invalid, plus the optional row id. It is also the row's **selection handle**
+  (`data-selects-row`).
 - **`ExtendedRow`** — wraps the row in an error `Tooltip` and scrolls it into
   view when focused.
 - **`ExtraRow`** — the always-present **new-publication** row at the bottom.
 
 Because it shares the table's structure, everything from the read-only view —
 column visibility, row virtualization, selection — still applies.
+
+## Selecting rows
+
+A row is selected by its **handle**, the leading signal cell: a plain click
+selects it, shift-click extends a contiguous range from it, and cmd/ctrl-click
+toggles one row. The other cells hold fields, so a click there belongs to the
+field — the row hears it, and ignores it.
+
+That is one question, and "can the text be selected" is another: the table turns
+text selection off while rows are selected, so dragging across them does not
+highlight their content. Both used to be the same `data-selectable` attribute,
+which meant selecting a row depended on the click missing the icon inside the
+handle, and cmd- or shift-clicking a second row could clear the selection instead
+of changing it. `modules/selection`'s `isSelectionGesture` is now the single
+definition, read by both the row that selects and the listener that clears.
 
 ## Editing & validation
 

--- a/frontend/components/PublicationWorkspace.stories.tsx
+++ b/frontend/components/PublicationWorkspace.stories.tsx
@@ -71,39 +71,91 @@ export const WithInvalidRow: Story = {
   },
 };
 
+/** Skip the header; the seeded rows follow, and the new-publication row trails. */
+const rowsIn = (canvas: ReturnType<typeof within>) =>
+  canvas.getAllByRole("row").slice(1);
+
 /**
- * Multi-select: a plain click selects one row, shift-click extends a contiguous
- * range from it, and cmd/ctrl-click toggles a single row. Selected rows carry
- * `data-selected` on their (amber) signal cell.
+ * A row's selection handle — its leading cell. Rows render placeholder cells until
+ * they scroll into view, so a story has to wait for the real ones before it can
+ * click them.
+ */
+const handleIn = async (row: HTMLElement) => {
+  await waitFor(() =>
+    expect(row.querySelector('[data-selects-row="true"]')).not.toBeNull(),
+  );
+  return row.querySelector('[data-selects-row="true"]') as HTMLElement;
+};
+
+const selectedCount = (canvas: ReturnType<typeof within>) =>
+  canvas
+    .getAllByRole("row")
+    .filter((row: HTMLElement) => row.querySelector('[data-selected="true"]'))
+    .length;
+
+/**
+ * Multi-select from the row handles: a plain click selects one row, shift-click
+ * extends a contiguous range from it, and cmd/ctrl-click toggles a single row.
+ * Selected rows carry `data-selected` on their (amber) signal cell.
  */
 export const Selection: Story = {
   beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    // Skip the header; the three seeded rows (the new-publication row trails).
-    const [, first, second, third] = canvas.getAllByRole("row");
-
-    // Click a cell, the way a user does: the row container is not selectable, and
-    // a click outside anything selectable clears the selection.
-    const cellIn = (row: HTMLElement) =>
-      row.querySelector('[role="cell"]') as HTMLElement;
-
-    const selectedCount = () =>
-      canvas
-        .getAllByRole("row")
-        .filter((row) => row.querySelector('[data-selected="true"]')).length;
+    const [first, second, third] = rowsIn(canvas);
 
     // Plain click selects just that row.
-    fireEvent.click(cellIn(first));
-    await waitFor(() => expect(selectedCount()).toBe(1));
+    fireEvent.click(await handleIn(first));
+    await waitFor(() => expect(selectedCount(canvas)).toBe(1));
 
     // Shift-click extends the contiguous range from the first row through it.
-    fireEvent.click(cellIn(third), { shiftKey: true });
-    await waitFor(() => expect(selectedCount()).toBe(3));
+    fireEvent.click(await handleIn(third), { shiftKey: true });
+    await waitFor(() => expect(selectedCount(canvas)).toBe(3));
 
     // Cmd/ctrl-click toggles a single row out of the range.
-    fireEvent.click(cellIn(second), { metaKey: true });
-    await waitFor(() => expect(selectedCount()).toBe(2));
+    fireEvent.click(await handleIn(second), { metaKey: true });
+    await waitFor(() => expect(selectedCount(canvas)).toBe(2));
+  },
+};
+
+/**
+ * The handle's own content — a row number, an error icon — is part of the handle:
+ * clicking it selects the row like clicking around it does. Selecting used to
+ * depend on the click *missing* that content.
+ */
+export const SelectionFromTheHandleContent: Story = {
+  beforeEach: () =>
+    seed(store, [{ title: "Dom Casmurro", errors: "conflict" }]),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const [row] = rowsIn(canvas);
+
+    // The invalid row's handle draws an icon, which covers its middle.
+    const icon = (await handleIn(row)).querySelector("span") as HTMLElement;
+    fireEvent.click(icon);
+
+    await waitFor(() => expect(selectedCount(canvas)).toBe(1));
+  },
+};
+
+/**
+ * A click that lands in a field belongs to the field. The row hears it too — it
+ * hears every click inside it — and must not turn it into a selection, or typing
+ * would swap the submit bar for the selection toolbar.
+ */
+export const TypingDoesNotSelect: Story = {
+  beforeEach: () => seed(store),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const [row] = rowsIn(canvas);
+
+    // Wait for the row to render for real, then click into one of its fields.
+    await handleIn(row);
+    const input = row.querySelector("input") as HTMLElement;
+    fireEvent.click(input);
+    await userEvent.type(input, "x");
+
+    await expect(selectedCount(canvas)).toBe(0);
   },
 };
 

--- a/frontend/components/PublicationWorkspace.stories.tsx
+++ b/frontend/components/PublicationWorkspace.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { fieldErrors, seed } from "modules/publication/fixtures";
 import { expect, fireEvent, userEvent, waitFor, within } from "storybook/test";
 
@@ -23,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 
 /** The editable review table — an inline input per cell, plus the "new row". */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // header + 3 seeded rows + the always-present new-publication row.
@@ -38,7 +39,7 @@ export const Default: Story = {
  * permanently empty — seeded rows would keep working and hide it.
  */
 export const NewRowAcceptsInput: Story = {
-  beforeEach: () => seed([]),
+  beforeEach: () => seed(store, []),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const title = await canvas.findByPlaceholderText("Title");
@@ -51,7 +52,7 @@ export const NewRowAcceptsInput: Story = {
 /** Field-level validation errors — the title and year cells are flagged. */
 export const WithInvalidRow: Story = {
   beforeEach: () =>
-    seed([
+    seed(store, [
       { title: "Dom Casmurro", authors: "Helen Caldwell", year: "1953" },
       {
         title: "",
@@ -76,11 +77,16 @@ export const WithInvalidRow: Story = {
  * `data-selected` on their (amber) signal cell.
  */
 export const Selection: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // Skip the header; the three seeded rows (the new-publication row trails).
     const [, first, second, third] = canvas.getAllByRole("row");
+
+    // Click a cell, the way a user does: the row container is not selectable, and
+    // a click outside anything selectable clears the selection.
+    const cellIn = (row: HTMLElement) =>
+      row.querySelector('[role="cell"]') as HTMLElement;
 
     const selectedCount = () =>
       canvas
@@ -88,15 +94,15 @@ export const Selection: Story = {
         .filter((row) => row.querySelector('[data-selected="true"]')).length;
 
     // Plain click selects just that row.
-    fireEvent.click(first);
+    fireEvent.click(cellIn(first));
     await waitFor(() => expect(selectedCount()).toBe(1));
 
     // Shift-click extends the contiguous range from the first row through it.
-    fireEvent.click(third, { shiftKey: true });
+    fireEvent.click(cellIn(third), { shiftKey: true });
     await waitFor(() => expect(selectedCount()).toBe(3));
 
     // Cmd/ctrl-click toggles a single row out of the range.
-    fireEvent.click(second, { metaKey: true });
+    fireEvent.click(cellIn(second), { metaKey: true });
     await waitFor(() => expect(selectedCount()).toBe(2));
   },
 };
@@ -108,7 +114,9 @@ export const Selection: Story = {
  */
 export const EditCell: Story = {
   beforeEach: () =>
-    seed([{ title: "Dom Casmurro", authors: "Helen Caldwell", year: "1953" }]),
+    seed(store, [
+      { title: "Dom Casmurro", authors: "Helen Caldwell", year: "1953" },
+    ]),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // findBy*: the row virtualizes on an IntersectionObserver, so its input

--- a/frontend/components/PublicationWorkspace.tsx
+++ b/frontend/components/PublicationWorkspace.tsx
@@ -13,6 +13,7 @@ import {
   RowProps,
   SignalColumn,
 } from "components/PublicationIndexTable";
+import ClearSelection from "listeners/ClearSelection";
 import { isElement } from "lodash";
 import {
   useAreRowIdsVisible,
@@ -241,18 +242,21 @@ const PublicationWorkspace: FC = () => {
   };
 
   return (
-    <PublicationIndexTable
-      ExtendedRow={ExtendedRow}
-      ExtendedColumn={ExtendedColumn}
-      ExtendedColumnHeader={ExtendedColumnHeader}
-      ExtendedContent={ExtendedContent}
-      ExtendedSignalColumn={ExtendedSignalColumn}
-      ExtendedTrailingColumn={ExtendedTrailingColumn}
-      ExtraRow={NewPublicationRow}
-      onRowClick={toggleSelection}
-      selectable={isSelectionEmpty}
-      collapsible={false}
-    />
+    <>
+      <ClearSelection store={store} />
+      <PublicationIndexTable
+        ExtendedRow={ExtendedRow}
+        ExtendedColumn={ExtendedColumn}
+        ExtendedColumnHeader={ExtendedColumnHeader}
+        ExtendedContent={ExtendedContent}
+        ExtendedSignalColumn={ExtendedSignalColumn}
+        ExtendedTrailingColumn={ExtendedTrailingColumn}
+        ExtraRow={NewPublicationRow}
+        onRowClick={toggleSelection}
+        selectable={isSelectionEmpty}
+        collapsible={false}
+      />
+    </>
   );
 };
 

--- a/frontend/components/PublicationWorkspace.tsx
+++ b/frontend/components/PublicationWorkspace.tsx
@@ -24,6 +24,7 @@ import {
   useVisiblePublicationIds,
 } from "modules/publication/hooks";
 import { validate } from "modules/publication/remote";
+import { usePublicationStore } from "modules/publication/workspace";
 import { DRAFT_ID, addNew } from "modules/publication/store";
 import { select, useIsSelected, useIsSelectionEmpty } from "modules/selection";
 import {
@@ -147,10 +148,12 @@ const ExtendedRow: FC<RowProps> = (props) => {
 };
 
 const useSubmit = () => {
+  const store = usePublicationStore();
+
   return useCallback(() => {
-    const id = addNew();
-    validate([id]);
-  }, []);
+    const id = addNew(store);
+    validate(store, [id]);
+  }, [store]);
 };
 
 const SubmittableData: typeof Content = ({ rowId, colId }) => {
@@ -214,11 +217,12 @@ const NewPublicationRow: FC = () => {
 };
 
 const PublicationWorkspace: FC = () => {
+  const store = usePublicationStore();
   const ids = useVisiblePublicationIds();
   const isSelectionEmpty = useIsSelectionEmpty();
 
   const toggleSelection = (id: number) => (event: MouseEvent) =>
-    select({
+    select(store, {
       id,
       type: "publication",
       shiftKey: event.shiftKey,

--- a/frontend/components/PublicationWorkspace.tsx
+++ b/frontend/components/PublicationWorkspace.tsx
@@ -26,7 +26,12 @@ import {
 import { validate } from "modules/publication/remote";
 import { usePublicationStore } from "modules/publication/workspace";
 import { DRAFT_ID, addNew } from "modules/publication/store";
-import { select, useIsSelected, useIsSelectionEmpty } from "modules/selection";
+import {
+  isSelectionGesture,
+  select,
+  useIsSelected,
+  useIsSelectionEmpty,
+} from "modules/selection";
 import {
   FC,
   KeyboardEventHandler,
@@ -52,7 +57,6 @@ const ExtendedColumn: typeof Column = (props) => {
       invalid={!isValid}
       focused={isFocused}
       selected={isSelected}
-      selectable={true}
     />
   );
 };
@@ -91,7 +95,7 @@ const ExtendedSignalColumn: FC<{ rowId: RowId }> = ({ rowId }) => {
       focused={isFocused}
       invalid={!isValid}
       selected={isSelected}
-      selectable
+      selectsRow
     >
       <span
         className="flex items-center text-xs text-gray-400 error:text-red-500"
@@ -221,7 +225,12 @@ const PublicationWorkspace: FC = () => {
   const ids = useVisiblePublicationIds();
   const isSelectionEmpty = useIsSelectionEmpty();
 
-  const toggleSelection = (id: number) => (event: MouseEvent) =>
+  // Only a click on the row's handle selects it. The row hears every click in
+  // it, including the ones that land in a field — those belong to the field, and
+  // selecting on them would fight the person typing.
+  const toggleSelection = (id: number) => (event: MouseEvent) => {
+    if (!isSelectionGesture(event.target)) return;
+
     select(store, {
       id,
       type: "publication",
@@ -229,6 +238,7 @@ const PublicationWorkspace: FC = () => {
       metaKey: event.metaKey,
       orderedIds: ids,
     });
+  };
 
   return (
     <PublicationIndexTable

--- a/frontend/components/ReferencesBackfill.stories.tsx
+++ b/frontend/components/ReferencesBackfill.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { RESET } from "jotai/utils";
+import { store } from "modules/store";
 import { Publication } from "modules/publication/model";
 import {
   discardEdit,
@@ -7,7 +8,6 @@ import {
   publicationFamily,
   resetAll,
   setAll,
-  store,
   visiblePublicationFamily,
 } from "modules/publication/store";
 import { ComponentProps, FC, useState } from "react";
@@ -32,8 +32,8 @@ const publication = (title: string, references: string[] = []) => ({
 });
 
 const seedQueue = () => {
-  resetAll();
-  setAll([
+  resetAll(store);
+  setAll(store, [
     { id: 1, publication: publication("Dom Casmurro"), errors: null },
     {
       id: 2,
@@ -114,7 +114,7 @@ const InteractiveView: FC<ComponentProps<typeof ReferencesBackfillView>> = ({
         advance();
       }}
       onSkip={() => {
-        if (currentId !== undefined) discardEdit(currentId);
+        if (currentId !== undefined) discardEdit(store, currentId);
         onSkip();
         advance();
       }}

--- a/frontend/components/ReferencesBackfill.tsx
+++ b/frontend/components/ReferencesBackfill.tsx
@@ -236,10 +236,6 @@ export const ReferencesBackfillView: FC<{
   );
 };
 
-/**
- * The wizard reads a queue and edits the records in it, so it brings the state
- * that holds both — nothing above it has to know that.
- */
 const ReferencesBackfill: FC = () => (
   <PublicationStoreProvider>
     <Backfill />

--- a/frontend/components/ReferencesBackfill.tsx
+++ b/frontend/components/ReferencesBackfill.tsx
@@ -9,7 +9,10 @@ import {
   useUnreferencedPublicationCount,
 } from "modules/publication/hooks";
 import type { PublicationId } from "modules/publication/model";
-import { usePublicationStore } from "modules/publication/workspace";
+import {
+  PublicationStoreProvider,
+  usePublicationStore,
+} from "modules/publication/workspace";
 import { index, update } from "modules/publication/remote";
 import {
   discardEdit,
@@ -233,7 +236,17 @@ export const ReferencesBackfillView: FC<{
   );
 };
 
-const ReferencesBackfill: FC = () => {
+/**
+ * The wizard reads a queue and edits the records in it, so it brings the state
+ * that holds both — nothing above it has to know that.
+ */
+const ReferencesBackfill: FC = () => (
+  <PublicationStoreProvider>
+    <Backfill />
+  </PublicationStoreProvider>
+);
+
+const Backfill: FC = () => {
   const store = usePublicationStore();
   const [ids, setIds] = useState<PublicationId[]>();
   const [position, setPosition] = useState(0);

--- a/frontend/components/ReferencesBackfill.tsx
+++ b/frontend/components/ReferencesBackfill.tsx
@@ -9,6 +9,7 @@ import {
   useUnreferencedPublicationCount,
 } from "modules/publication/hooks";
 import type { PublicationId } from "modules/publication/model";
+import { usePublicationStore } from "modules/publication/workspace";
 import { index, update } from "modules/publication/remote";
 import {
   discardEdit,
@@ -128,6 +129,7 @@ export const BackfillStep: FC<{
   onSave: () => void;
   onSkip: () => void;
 }> = ({ id, position, total, saving, onSave, onSkip }) => {
+  const store = usePublicationStore();
   const publication = usePublication(id);
   const references = usePublicationReferences(id);
 
@@ -154,7 +156,7 @@ export const BackfillStep: FC<{
 
       <ReferencesEditor
         value={references}
-        onChange={(next) => overrideReferences(id, next)}
+        onChange={(next) => overrideReferences(store, id, next)}
       />
 
       <div className="flex gap-3 justify-end mt-auto">
@@ -232,28 +234,29 @@ export const ReferencesBackfillView: FC<{
 };
 
 const ReferencesBackfill: FC = () => {
+  const store = usePublicationStore();
   const [ids, setIds] = useState<PublicationId[]>();
   const [position, setPosition] = useState(0);
   const [saving, setSaving] = useState(false);
 
   useEffect(() => {
-    index({ unreferenced: true }).then(setIds);
+    index(store, { unreferenced: true }).then(setIds);
     // Leave the store as we found it when the admin walks away.
-    return () => resetAll();
-  }, []);
+    return () => resetAll(store);
+  }, [store]);
 
   const currentId = ids?.[position];
 
   async function handleSave() {
     if (currentId === undefined) return;
     setSaving(true);
-    const saved = await update(currentId);
+    const saved = await update(store, currentId);
     setSaving(false);
     if (saved) setPosition((p) => Math.min(p + 1, (ids?.length ?? 1) - 1));
   }
 
   function handleSkip() {
-    if (currentId !== undefined) discardEdit(currentId);
+    if (currentId !== undefined) discardEdit(store, currentId);
     setPosition((p) => Math.min(p + 1, (ids?.length ?? 1) - 1));
   }
 

--- a/frontend/components/ResetDiscarded.stories.tsx
+++ b/frontend/components/ResetDiscarded.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { useVisiblePublicationIds } from "modules/publication/hooks";
 import { setDiscarded } from "modules/publication/store";
 import { seed } from "modules/publication/fixtures";
@@ -18,7 +19,7 @@ const DiscardControls: FC = () => {
     <button
       className="rounded border border-indigo-600 px-3 py-1 text-sm text-indigo-600 hover:bg-indigo-50 disabled:opacity-40"
       disabled={first === undefined}
-      onClick={() => first !== undefined && setDiscarded([first])}
+      onClick={() => first !== undefined && setDiscarded(store, [first])}
     >
       Discard a row
     </button>
@@ -45,7 +46,7 @@ type Story = StoryObj<typeof meta>;
 
 /** Discard a row → the reset button appears → reset restores it (a full round-trip). */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/frontend/components/ResetDiscarded.tsx
+++ b/frontend/components/ResetDiscarded.tsx
@@ -2,6 +2,7 @@
 
 import RestoreTrashIcon from "assets/restore-trash.svg";
 import { useDiscardedPublicationCount } from "modules/publication/hooks";
+import { usePublicationStore } from "modules/publication/workspace";
 import { resetDiscarded } from "modules/publication/store";
 import { FC } from "react";
 import { clearSelection } from "modules/selection";
@@ -10,9 +11,11 @@ import Button from "./Button";
 const ResetDiscarded: FC = () => {
   const discardedCount = useDiscardedPublicationCount();
 
+  const store = usePublicationStore();
+
   const reset = () => {
-    resetDiscarded();
-    clearSelection();
+    resetDiscarded(store);
+    clearSelection(store);
   };
 
   return discardedCount !== 0 ? (

--- a/frontend/components/ResetOverridden.stories.tsx
+++ b/frontend/components/ResetOverridden.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { useVisiblePublicationIds } from "modules/publication/hooks";
 import { overrideField } from "modules/publication/store";
 import { seed } from "modules/publication/fixtures";
@@ -19,7 +20,8 @@ const OverrideControls: FC = () => {
       className="rounded border border-indigo-600 px-3 py-1 text-sm text-indigo-600 hover:bg-indigo-50 disabled:opacity-40"
       disabled={first === undefined}
       onClick={() =>
-        first !== undefined && overrideField(first, "title", "Edited title")
+        first !== undefined &&
+        overrideField(store, first, "title", "Edited title")
       }
     >
       Edit a field
@@ -51,7 +53,7 @@ type Story = StoryObj<typeof meta>;
  * "Edit a field" lets you repeat the round-trip.)
  */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 

--- a/frontend/components/ResetOverridden.tsx
+++ b/frontend/components/ResetOverridden.tsx
@@ -6,6 +6,7 @@ import {
   useOverriddenPublicationIds,
 } from "modules/publication/hooks";
 import { resetOverridden } from "modules/publication/store";
+import { usePublicationStore } from "modules/publication/workspace";
 import { validate } from "modules/publication/remote";
 import { FC } from "react";
 import { clearSelection } from "modules/selection";
@@ -16,12 +17,14 @@ const ResetOverridden: FC = () => {
 
   const overriddenIds = useOverriddenPublicationIds();
 
+  const store = usePublicationStore();
+
   const reset = () => {
     if (!overriddenIds)
       throw "Can not reset publications: overriden ids are undefined.";
-    resetOverridden();
-    clearSelection();
-    validate(overriddenIds);
+    resetOverridden(store);
+    clearSelection(store);
+    validate(store, overriddenIds);
   };
 
   return overriddenCount !== 0 ? (

--- a/frontend/components/RowIdToggle.stories.tsx
+++ b/frontend/components/RowIdToggle.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store } from "modules/store";
 import { resetAll } from "modules/publication/store";
 import { seed } from "modules/publication/fixtures";
 import { expect, within } from "storybook/test";
@@ -17,7 +18,7 @@ type Story = StoryObj<typeof meta>;
 
 /** With publications loaded, the toggle shows the row-number control. */
 export const Default: Story = {
-  beforeEach: () => seed(),
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
     await expect(
       within(canvasElement).getByRole("button", { name: "Row Ids" }),
@@ -27,7 +28,7 @@ export const Default: Story = {
 
 /** With nothing loaded, the toggle hides itself entirely. */
 export const Empty: Story = {
-  beforeEach: () => resetAll(),
+  beforeEach: () => resetAll(store),
   play: async ({ canvasElement }) => {
     await expect(within(canvasElement).queryByRole("button")).toBeNull();
   },

--- a/frontend/components/Select.mdx
+++ b/frontend/components/Select.mdx
@@ -1,0 +1,57 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+
+import * as SelectStories from "./Select.stories";
+
+<Meta of={SelectStories} />
+
+# Select
+
+A single-value combobox: an input that filters an async list and a dropdown that
+offers what it found. Picking one emits it through `onChange`; the input then
+shows that option's label.
+
+<Canvas of={SelectStories.Default} />
+
+## Props
+
+- `value` — the selected option (`{ id, label }`), or nothing.
+- `onChange` — called with the option the reader picked.
+- `getOptions(search)` — the lookup behind the list. Called with `""` for the
+  unfiltered list and with what has been typed otherwise; it may be debounced by
+  the caller.
+- `error` — marks the field invalid (`aria-invalid`) and colours it.
+- `bordered` — outlined style, applied to the input and its dropdown alike.
+
+## When it asks for options
+
+**When the menu opens, not when the field mounts.** Focusing the input (or
+clicking the chevron) loads the unfiltered list; typing asks for the filtered
+one. This matters where these are dense: a grid of them used to ask for every
+list on screen as it rendered — before anyone had looked at a single field — and
+again on the way out of each one. Nothing is fetched for a field a reader never
+visits.
+
+## Filtering
+
+The typed query lives in state only while the menu is open: closing it drops the
+query and the input reverts to the selected option's label, reset from `isOpen`
+during render rather than mirrored in an effect.
+
+<Canvas of={SelectStories.ClearsFilterOnClose} />
+
+## Keyboard
+
+Typing highlights the first match; **Enter** or **→** selects the highlighted
+option and closes the menu, keeping focus in the input — the combobox pattern.
+Blurring on selection bounced focus through the menu's focus manager, whose
+focus-return reopened an emptied menu over the fresh selection.
+
+<Canvas of={SelectStories.SelectsHighlightedOption} />
+
+## States
+
+- **Default** — empty, closed.
+- **With value** — the selected option's label in the input.
+- **Filter and select** — typing runs the lookup.
+- **Clears filter on close** — the query does not outlive the menu.
+- **With error** — invalid, with the message.

--- a/frontend/components/Select.stories.tsx
+++ b/frontend/components/Select.stories.tsx
@@ -33,7 +33,6 @@ const Controlled: FC<ComponentProps<typeof Select>> = ({
 const meta = {
   title: "Components/Select",
   component: Select,
-  tags: ["autodocs"],
   args: {
     value: undefined,
     error: "",

--- a/frontend/components/Select.tsx
+++ b/frontend/components/Select.tsx
@@ -58,9 +58,6 @@ export default forwardRef<HTMLInputElement, Props>(function Select(
   function handleFocus(event: FocusEvent<HTMLInputElement>) {
     setSearch("");
     setIsOpen(true);
-    // Ask when the menu opens, not when the field mounts: a grid of these used
-    // to fetch every list on screen before anyone had looked at one, and again
-    // on the way out of each field.
     loadOptions();
     onFocus?.(event);
   }
@@ -96,8 +93,6 @@ export default forwardRef<HTMLInputElement, Props>(function Select(
   function handleToggleClick() {
     setIsOpen((isOpen) => !isOpen);
     if (!isOpen) {
-      // Focusing an already-focused input fires no focus event, so the menu
-      // asks for its own list here.
       inputRef.current?.focus();
       loadOptions();
     } else {

--- a/frontend/components/Select.tsx
+++ b/frontend/components/Select.tsx
@@ -7,7 +7,6 @@ import {
   forwardRef,
   HTMLProps,
   KeyboardEvent,
-  useEffect,
   useRef,
   useState,
 } from "react";
@@ -48,13 +47,21 @@ export default forwardRef<HTMLInputElement, Props>(function Select(
   const [options, setOptions] = useState<Option[]>([]);
 
   function handleBlur(event: FocusEvent<HTMLInputElement>) {
-    getOptions("").then(setOptions);
     onBlur?.(event);
+  }
+
+  /** The unfiltered list, for a menu that is about to be shown. */
+  function loadOptions() {
+    getOptions("").then(setOptions);
   }
 
   function handleFocus(event: FocusEvent<HTMLInputElement>) {
     setSearch("");
     setIsOpen(true);
+    // Ask when the menu opens, not when the field mounts: a grid of these used
+    // to fetch every list on screen before anyone had looked at one, and again
+    // on the way out of each field.
+    loadOptions();
     onFocus?.(event);
   }
 
@@ -89,11 +96,13 @@ export default forwardRef<HTMLInputElement, Props>(function Select(
   function handleToggleClick() {
     setIsOpen((isOpen) => !isOpen);
     if (!isOpen) {
+      // Focusing an already-focused input fires no focus event, so the menu
+      // asks for its own list here.
       inputRef.current?.focus();
+      loadOptions();
     } else {
       inputRef.current?.blur();
     }
-    getOptions("").then(setOptions);
   }
 
   function handleSelect(option: Option) {
@@ -110,10 +119,6 @@ export default forwardRef<HTMLInputElement, Props>(function Select(
     setWasOpen(isOpen);
     if (!isOpen) setSearch(undefined);
   }
-
-  useEffect(() => {
-    getOptions("").then(setOptions);
-  }, [getOptions]);
 
   return (
     <MenuProvider

--- a/frontend/components/WorkspaceReferencesCell.stories.tsx
+++ b/frontend/components/WorkspaceReferencesCell.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { store, type Store } from "modules/store";
 import { Publication } from "modules/publication/model";
 import { resetAll, setAll } from "modules/publication/store";
 import { expect, screen, userEvent, waitFor } from "storybook/test";
 
 import WorkspaceReferencesCell from "./WorkspaceReferencesCell";
 
-const seed = (rowId: number, references: string[]) => {
-  resetAll();
-  setAll([
+const seed = (store: Store, rowId: number, references: string[]) => {
+  resetAll(store);
+  setAll(store, [
     {
       id: rowId,
       publication: {
@@ -44,7 +45,7 @@ type Story = StoryObj<typeof meta>;
 
 /** With references: the button summarizes the count and opens the list editor. */
 export const WithReferences: Story = {
-  beforeEach: () => seed(1, ["A source", "Another source"]),
+  beforeEach: () => seed(store, 1, ["A source", "Another source"]),
   parameters: {
     // The open modal aria-hides the background trigger, which is still focusable.
     a11y: { config: { rules: [{ id: "aria-hidden-focus", enabled: false }] } },
@@ -63,7 +64,7 @@ export const WithReferences: Story = {
 
 /** With none: the button invites adding references. */
 export const Empty: Story = {
-  beforeEach: () => seed(1, []),
+  beforeEach: () => seed(store, 1, []),
   play: async () => {
     await expect(
       screen.getByRole("button", { name: "Add references" }),

--- a/frontend/components/WorkspaceReferencesCell.tsx
+++ b/frontend/components/WorkspaceReferencesCell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { usePublicationReferences } from "modules/publication/hooks";
+import { usePublicationStore } from "modules/publication/workspace";
 import { overrideReferences } from "modules/publication/store";
 import { FC, MouseEvent, useState } from "react";
 import Button from "./Button";
@@ -30,6 +31,8 @@ const WorkspaceReferencesCell: FC<{
 
   // The cell sits inside the row's onClick (which selects the row); opening the
   // editor must not also select.
+  const store = usePublicationStore();
+
   const openEditor = (event: MouseEvent) => {
     event.stopPropagation();
     setOpen(true);
@@ -66,7 +69,7 @@ const WorkspaceReferencesCell: FC<{
           <h1 className="text-xl font-normal">References</h1>
           <ReferencesEditor
             value={references}
-            onChange={(next) => overrideReferences(rowId, next)}
+            onChange={(next) => overrideReferences(store, rowId, next)}
           />
         </div>
       </Modal>

--- a/frontend/components/WorkspaceReferencesCell.tsx
+++ b/frontend/components/WorkspaceReferencesCell.tsx
@@ -42,7 +42,6 @@ const WorkspaceReferencesCell: FC<{
     <div
       role="cell"
       data-selected={selected}
-      data-selectable
       data-error={invalid}
       data-focused={focused}
       className="flex py-1 px-2 transition-colors group-hover:bg-indigo-100 error:group-hover:bg-red-100 error:focused:bg-red-100 selected:bg-amber-100 selected:focused:error:bg-amber-100"

--- a/frontend/e2e/export-publications.spec.ts
+++ b/frontend/e2e/export-publications.spec.ts
@@ -9,17 +9,26 @@ test("an admin exports the corpus as a CSV, references included", async ({
   // The button disables while the count is 0 — wait for the index to load.
   await expect(indexTable(page).getByText("Barren Lives")).toBeVisible();
 
-  // Clicking Download drives the admin-only CSV export endpoint.
-  const [response] = await Promise.all([
+  // Clicking Download drives the admin-only CSV export endpoint *and* saves what
+  // comes back. Waiting only for the response missed a browser-side crash that
+  // stopped the file from ever being offered.
+  const [response, download] = await Promise.all([
     page.waitForResponse(
       (r) =>
         r.url().includes("files/publications") &&
         r.request().method() === "GET",
     ),
+    page.waitForEvent("download"),
     page.getByRole("button", { name: "Download .csv" }).click(),
   ]);
   expect(response.status()).toBe(200);
   expect(response.headers()["content-type"]).toMatch(/csv/);
+
+  // The file is offered under the name the server gave it.
+  const named = /filename[^;=\n]*=\"?([^\";\n]*)/.exec(
+    response.headers()["content-disposition"],
+  );
+  expect(download.suggestedFilename()).toBe(named![1]);
 
   // The file carries the whole corpus, provenance included.
   const csv = await response.text();

--- a/frontend/e2e/import-publications.spec.ts
+++ b/frontend/e2e/import-publications.spec.ts
@@ -18,7 +18,7 @@ import {
 const CSV_ROW =
   "Machado de Assis;1899;BR;Dom Casmurro;Dom Casmurro (CSV);Helen Caldwell;Noonday Press;A source\n";
 
-const [, REFERENCED, DUPLICATED] = PUBLICATIONS;
+const [FIRST, REFERENCED, DUPLICATED] = PUBLICATIONS;
 
 const REFERENCES = [
   "Caldwell, Helen. The Brazilian Othello of Machado de Assis, 1960.",
@@ -40,8 +40,35 @@ test("an admin bulk-inserts publications with references from the workspace", as
   // Attach two sources to the second row through its "Sources" cell.
   await addRowReferences(page, REFERENCED.title, REFERENCES);
 
-  // Selection tools: select the third row (via its signal cell — the row's cells
-  // are inputs), duplicate it, then delete the copy again.
+  // Selection: a row is selected by its leading cell — the handle. The other
+  // cells hold fields, and a click there belongs to the field.
+  const handleOf = (title: string) =>
+    table.getByRole("row", { name: title }).getByRole("cell").first();
+
+  await handleOf(FIRST.title).click();
+  await expect(page.getByRole("button", { name: "Deselect 1" })).toBeVisible();
+
+  // Shift-click extends a contiguous range from it, and cmd-click then toggles a
+  // single row back out. Both used to lose the selection instead of changing it.
+  await handleOf(DUPLICATED.title).click({ modifiers: ["Shift"] });
+  await expect(page.getByRole("button", { name: "Deselect 3" })).toBeVisible();
+
+  await handleOf(REFERENCED.title).click({ modifiers: ["Meta"] });
+  await expect(page.getByRole("button", { name: "Deselect 2" })).toBeVisible();
+
+  // Clicking anything that is not a row's handle clears it.
+  await page.getByRole("heading", { name: "Add publications" }).click();
+  await expect(page.getByRole("button", { name: /^Deselect/ })).toHaveCount(0);
+
+  // Clicking into a field is not a selection: it is where you type.
+  const titleCell = table
+    .getByRole("row", { name: FIRST.title })
+    .getByPlaceholder("Title", { exact: true });
+  await titleCell.click();
+  await expect(page.getByRole("button", { name: /^Deselect/ })).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Submit" })).toBeVisible();
+
+  // Duplicate the third row, then delete the copy again.
   const duplicatedRows = table.getByRole("row", { name: DUPLICATED.title });
   await duplicatedRows.getByRole("cell").first().click();
   await expect(page.getByRole("button", { name: "Deselect 1" })).toBeVisible();

--- a/frontend/e2e/import-publications.spec.ts
+++ b/frontend/e2e/import-publications.spec.ts
@@ -70,7 +70,7 @@ test("an admin bulk-inserts publications with references from the workspace", as
 
   // Duplicate the third row, then delete the copy again.
   const duplicatedRows = table.getByRole("row", { name: DUPLICATED.title });
-  await duplicatedRows.getByRole("cell").first().click();
+  await handleOf(DUPLICATED.title).click();
   await expect(page.getByRole("button", { name: "Deselect 1" })).toBeVisible();
   await page.getByRole("button", { name: "Duplicate 1" }).click();
   await expect(duplicatedRows).toHaveCount(2);

--- a/frontend/listeners/ClearSelection.tsx
+++ b/frontend/listeners/ClearSelection.tsx
@@ -14,10 +14,6 @@ import { FC, useEffect } from "react";
 const ClearSelection: FC<{ store: Store }> = ({ store }) => {
   useEffect(() => {
     const handle = (event: MouseEvent) => {
-      // `closest`, via the shared gesture test: the handle has content of its
-      // own (a row number, an error icon), and a click that landed on *that*
-      // is still a click on the handle. Testing the exact target made selecting
-      // depend on missing the icon.
       if (!isSelectionGesture(event.target)) clearSelection(store);
     };
 

--- a/frontend/listeners/ClearSelection.tsx
+++ b/frontend/listeners/ClearSelection.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { isElement } from "lodash";
-import { clearSelection } from "modules/selection";
+import { clearSelection, isSelectionGesture } from "modules/selection";
 import type { Store } from "modules/store";
 import { FC, useEffect } from "react";
 
 /**
- * Clicking outside the rows clears the selection.
+ * A click that is not asking for a row clears the selection.
  *
  * Rendered by the surface that selects — the bulk workspace — and given its
  * store: a selection belongs to the rows one workspace holds, so clearing it has
@@ -15,11 +14,11 @@ import { FC, useEffect } from "react";
 const ClearSelection: FC<{ store: Store }> = ({ store }) => {
   useEffect(() => {
     const handle = (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-
-      if (isElement(target) && !target.matches('[data-selectable="true"]')) {
-        clearSelection(store);
-      }
+      // `closest`, via the shared gesture test: the handle has content of its
+      // own (a row number, an error icon), and a click that landed on *that*
+      // is still a click on the handle. Testing the exact target made selecting
+      // depend on missing the icon.
+      if (!isSelectionGesture(event.target)) clearSelection(store);
     };
 
     document.addEventListener("click", handle);

--- a/frontend/listeners/ClearSelection.tsx
+++ b/frontend/listeners/ClearSelection.tsx
@@ -2,15 +2,23 @@
 
 import { isElement } from "lodash";
 import { clearSelection } from "modules/selection";
+import type { Store } from "modules/store";
 import { FC, useEffect } from "react";
 
-const ClearSelection: FC = () => {
+/**
+ * Clicking outside the rows clears the selection.
+ *
+ * Rendered by the surface that selects — the bulk workspace — and given its
+ * store: a selection belongs to the rows one workspace holds, so clearing it has
+ * to reach the same store the rows were selected in.
+ */
+const ClearSelection: FC<{ store: Store }> = ({ store }) => {
   useEffect(() => {
     const handle = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
 
       if (isElement(target) && !target.matches('[data-selectable="true"]')) {
-        clearSelection();
+        clearSelection(store);
       }
     };
 
@@ -18,7 +26,7 @@ const ClearSelection: FC = () => {
     return () => {
       document.removeEventListener("click", handle);
     };
-  }, []);
+  }, [store]);
 
   return null;
 };

--- a/frontend/modules/publication/fixtures.ts
+++ b/frontend/modules/publication/fixtures.ts
@@ -1,4 +1,6 @@
 import { Publication, PublicationError, PublicationKey, empty } from "./model";
+import { clearSelection } from "modules/selection";
+import type { Store } from "modules/store";
 import { createId, resetAll, resetAttributes, setAll } from "./store";
 
 type SeedEntry = Partial<Publication> & { errors?: PublicationError };
@@ -57,15 +59,20 @@ function sampleManyPublications(count: number): Partial<Publication>[] {
 }
 
 /**
- * Reset the store and seed it with the given publications (defaults to
- * samples). Each entry may carry an `errors` value to render an invalid row.
+ * Reset a store and seed it with the given publications (defaults to samples).
+ * Each entry may carry an `errors` value to render an invalid row.
+ *
+ * Takes the store so a story can seed the one it is about to hand its provider,
+ * rather than a shared singleton.
  */
-function seed(entries: SeedEntry[] = SAMPLE_PUBLICATIONS): void {
-  resetAll();
+function seed(store: Store, entries: SeedEntry[] = SAMPLE_PUBLICATIONS): void {
+  resetAll(store);
+  clearSelection(store);
   // Column visibility survives resetAll (it's a UI preference in the app), so
   // reset it here too — otherwise a column hidden in one story stays hidden.
-  resetAttributes();
+  resetAttributes(store);
   setAll(
+    store,
     entries.map(({ errors = null, ...publication }) => ({
       id: createId(),
       publication: { ...empty(), ...publication },

--- a/frontend/modules/publication/remote.spec.ts
+++ b/frontend/modules/publication/remote.spec.ts
@@ -1,7 +1,10 @@
 import { request } from "app";
+import { createStore } from "jotai";
 import type { AxiosInstance } from "axios";
 import { notify } from "components/Notifications";
 import hash from "object-hash";
+
+import type { Store } from "modules/store";
 
 import type { Publication } from "./model";
 import { empty } from "./model";
@@ -27,9 +30,7 @@ import {
   overrideField,
   publicationFamily,
   publicationIdsAtom,
-  resetAll,
   setAll,
-  store,
   totalIndexCountAtom,
   visiblePublicationFamily,
 } from "./store";
@@ -50,13 +51,15 @@ type Http = {
 };
 let http: Http;
 
+// A store per test — the remote layer writes the one it is handed.
+let store: Store;
+
 function pub(fields: Partial<Publication> = {}): Publication {
   return { ...empty(), ...fields };
 }
 
 beforeEach(() => {
-  resetAll();
-  store.set(isValidatingAtom, false);
+  store = createStore();
   vi.clearAllMocks();
 
   http = { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() };
@@ -78,7 +81,7 @@ describe("index", () => {
       headers: { "rb-total-count": "42" },
     });
 
-    await index();
+    await index(store);
 
     const ids = store.get(publicationIdsAtom);
     expect(ids).toEqual([7, 12]);
@@ -97,14 +100,14 @@ describe("index", () => {
       headers: {},
     });
 
-    await index({ search: "Machado" });
+    await index(store, { search: "Machado" });
 
     expect(http.get).toHaveBeenCalledWith("publications?search=Machado");
   });
 
   test("keeps the previous rows on screen until the new results arrive", async () => {
     const [a, b] = [createId(), createId()];
-    setAll([
+    setAll(store, [
       { id: a, publication: pub({ title: "Old A" }), errors: null },
       { id: b, publication: pub({ title: "Old B" }), errors: null },
     ]);
@@ -114,7 +117,7 @@ describe("index", () => {
     http.get.mockReturnValue(new Promise((r) => (resolve = r)));
 
     store.set(isIndexLoadingAtom, true);
-    const pending = index({ search: "new" });
+    const pending = index(store, { search: "new" });
 
     // Mid-fetch: the old ids are still there — no reset-to-undefined, so the
     // table shows the stale rows instead of blinking the skeleton.
@@ -134,7 +137,7 @@ describe("index", () => {
   });
 });
 
-describe("index({ unreferenced })", () => {
+describe("index(store, { unreferenced })", () => {
   test("loads the reference-less publications and returns their ids", async () => {
     http.get.mockResolvedValue({
       data: {
@@ -146,7 +149,7 @@ describe("index({ unreferenced })", () => {
       headers: {},
     });
 
-    const ids = await index({ unreferenced: true });
+    const ids = await index(store, { unreferenced: true });
 
     expect(http.get).toHaveBeenCalledWith("publications?unreferenced");
     expect(ids).toEqual([7, 12]);
@@ -159,14 +162,14 @@ describe("index({ unreferenced })", () => {
 describe("bulk", () => {
   test("submits the visible working set and clears the list", async () => {
     const [a, b] = [createId(), createId()];
-    setAll([
+    setAll(store, [
       { id: a, publication: pub({ title: "A" }), errors: null },
       { id: b, publication: pub({ title: "B" }), errors: null },
     ]);
     const created = [pub({ title: "A" })];
     http.post.mockResolvedValue({ data: created });
 
-    const result = await bulk();
+    const result = await bulk(store);
 
     expect(http.post).toHaveBeenCalledTimes(1);
     const [url, body] = http.post.mock.calls[0];
@@ -183,11 +186,11 @@ describe("update", () => {
   test("PUTs the edited row, replaces it with the server value, and clears the edit", async () => {
     const id = 7;
     store.set(publicationFamily(id), pub({ title: "Old title" }));
-    overrideField(id, "title", "New title");
+    overrideField(store, id, "title", "New title");
     const returned = { ...pub({ title: "New title" }), id };
     http.put.mockResolvedValue({ data: returned });
 
-    const ok = await update(id);
+    const ok = await update(store, id);
 
     expect(ok).toBe(true);
     const [url, body] = http.put.mock.calls[0];
@@ -209,7 +212,7 @@ describe("update", () => {
       response: { status: 409, data: { errors: "conflict" } },
     });
 
-    const ok = await update(id);
+    const ok = await update(store, id);
 
     expect(ok).toBe(false);
     expect(mockNotify).toHaveBeenCalledWith(
@@ -224,7 +227,7 @@ describe("update", () => {
       response: { status: 400, data: { errors: { title: "required" } } },
     });
 
-    const ok = await update(id);
+    const ok = await update(store, id);
 
     expect(ok).toBe(false);
     expect(store.get(errorFamily(id))).toEqual({ title: "required" });
@@ -239,7 +242,7 @@ describe("remove", () => {
     store.set(totalIndexCountAtom, 288);
     http.delete.mockResolvedValue({});
 
-    const ok = await deletePublication(7);
+    const ok = await deletePublication(store, 7);
 
     expect(ok).toBe(true);
     expect(http.delete).toHaveBeenCalledWith("publications/7");
@@ -258,7 +261,7 @@ describe("remove", () => {
     store.set(totalIndexCountAtom, 288);
     http.delete.mockRejectedValue({ response: { status: 404 } });
 
-    const ok = await deletePublication(7);
+    const ok = await deletePublication(store, 7);
 
     expect(ok).toBe(false);
     expect(store.get(publicationIdsAtom)).toEqual([7]);
@@ -334,12 +337,12 @@ describe("validateUpdate", () => {
   test("POSTs the visible value to the row's validate endpoint and surfaces its errors", async () => {
     const id = 7;
     store.set(publicationFamily(id), pub({ title: "Old title" }));
-    overrideField(id, "title", "New title");
+    overrideField(store, id, "title", "New title");
     http.post.mockResolvedValue({
       data: { publication: pub({ title: "New title" }), errors: "conflict" },
     });
 
-    await validateUpdate(id);
+    await validateUpdate(store, id);
 
     const [url, body] = http.post.mock.calls[0];
     // The id is in the path so the server can exclude the row from its own
@@ -361,8 +364,8 @@ describe("validateUpdate", () => {
     });
 
     // Blur fires this on every field, so an untouched row must not re-ask.
-    await validateUpdate(id);
-    await validateUpdate(id);
+    await validateUpdate(store, id);
+    await validateUpdate(store, id);
 
     expect(http.post).toHaveBeenCalledTimes(1);
   });
@@ -374,7 +377,7 @@ describe("validateUpdate", () => {
       data: { publication: pub({ title: "Dom Casmurro" }), errors: null },
     });
 
-    await validateUpdate(id);
+    await validateUpdate(store, id);
 
     expect(store.get(errorFamily(id))).toBeNull();
   });
@@ -383,7 +386,7 @@ describe("validateUpdate", () => {
 describe("validate", () => {
   test("maps each result back to the row it was sent for, not the row's list position", async () => {
     const [a, b, c] = [createId(), createId(), createId()];
-    setAll([
+    setAll(store, [
       { id: a, publication: pub({ title: "A" }), errors: null },
       { id: b, publication: pub({ title: "B" }), errors: null },
       { id: c, publication: pub({ title: "C" }), errors: null },
@@ -403,7 +406,7 @@ describe("validate", () => {
       ],
     });
 
-    await validate([a, b, c]);
+    await validate(store, [a, b, c]);
 
     // The 2nd result must land on C (the 2nd row *sent*), never B (2nd *listed*).
     expect(store.get(errorFamily(a))).toBe("conflict");
@@ -418,13 +421,13 @@ describe("validate", () => {
 
   test("re-sends a row after its value changes and refreshes its error", async () => {
     const a = createId();
-    setAll([{ id: a, publication: pub({ title: "" }), errors: null }]);
+    setAll(store, [{ id: a, publication: pub({ title: "" }), errors: null }]);
 
     // First pass: the server rejects the row.
     http.post.mockResolvedValueOnce({
       data: [{ publication: pub({ title: "" }), errors: "conflict" }],
     });
-    await validate([a]);
+    await validate(store, [a]);
     expect(store.get(errorFamily(a))).toBe("conflict");
 
     // The user fixes the row: its value — and therefore its hash — changes, so
@@ -436,7 +439,7 @@ describe("validate", () => {
     http.post.mockResolvedValueOnce({
       data: [{ publication: pub({ title: "Dom Casmurro" }), errors: null }],
     });
-    await validate([a]);
+    await validate(store, [a]);
 
     expect(http.post).toHaveBeenCalledTimes(2);
     expect(store.get(errorFamily(a))).toBeNull();
@@ -444,13 +447,13 @@ describe("validate", () => {
 
   test("skips the request when nothing changed", async () => {
     const a = createId();
-    setAll([{ id: a, publication: pub({ title: "A" }), errors: null }]);
+    setAll(store, [{ id: a, publication: pub({ title: "A" }), errors: null }]);
     store.set(
       lastValidatedFamily(a),
       hash(store.get(visiblePublicationFamily(a))),
     );
 
-    await validate([a]);
+    await validate(store, [a]);
 
     expect(http.post).not.toHaveBeenCalled();
     expect(store.get(isValidatingAtom)).toBe(false);
@@ -458,10 +461,10 @@ describe("validate", () => {
 
   test("clears the validating flag even when the request fails", async () => {
     const a = createId();
-    setAll([{ id: a, publication: pub({ title: "A" }), errors: null }]);
+    setAll(store, [{ id: a, publication: pub({ title: "A" }), errors: null }]);
     http.post.mockRejectedValue("boom");
 
-    await expect(validate([a])).rejects.toBe("boom");
+    await expect(validate(store, [a])).rejects.toBe("boom");
 
     expect(store.get(isValidatingAtom)).toBe(false);
     expect(mockNotify).toHaveBeenCalled();
@@ -471,7 +474,9 @@ describe("validate", () => {
 describe("upload", () => {
   test("replaces the working set from the server's validation", async () => {
     const old = createId();
-    setAll([{ id: old, publication: pub({ title: "old" }), errors: null }]);
+    setAll(store, [
+      { id: old, publication: pub({ title: "old" }), errors: null },
+    ]);
 
     http.post.mockResolvedValue({
       data: [
@@ -480,7 +485,7 @@ describe("upload", () => {
       ],
     });
 
-    await upload(new FormData());
+    await upload(store, new FormData());
 
     const ids = store.get(publicationIdsAtom);
     expect(ids).toHaveLength(2);
@@ -498,7 +503,7 @@ describe("run (error handling)", () => {
   test("notifies with a friendly message and re-throws on failure", async () => {
     mockRequest.mockRejectedValueOnce("conflict");
 
-    await expect(index()).rejects.toBe("conflict");
+    await expect(index(store)).rejects.toBe("conflict");
 
     expect(mockNotify).toHaveBeenCalledWith({
       message: "A publication with this data already exists",

--- a/frontend/modules/publication/remote.ts
+++ b/frontend/modules/publication/remote.ts
@@ -3,6 +3,8 @@ import { AxiosError, AxiosInstance } from "axios";
 import { notify } from "components/Notifications";
 import { RESET } from "jotai/utils";
 import { TOTAL_COUNT_HEADER } from "modules/api";
+import type { Store } from "modules/store";
+import { usePublicationStore } from "./workspace";
 import hash from "object-hash";
 import { useCallback } from "react";
 import useDebounce from "utils/useDebounce";
@@ -29,7 +31,6 @@ import {
   resetAll,
   setAll,
   setErrors,
-  store,
   totalIndexCountAtom,
   visibleIdsAtom,
   visiblePublicationFamily,
@@ -67,9 +68,10 @@ type IndexOptions = { search?: string; unreferenced?: boolean };
  * by `search`, or to only the publications missing references (`unreferenced`) —
  * the queue the references backfill wizard steps through.
  */
-async function index({ search, unreferenced }: IndexOptions = {}): Promise<
-  PublicationId[]
-> {
+async function index(
+  store: Store,
+  { search, unreferenced }: IndexOptions = {},
+): Promise<PublicationId[]> {
   return run(async (http) => {
     const query = search
       ? `?search=${search}`
@@ -92,7 +94,7 @@ async function index({ search, unreferenced }: IndexOptions = {}): Promise<
       }
       store.set(keywordsAtom, keywords ?? []);
 
-      return hydrate(entries);
+      return hydrate(store, entries);
     } finally {
       store.set(isIndexLoadingAtom, false);
     }
@@ -100,7 +102,7 @@ async function index({ search, unreferenced }: IndexOptions = {}): Promise<
 }
 
 /** Submit the current (visible) working set. */
-async function bulk(): Promise<Publication[]> {
+async function bulk(store: Store): Promise<Publication[]> {
   return run(async (http) => {
     const ids = store.get(visibleIdsAtom);
     const publications = ids?.map((id) =>
@@ -121,7 +123,7 @@ async function bulk(): Promise<Publication[]> {
  * Persist edits to a single publication (admin). Returns whether it succeeded;
  * on a conflict or validation error the row keeps its edits so they can be fixed.
  */
-async function update(id: PublicationId): Promise<boolean> {
+async function update(store: Store, id: PublicationId): Promise<boolean> {
   const publication = store.get(visiblePublicationFamily(id));
 
   try {
@@ -170,13 +172,16 @@ async function update(id: PublicationId): Promise<boolean> {
  * the record leaves the index and search but stays restorable, and the change
  * lands in the publication history. Returns whether it succeeded.
  */
-async function deletePublication(id: PublicationId): Promise<boolean> {
+async function deletePublication(
+  store: Store,
+  id: PublicationId,
+): Promise<boolean> {
   const { title } = store.get(publicationFamily(id));
 
   try {
     await request((http) => http.delete(`publications/${id}`));
 
-    removePublication(id);
+    removePublication(store, id);
     notify({
       message: "Publication deleted",
       detail: `“${title}” is out of the catalogue. Restore it from Deleted publications.`,
@@ -257,7 +262,7 @@ async function restore(id: PublicationId): Promise<boolean> {
  * Live-validate a single publication's pending edits, excluding it from the
  * conflict check so an in-place edit doesn't collide with itself.
  */
-async function validateUpdate(id: PublicationId): Promise<void> {
+async function validateUpdate(store: Store, id: PublicationId): Promise<void> {
   const publication = store.get(visiblePublicationFamily(id));
   const fingerprint = hash(publication);
 
@@ -271,12 +276,12 @@ async function validateUpdate(id: PublicationId): Promise<void> {
       `publications/${id}/validate`,
       publication,
     );
-    setErrors([{ ...data, id }]);
+    setErrors(store, [{ ...data, id }]);
   });
 }
 
 /** Validate the given rows server-side, but only those whose value changed. */
-async function validate(ids: PublicationId[]): Promise<void> {
+async function validate(store: Store, ids: PublicationId[]): Promise<void> {
   return run(async (http) => {
     store.set(isValidatingAtom, true);
     try {
@@ -299,7 +304,10 @@ async function validate(ids: PublicationId[]): Promise<void> {
         );
         // Map results back to the rows we actually sent (the filtered set),
         // not the original id list.
-        setErrors(data.map((entry, i) => ({ ...entry, id: pending[i].id })));
+        setErrors(
+          store,
+          data.map((entry, i) => ({ ...entry, id: pending[i].id })),
+        );
       }
     } finally {
       // Always clear the flag, even if the request throws.
@@ -309,33 +317,37 @@ async function validate(ids: PublicationId[]): Promise<void> {
 }
 
 /** Replace the working set from an uploaded CSV (validated server-side). */
-async function upload(payload: FormData): Promise<void> {
+async function upload(store: Store, payload: FormData): Promise<void> {
   return run(async (http) => {
-    resetAll();
+    resetAll(store);
     try {
       const { data } = await http.post<ValidationResult[]>(
         "publications/validate",
         payload,
       );
-      setAll(data.map((entry) => ({ ...entry, id: createId() })));
+      setAll(
+        store,
+        data.map((entry) => ({ ...entry, id: createId() })),
+      );
     } catch (error) {
-      setAll([]);
+      setAll(store, []);
       throw error;
     }
   });
 }
 
-/** Debounced index, for search-as-you-type. */
+/** Debounced index, for search-as-you-type, against the workspace's own store. */
 function usePublicationIndex() {
+  const store = usePublicationStore();
   const debounced = useDebounce(index, 350);
   // Flag loading immediately (before the debounce) so the search bar's loading
   // bar spans the whole keystroke-to-results window, not just the fetch.
   return useCallback(
     (args?: { search?: string }) => {
       store.set(isIndexLoadingAtom, true);
-      return debounced(args);
+      return debounced(store, args);
     },
-    [debounced],
+    [debounced, store],
   );
 }
 

--- a/frontend/modules/publication/store.spec.ts
+++ b/frontend/modules/publication/store.spec.ts
@@ -1,3 +1,4 @@
+import { createStore } from "jotai";
 import { RESET } from "jotai/utils";
 
 import {
@@ -35,7 +36,6 @@ import {
   setAttributesVisible,
   setDiscarded,
   setErrors,
-  store,
   totalCountAtom,
   validCountAtom,
   visibleAttributesAtom,
@@ -43,6 +43,12 @@ import {
   visibleIdsAtom,
   visiblePublicationFamily,
 } from "./store";
+
+import type { Store } from "modules/store";
+
+// A store per test: publication state belongs to a workspace, so a spec makes
+// its own rather than resetting one everybody shares.
+let store: Store;
 
 type Fields = Partial<ReturnType<typeof empty>>;
 
@@ -63,18 +69,18 @@ function fieldErrors(
 }
 
 beforeEach(() => {
-  // The store is a module singleton; give every test a clean slate. `resetAll`
-  // only touches rows currently in the id list, so reset the draft (never
-  // listed) and the attribute toggles explicitly.
-  resetAll();
+  store = createStore();
+  // The atom *caches* are still module-level, so ids from an earlier test are
+  // reachable through the families even with a fresh store — clear them, and the
+  // draft row with them (it is never in the id list).
+  forget(knownIds());
   store.set(overrideFamily(DRAFT_ID), RESET);
-  resetAttributes();
 });
 
 describe("setAll", () => {
   test("registers the given ids and exposes them as visible", () => {
     const [a, b, c] = [createId(), createId(), createId()];
-    setAll([entry(a, { title: "Dom Casmurro" }), entry(b), entry(c)]);
+    setAll(store, [entry(a, { title: "Dom Casmurro" }), entry(b), entry(c)]);
 
     expect(store.get(publicationIdsAtom)).toEqual([a, b, c]);
     expect(store.get(visibleIdsAtom)).toEqual([a, b, c]);
@@ -84,7 +90,7 @@ describe("setAll", () => {
 
   test("a cell reads its publication's field", () => {
     const a = createId();
-    setAll([entry(a, { title: "Dom Casmurro" })]);
+    setAll(store, [entry(a, { title: "Dom Casmurro" })]);
 
     expect(store.get(fieldValueFamily({ id: a, key: "title" }))).toBe(
       "Dom Casmurro",
@@ -107,7 +113,7 @@ describe("setAll", () => {
 
   test("a cell key survives the negative ids minted for unsaved rows", () => {
     const a = createId();
-    setAll([entry(a, { title: "Dom Casmurro" })]);
+    setAll(store, [entry(a, { title: "Dom Casmurro" })]);
 
     // Ids are packed into a `<id>:<key>` string; a negative id carries its own
     // "-", so splitting on the wrong separator would misread the id.
@@ -121,7 +127,7 @@ describe("setAll", () => {
 describe("validity", () => {
   test("only error-free rows count as valid", () => {
     const [a, b] = [createId(), createId()];
-    setAll([entry(a), entry(b, {}, "conflict")]);
+    setAll(store, [entry(a), entry(b, {}, "conflict")]);
 
     expect(store.get(validCountAtom)).toBe(1);
     expect(store.get(isValidFamily(a))).toBe(true);
@@ -130,10 +136,10 @@ describe("validity", () => {
 
   test("setErrors flips a loaded row to invalid", () => {
     const a = createId();
-    setAll([entry(a)]);
+    setAll(store, [entry(a)]);
     expect(store.get(validCountAtom)).toBe(1);
 
-    setErrors([entry(a, {}, fieldErrors({ title: "required" }))]);
+    setErrors(store, [entry(a, {}, fieldErrors({ title: "required" }))]);
 
     expect(store.get(isValidFamily(a))).toBe(false);
     expect(store.get(validCountAtom)).toBe(0);
@@ -143,9 +149,9 @@ describe("validity", () => {
 describe("deletion", () => {
   test("setDiscarded hides a row without dropping it from the list", () => {
     const [a, b] = [createId(), createId()];
-    setAll([entry(a), entry(b)]);
+    setAll(store, [entry(a), entry(b)]);
 
-    setDiscarded([a]);
+    setDiscarded(store, [a]);
 
     expect(store.get(visibleIdsAtom)).toEqual([b]);
     expect(store.get(visibleCountAtom)).toBe(1);
@@ -155,21 +161,21 @@ describe("deletion", () => {
 
   test("a deleted row no longer counts as valid", () => {
     const [a, b] = [createId(), createId()];
-    setAll([entry(a), entry(b)]);
+    setAll(store, [entry(a), entry(b)]);
     expect(store.get(validCountAtom)).toBe(2);
 
-    setDiscarded([a]);
+    setDiscarded(store, [a]);
 
     expect(store.get(validCountAtom)).toBe(1);
   });
 
   test("resetDiscarded brings hidden rows back", () => {
     const [a, b] = [createId(), createId()];
-    setAll([entry(a), entry(b)]);
-    setDiscarded([a]);
+    setAll(store, [entry(a), entry(b)]);
+    setDiscarded(store, [a]);
     expect(store.get(visibleCountAtom)).toBe(1);
 
-    resetDiscarded();
+    resetDiscarded(store);
 
     expect(store.get(visibleIdsAtom)).toEqual([a, b]);
   });
@@ -178,9 +184,9 @@ describe("deletion", () => {
 describe("overrides", () => {
   test("overrideField layers an edit over the stored publication", () => {
     const a = createId();
-    setAll([entry(a, { title: "Dom Casmurro" })]);
+    setAll(store, [entry(a, { title: "Dom Casmurro" })]);
 
-    overrideField(a, "title", "Dom Casmurro (rev.)");
+    overrideField(store, a, "title", "Dom Casmurro (rev.)");
 
     // The merged (visible) value reflects the edit...
     expect(store.get(fieldValueFamily({ id: a, key: "title" }))).toBe(
@@ -198,11 +204,11 @@ describe("overrides", () => {
 
   test("resetOverridden drops pending edits", () => {
     const a = createId();
-    setAll([entry(a, { title: "Dom Casmurro" })]);
-    overrideField(a, "title", "changed");
+    setAll(store, [entry(a, { title: "Dom Casmurro" })]);
+    overrideField(store, a, "title", "changed");
     expect(store.get(overriddenCountAtom)).toBe(1);
 
-    resetOverridden();
+    resetOverridden(store);
 
     expect(store.get(overriddenCountAtom)).toBe(0);
     expect(store.get(fieldValueFamily({ id: a, key: "title" }))).toBe(
@@ -212,12 +218,12 @@ describe("overrides", () => {
 
   test("discardEdit drops one row's pending edits and errors", () => {
     const a = createId();
-    setAll([entry(a, { title: "Dom Casmurro" }, "conflict")]);
-    overrideField(a, "title", "changed");
+    setAll(store, [entry(a, { title: "Dom Casmurro" }, "conflict")]);
+    overrideField(store, a, "title", "changed");
     expect(store.get(overriddenCountAtom)).toBe(1);
     expect(store.get(isValidFamily(a))).toBe(false);
 
-    discardEdit(a);
+    discardEdit(store, a);
 
     expect(store.get(overriddenCountAtom)).toBe(0);
     expect(store.get(fieldValueFamily({ id: a, key: "title" }))).toBe(
@@ -230,11 +236,11 @@ describe("overrides", () => {
 describe("addNew", () => {
   test("commits the typed draft as a real row and clears the draft", () => {
     const a = createId();
-    setAll([entry(a)]);
+    setAll(store, [entry(a)]);
 
     // Type into the always-present draft row, then commit it.
-    overrideField(DRAFT_ID, "title", "A Hora da Estrela");
-    const newId = addNew();
+    overrideField(store, DRAFT_ID, "title", "A Hora da Estrela");
+    const newId = addNew(store);
 
     expect(store.get(publicationIdsAtom)).toEqual([a, newId]);
     expect(store.get(publicationFamily(newId)).title).toBe("A Hora da Estrela");
@@ -244,19 +250,19 @@ describe("addNew", () => {
 
   test("refuses to run before entries are loaded", () => {
     // beforeEach left the id list unset (RESET → undefined).
-    expect(() => addNew()).toThrow();
+    expect(() => addNew(store)).toThrow();
   });
 });
 
 describe("duplicate", () => {
   test("inserts a copy immediately after each selected row", () => {
     const [a, b] = [createId(), createId()];
-    setAll([
+    setAll(store, [
       entry(a, { title: "Dom Casmurro" }),
       entry(b, { title: "Grande Sertão" }),
     ]);
 
-    const [copyId] = duplicate(new Set([a]));
+    const [copyId] = duplicate(store, new Set([a]));
 
     expect(store.get(publicationIdsAtom)).toEqual([a, copyId, b]);
     expect(store.get(publicationFamily(copyId)).title).toBe("Dom Casmurro");
@@ -267,16 +273,16 @@ describe("attribute visibility", () => {
   test("hiding an attribute moves it from visible to hidden", () => {
     expect(store.get(visibleAttributesAtom)).toContain("year");
 
-    setAttributesVisible(["year"], false);
+    setAttributesVisible(store, ["year"], false);
 
     expect(store.get(visibleAttributesAtom)).not.toContain("year");
     expect(store.get(hiddenAttributesAtom)).toContain("year");
   });
 
   test("resetAttributes restores default visibility", () => {
-    setAttributesVisible(["year"], false);
+    setAttributesVisible(store, ["year"], false);
 
-    resetAttributes();
+    resetAttributes(store);
 
     expect(store.get(visibleAttributesAtom)).toContain("year");
   });
@@ -285,7 +291,7 @@ describe("attribute visibility", () => {
 describe("focusNextInvalid", () => {
   test("steps through invalid rows and wraps back to the first", () => {
     const [a, b, c, d] = [createId(), createId(), createId(), createId()];
-    setAll([
+    setAll(store, [
       entry(a),
       entry(b, {}, "conflict"),
       entry(c),
@@ -293,15 +299,15 @@ describe("focusNextInvalid", () => {
     ]);
 
     // Nothing focused yet → first invalid (b).
-    focusNextInvalid();
+    focusNextInvalid(store);
     expect(store.get(focusedRowIdAtom)).toBe(b);
 
     // → next invalid after b (d).
-    focusNextInvalid();
+    focusNextInvalid(store);
     expect(store.get(focusedRowIdAtom)).toBe(d);
 
     // → nothing invalid after d, so wrap around to b.
-    focusNextInvalid();
+    focusNextInvalid(store);
     expect(store.get(focusedRowIdAtom)).toBe(b);
   });
 });
@@ -329,11 +335,11 @@ describe("family lifecycle", () => {
   });
 
   test("a load forgets the publications the previous one held", () => {
-    hydrate([saved(1), saved(2)]);
+    hydrate(store, [saved(1), saved(2)]);
     expect([...knownIds()]).toEqual(expect.arrayContaining([1, 2]));
 
     // A disjoint second load — a different search, say.
-    hydrate([saved(3)]);
+    hydrate(store, [saved(3)]);
 
     // The families hold the current set and nothing else: an id that keeps its
     // atom keeps it for the whole session.
@@ -341,10 +347,10 @@ describe("family lifecycle", () => {
   });
 
   test("a row with unsaved edits survives a load that drops it", () => {
-    hydrate([saved(1)]);
-    overrideField(1, "title", "Being typed");
+    hydrate(store, [saved(1)]);
+    overrideField(store, 1, "title", "Being typed");
 
-    hydrate([saved(2)]);
+    hydrate(store, [saved(2)]);
 
     // Dropping it would discard what the admin is in the middle of writing —
     // a search running behind an open editor must not do that.
@@ -352,7 +358,7 @@ describe("family lifecycle", () => {
   });
 
   test("forgetting a publication drops its per-cell atoms too", () => {
-    hydrate([saved(7, "Dom Casmurro")]);
+    hydrate(store, [saved(7, "Dom Casmurro")]);
     // Touch a cell so its atom is cached.
     store.get(fieldValueFamily({ id: 7, key: "title" }));
 
@@ -369,7 +375,7 @@ describe("family lifecycle", () => {
     // The specs poke families with ids that never enter publicationIdsAtom.
     store.set(publicationFamily(99), saved(99, "Poked"));
 
-    resetAll();
+    resetAll(store);
 
     expect([...knownIds()]).not.toContain(99);
   });

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -1,7 +1,7 @@
 import { Atom, atom } from "jotai";
 import { atomFamily } from "jotai-family";
 import { RESET, atomWithReset } from "jotai/utils";
-import { store } from "modules/store";
+import type { Store } from "modules/store";
 import {
   ATTRIBUTES,
   DEFAULT_ATTRIBUTE_VISIBILITY,
@@ -263,7 +263,7 @@ function knownIds(): Set<PublicationId> {
  * publication seen this session. A row with a pending edit is kept regardless:
  * a search running behind an open editor must not discard what is being typed.
  */
-function hydrate(publications: Publication[]): PublicationId[] {
+function hydrate(store: Store, publications: Publication[]): PublicationId[] {
   const ids = publications.map((publication) => publication.id!);
   const arriving = new Set(ids);
 
@@ -287,11 +287,11 @@ function hydrate(publications: Publication[]): PublicationId[] {
  * record (a publication's own page) needs before it can be edited, since the
  * form edits the store's copy.
  */
-function remember(publication: Publication): void {
+function remember(store: Store, publication: Publication): void {
   store.set(publicationFamily(publication.id!), publication);
 }
 
-function setAll(entries: PublicationEntry[]): void {
+function setAll(store: Store, entries: PublicationEntry[]): void {
   store.set(
     publicationIdsAtom,
     entries.map(({ id }) => id),
@@ -302,19 +302,24 @@ function setAll(entries: PublicationEntry[]): void {
   });
 }
 
-function setErrors(entries: PublicationEntry[]): void {
+function setErrors(store: Store, entries: PublicationEntry[]): void {
   entries.forEach(({ id, errors }) => store.set(errorFamily(id), errors));
 }
 
-function setDiscarded(ids: PublicationId[], isDeleted = true): void {
+function setDiscarded(
+  store: Store,
+  ids: PublicationId[],
+  isDeleted = true,
+): void {
   ids.forEach((id) => store.set(discardedFamily(id), isDeleted));
 }
 
-function setFocusedRowId(id: PublicationId | undefined): void {
+function setFocusedRowId(store: Store, id: PublicationId | undefined): void {
   store.set(focusedRowIdAtom, id);
 }
 
 function overrideField(
+  store: Store,
   id: PublicationId,
   attribute: PublicationKey,
   value: string,
@@ -325,23 +330,31 @@ function overrideField(
 
 /** Overlay the whole provenance list (references are edited as a unit, not per
  * cell), reusing the same override overlay as the scalar fields. */
-function overrideReferences(id: PublicationId, references: string[]): void {
+function overrideReferences(
+  store: Store,
+  id: PublicationId,
+  references: string[],
+): void {
   const current = store.get(overrideFamily(id));
   store.set(overrideFamily(id), { ...current, references });
 }
 
 /** Drop a single row's pending edits and errors (cancelling an edit). */
-function discardEdit(id: PublicationId): void {
+function discardEdit(store: Store, id: PublicationId): void {
   store.set(overrideFamily(id), RESET);
   store.set(errorFamily(id), RESET);
 }
 
-function setAttributesVisible(keys: PublicationKey[], isVisible = true): void {
+function setAttributesVisible(
+  store: Store,
+  keys: PublicationKey[],
+  isVisible = true,
+): void {
   keys.forEach((key) => store.set(attributeVisibleFamily(key), isVisible));
 }
 
 /** Register the draft row as a new publication and clear the draft. */
-function addNew(): PublicationId {
+function addNew(store: Store): PublicationId {
   const ids = store.get(publicationIdsAtom);
   if (!ids) throw "Can not add new publications: entries not loaded.";
 
@@ -356,7 +369,10 @@ function addNew(): PublicationId {
 }
 
 /** Duplicate each selected publication, inserting the copy right after it. */
-function duplicate(duplicateIds: Set<PublicationId>): PublicationId[] {
+function duplicate(
+  store: Store,
+  duplicateIds: Set<PublicationId>,
+): PublicationId[] {
   const ids = store.get(publicationIdsAtom);
   if (!ids) throw "Can not duplicate publications: entries not loaded.";
 
@@ -378,7 +394,7 @@ function duplicate(duplicateIds: Set<PublicationId>): PublicationId[] {
   return newIds;
 }
 
-function resetAll(): void {
+function resetAll(store: Store): void {
   // Every id the families know, not just the ones currently listed: a value
   // set directly — as the specs do — would otherwise survive teardown and leak
   // into whatever runs next.
@@ -400,7 +416,7 @@ function resetAll(): void {
   store.set(isIndexLoadingAtom, false);
 }
 
-function resetDiscarded(): void {
+function resetDiscarded(store: Store): void {
   store
     .get(discardedIdsAtom)
     ?.forEach((id) => store.set(discardedFamily(id), RESET));
@@ -411,7 +427,7 @@ function resetDiscarded(): void {
  * delete): remove its id from the index and reset its per-row state. Distinct
  * from the workspace's `setDiscarded`, which only hides rows in memory.
  */
-function removePublication(id: PublicationId): void {
+function removePublication(store: Store, id: PublicationId): void {
   const ids = store.get(publicationIdsAtom);
   if (ids) {
     store.set(
@@ -433,18 +449,18 @@ function removePublication(id: PublicationId): void {
   }
 }
 
-function resetOverridden(): void {
+function resetOverridden(store: Store): void {
   store
     .get(publicationIdsAtom)
     ?.forEach((id) => store.set(overrideFamily(id), RESET));
 }
 
-function resetAttributes(): void {
+function resetAttributes(store: Store): void {
   ATTRIBUTES.forEach((key) => store.set(attributeVisibleFamily(key), RESET));
 }
 
 /** Focus the next invalid row after the currently focused one (wrapping). */
-function focusNextInvalid(): void {
+function focusNextInvalid(store: Store): void {
   const visibleIds = store.get(visibleIdsAtom);
   if (!visibleIds) return;
 
@@ -503,7 +519,6 @@ export {
   setDiscarded,
   setErrors,
   setFocusedRowId,
-  store,
   storedFieldValueFamily,
   storedReferencesFamily,
   totalCountAtom,

--- a/frontend/modules/publication/workspace.tsx
+++ b/frontend/modules/publication/workspace.tsx
@@ -2,45 +2,76 @@
 
 import { Provider, createStore } from "jotai";
 import type { Store } from "modules/store";
-import { createContext, ReactNode, useContext, useState } from "react";
+import { createContext, FC, ReactNode, useContext, useState } from "react";
 
 const PublicationStoreContext = createContext<Store | null>(null);
 
-/**
- * A workspace's own publication state.
- *
- * Publication state is a *working set* — rows loaded, edits pending, rows
- * selected, columns hidden — so it belongs to whatever surface is doing the work,
- * not to the application. Each provider owns a store of its own: two workspaces
- * on screen cannot see each other's edits, and a story or a spec gets a clean
- * one per render instead of resetting a shared singleton.
- *
- * Reads need nothing: the hooks in `./hooks` resolve this store through Jotai's
- * own provider. Writes name it, because the actions and the remote layer are
- * plain functions called from event handlers rather than hooks — they take the
- * store as their first argument, and `usePublicationStore` is how a component
- * hands them the right one.
- *
- * `store` is for a caller that has to seed the state before the tree renders
- * (a story's `beforeEach`, a spec); otherwise one is created here.
- */
-function PublicationStoreProvider({
-  store: provided,
-  children,
-}: {
+const OwnPublicationStore: FC<{
   store?: Store;
+  initialize?: (store: Store) => void;
   children: ReactNode;
-}) {
-  const [store] = useState(() => provided ?? createStore());
+}> = ({ store: provided, initialize, children }) => {
+  const [store] = useState(() => {
+    const store = provided ?? createStore();
+    initialize?.(store);
+    return store;
+  });
 
   return (
     <PublicationStoreContext.Provider value={store}>
       <Provider store={store}>{children}</Provider>
     </PublicationStoreContext.Provider>
   );
-}
+};
 
-/** The store of the workspace this component renders in. */
+/**
+ * Ensure this subtree has publication state to work in.
+ *
+ * Publication state is a *working set* — rows loaded, edits pending, rows
+ * selected, columns hidden — so it belongs to whatever surface is doing the
+ * work, not to the application. A surface that needs one renders this around
+ * itself, so nothing above it has to know that it does: needing a store is the
+ * component's own business, not a condition it puts on its callers.
+ *
+ * It **joins** an existing store rather than shadowing it. That is what lets a
+ * publication's view be both things at once: on its own page it owns the state
+ * it edits, and in the overlay over the catalogue it edits the catalogue's, so
+ * the row behind it changes with it. Two surfaces that are *not* nested get a
+ * store each, and cannot see each other's edits.
+ *
+ * Reads need nothing: the hooks in `./hooks` resolve this store through Jotai's
+ * own provider. Writes name it, because the actions and the remote layer are
+ * plain functions called from event handlers rather than hooks — they take the
+ * store as their first argument, and `usePublicationStore` is how a component
+ * hands them the right one.
+ */
+const PublicationStoreProvider: FC<{
+  /**
+   * A store to use as-is, for a caller that has to seed state before the tree
+   * renders (a story's `beforeEach`, a spec). Always wins.
+   */
+  store?: Store;
+  /**
+   * The state this surface starts in, written once before anything renders. A
+   * starting state belongs to the store, not to an effect that puts it there
+   * after the first paint — and writing to a store nobody has subscribed to yet
+   * is safe, which is what makes this different from seeding a shared one.
+   */
+  initialize?: (store: Store) => void;
+  children: ReactNode;
+}> = ({ store, initialize, children }) => {
+  const joined = useContext(PublicationStoreContext);
+
+  return store || !joined ? (
+    <OwnPublicationStore store={store} initialize={initialize}>
+      {children}
+    </OwnPublicationStore>
+  ) : (
+    <>{children}</>
+  );
+};
+
+/** The store of the surface this component renders in. */
 function usePublicationStore(): Store {
   const store = useContext(PublicationStoreContext);
 

--- a/frontend/modules/publication/workspace.tsx
+++ b/frontend/modules/publication/workspace.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Provider, createStore } from "jotai";
+import type { Store } from "modules/store";
+import { createContext, ReactNode, useContext, useState } from "react";
+
+const PublicationStoreContext = createContext<Store | null>(null);
+
+/**
+ * A workspace's own publication state.
+ *
+ * Publication state is a *working set* — rows loaded, edits pending, rows
+ * selected, columns hidden — so it belongs to whatever surface is doing the work,
+ * not to the application. Each provider owns a store of its own: two workspaces
+ * on screen cannot see each other's edits, and a story or a spec gets a clean
+ * one per render instead of resetting a shared singleton.
+ *
+ * Reads need nothing: the hooks in `./hooks` resolve this store through Jotai's
+ * own provider. Writes name it, because the actions and the remote layer are
+ * plain functions called from event handlers rather than hooks — they take the
+ * store as their first argument, and `usePublicationStore` is how a component
+ * hands them the right one.
+ *
+ * `store` is for a caller that has to seed the state before the tree renders
+ * (a story's `beforeEach`, a spec); otherwise one is created here.
+ */
+function PublicationStoreProvider({
+  store: provided,
+  children,
+}: {
+  store?: Store;
+  children: ReactNode;
+}) {
+  const [store] = useState(() => provided ?? createStore());
+
+  return (
+    <PublicationStoreContext.Provider value={store}>
+      <Provider store={store}>{children}</Provider>
+    </PublicationStoreContext.Provider>
+  );
+}
+
+/** The store of the workspace this component renders in. */
+function usePublicationStore(): Store {
+  const store = useContext(PublicationStoreContext);
+
+  if (!store) {
+    throw new Error(
+      "No publication store: render this inside <PublicationStoreProvider>.",
+    );
+  }
+
+  return store;
+}
+
+/** A store to seed and then hand to the provider. */
+function createPublicationStore(): Store {
+  return createStore();
+}
+
+export {
+  PublicationStoreProvider,
+  createPublicationStore,
+  usePublicationStore,
+};

--- a/frontend/modules/publication/workspace.tsx
+++ b/frontend/modules/publication/workspace.tsx
@@ -3,6 +3,7 @@
 import { Provider, createStore } from "jotai";
 import type { Store } from "modules/store";
 import { createContext, FC, ReactNode, useContext, useState } from "react";
+import invariant from "tiny-invariant";
 
 const PublicationStoreContext = createContext<Store | null>(null);
 
@@ -75,11 +76,10 @@ const PublicationStoreProvider: FC<{
 function usePublicationStore(): Store {
   const store = useContext(PublicationStoreContext);
 
-  if (!store) {
-    throw new Error(
-      "No publication store: render this inside <PublicationStoreProvider>.",
-    );
-  }
+  invariant(
+    store,
+    "No publication store: render this inside <PublicationStoreProvider>.",
+  );
 
   return store;
 }

--- a/frontend/modules/publication/workspace.tsx
+++ b/frontend/modules/publication/workspace.tsx
@@ -84,13 +84,4 @@ function usePublicationStore(): Store {
   return store;
 }
 
-/** A store to seed and then hand to the provider. */
-function createPublicationStore(): Store {
-  return createStore();
-}
-
-export {
-  PublicationStoreProvider,
-  createPublicationStore,
-  usePublicationStore,
-};
+export { PublicationStoreProvider, usePublicationStore };

--- a/frontend/modules/selection.spec.ts
+++ b/frontend/modules/selection.spec.ts
@@ -1,22 +1,30 @@
-import { clearSelection, getSelection, select } from "./selection";
+import { createStore } from "jotai";
+
+import { getSelection, select } from "./selection";
+import type { Store } from "./store";
+
+// A store per test: selection belongs to a workspace, so a spec makes its own.
+let store: Store;
 
 // A stable row order for shift-range selection.
 const orderedIds = [1, 2, 3, 4, 5];
 
-/** Apply a row click to the (shared, module-global) selection store. */
+/** Apply a row click to this test's selection store. */
 function click(
   id: number,
   modifiers: { metaKey?: boolean; shiftKey?: boolean } = {},
 ) {
-  select({ id, type: "publication", orderedIds, ...modifiers });
+  select(store, { id, type: "publication", orderedIds, ...modifiers });
 }
 
 function selected(): number[] {
-  return [...getSelection()].map(Number).sort((a, b) => a - b);
+  return [...getSelection(store)].map(Number).sort((a, b) => a - b);
 }
 
 describe("selection store", () => {
-  beforeEach(() => clearSelection());
+  beforeEach(() => {
+    store = createStore();
+  });
 
   test("a plain click selects only the clicked row", () => {
     click(3);
@@ -53,15 +61,15 @@ describe("selection store", () => {
 
   test("selecting a different entity type restarts the selection", () => {
     click(3);
-    select({ id: 1, type: "other", orderedIds });
+    select(store, { id: 1, type: "other", orderedIds });
     expect(selected()).toEqual([1]);
   });
 
   test("the selection size tracks the store", () => {
-    expect(getSelection().size).toBe(0);
+    expect(getSelection(store).size).toBe(0);
 
     click(2);
     click(3, { metaKey: true });
-    expect(getSelection().size).toBe(2);
+    expect(getSelection(store).size).toBe(2);
   });
 });

--- a/frontend/modules/selection.ts
+++ b/frontend/modules/selection.ts
@@ -2,7 +2,7 @@
 
 import { atom, useAtomValue } from "jotai";
 import { atomFamily } from "jotai-family";
-import { store } from "modules/store";
+import type { Store } from "modules/store";
 
 type SelectableId = string | number;
 
@@ -115,18 +115,18 @@ function reduce(state: SelectionState, event: SelectionEvent): SelectionState {
   return { selection: new Set([id]), type, pivot: id };
 }
 
-// --- Actions (write the shared store, like modules/publication) -------------
+// --- Actions (write the store they are given, like modules/publication) -----
 
-export function select(event: SelectionEvent): void {
+export function select(store: Store, event: SelectionEvent): void {
   store.set(selectionStateAtom, reduce(store.get(selectionStateAtom), event));
 }
 
-export function clearSelection(): void {
+export function clearSelection(store: Store): void {
   store.set(selectionStateAtom, empty());
 }
 
 /** Imperative, non-reactive read of the current selection. */
-export function getSelection(): Set<SelectableId> {
+export function getSelection(store: Store): Set<SelectableId> {
   return store.get(selectionAtom);
 }
 

--- a/frontend/modules/selection.ts
+++ b/frontend/modules/selection.ts
@@ -1,5 +1,7 @@
 // Ported from `react-selection-manager` to `jotai`.
 
+import { isElement } from "lodash";
+
 import { atom, useAtomValue } from "jotai";
 import { atomFamily } from "jotai-family";
 import type { Store } from "modules/store";
@@ -113,6 +115,25 @@ function reduce(state: SelectionState, event: SelectionEvent): SelectionState {
 
   // Plain click: select just the clicked row.
   return { selection: new Set([id]), type, pivot: id };
+}
+
+/**
+ * The marker for a row's **selection handle**: a click on it, or on anything
+ * inside it, asks for that row to be selected.
+ *
+ * Deliberately separate from the flag that governs *text* selection, and
+ * deliberately absent from cells that hold a field — a click that lands in an
+ * input is there to type, not to select. Both the row that selects and the
+ * listener that clears read this one marker, so the two can never disagree about
+ * what counts as a selection.
+ */
+const SELECTION_HANDLE = '[data-selects-row="true"]';
+
+/** Whether a click asks for a row to be selected. */
+export function isSelectionGesture(target: EventTarget | null): boolean {
+  return (
+    isElement(target) && Boolean((target as Element).closest(SELECTION_HANDLE))
+  );
 }
 
 // --- Actions (write the store they are given, like modules/publication) -----

--- a/frontend/modules/store.ts
+++ b/frontend/modules/store.ts
@@ -1,9 +1,15 @@
 import { createStore } from "jotai";
 
 /**
- * The single Jotai store for the whole app. Provided to the React tree via
- * `<Provider store={store}>` in `pages/_app`, read by hooks (through the
- * Provider) and written by the imperative actions + remote layer — so
- * subscriptions and imperative writes always hit the same store.
+ * A Jotai store — the handle the imperative actions and the remote layer write
+ * through. Named so they can take one as an argument instead of reaching for a
+ * module-level singleton: which store a call belongs to is then part of the call.
  */
-export const store = createStore();
+export type Store = ReturnType<typeof createStore>;
+
+/**
+ * The app-global store, for state that is genuinely app-wide (notifications).
+ * Publication state lives in its own store, provided per workspace — see
+ * `PublicationStoreProvider`.
+ */
+export const store: Store = createStore();


### PR DESCRIPTION
Roadmap 15, in full. Publication state is a working set — rows loaded, edits pending, rows selected, columns hidden — so it belongs to the surface doing the work, not to the application. A module-global store made that impossible: nothing stopped two surfaces from sharing one working set, a hook chain imported into a server component would have shared it across requests, and every story and spec had to reset it by hand.

A provider now owns a store per workspace. Reads are unchanged — the hooks resolve it through Jotai's own provider — while the actions, the remote layer and the selection take the store as their first argument, since they are plain functions called from event handlers rather than hooks. Which store a write belongs to is part of the call.

A surface brings the state it needs rather than asking whatever renders it to provide one, and the provider joins the state it is already in rather than shadowing it — which is what lets a publication's view own what it edits on its own page and edit the catalogue's inside the overlay.

Two bugs surfaced while doing it, both fixed here. Selecting a row depended on the click missing the icon inside the handle, and cmd- or shift-clicking a second row could clear the selection instead of extending it — one attribute was answering two different questions. And the CSV export had not downloaded anything since response headers stopped being camelCased: the filename parse threw before the click that saves the file.

Stacked on #391.
