### PR TITLE
Read the catalogue where the page is rendered

### DIFF
--- a/frontend/app/Home.tsx
+++ b/frontend/app/Home.tsx
@@ -51,9 +51,6 @@ function Catalogue({ index, opened }: Props) {
   const isAuthenticated = useIsAuthenticated();
   const count = usePublicationIndexCount() || 0;
 
-  // The store opened with the first read (see `initialize`); this carries the
-  // ones after it — a new query, or a re-read after a change. Not a fetch: the
-  // reading is done, and this is the store catching up with it.
   const received = useRef(index);
 
   useEffect(() => {

--- a/frontend/app/Home.tsx
+++ b/frontend/app/Home.tsx
@@ -17,40 +17,50 @@ import {
 import PublicationSearch from "components/PublicationSearch";
 import SignInButton from "components/SignInButton";
 import SignOutButton from "components/SignOutButton";
-import type { PublicationView } from "app/publications/read";
+import type { PublicationIndex, PublicationView } from "app/publications/read";
 import { usePublicationIndexCount } from "modules/publication/hooks";
-import { usePublicationIndex } from "modules/publication/remote";
-import { PublicationStoreProvider } from "modules/publication/workspace";
+import { receiveIndex } from "modules/publication/store";
+import {
+  PublicationStoreProvider,
+  usePublicationStore,
+} from "modules/publication/workspace";
 import { useIsAuthenticated } from "modules/session";
 import Link from "next/link";
-import { useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 type Props = {
+  /** The catalogue for the current query, read on the server. */
+  index: PublicationIndex;
   /** The publication the URL names, read on the server. Unawaited, so the
    * overlay can open before it arrives. */
   opened?: Promise<PublicationView | null>;
 };
 
-export default function Home(props: Props) {
+export default function Home({ index, opened }: Props) {
   return (
-    <PublicationStoreProvider>
-      <Catalogue {...props} />
+    <PublicationStoreProvider
+      initialize={(store) => receiveIndex(store, index)}
+    >
+      <Catalogue index={index} opened={opened} />
     </PublicationStoreProvider>
   );
 }
 
-function Catalogue({ opened }: Props) {
-  const index = usePublicationIndex();
+function Catalogue({ index, opened }: Props) {
+  const store = usePublicationStore();
   const isAuthenticated = useIsAuthenticated();
   const count = usePublicationIndexCount() || 0;
 
-  const searchParams = useSearchParams();
-  const search = searchParams?.get("search") ?? undefined;
+  // The store opened with the first read (see `initialize`); this carries the
+  // ones after it — a new query, or a re-read after a change. Not a fetch: the
+  // reading is done, and this is the store catching up with it.
+  const received = useRef(index);
 
   useEffect(() => {
-    index({ search });
-  }, [index, search]);
+    if (received.current === index) return;
+    received.current = index;
+    receiveIndex(store, index);
+  }, [store, index]);
 
   const modal = useURLQueryModal(PUBLICATION_MODAL_KEY);
 

--- a/frontend/app/admin/publications/references/page.tsx
+++ b/frontend/app/admin/publications/references/page.tsx
@@ -1,9 +1,8 @@
-"use client";
-
 import Breadcrumb from "components/Breadcrumb";
 import Layout from "components/Layout";
 import PageHeader from "components/PageHeader";
 import ReferencesBackfill from "components/ReferencesBackfill";
+import { readUnreferenced } from "app/publications/read";
 
 const BREADCRUMB_ITEMS = [
   { label: "Home", href: "/" },
@@ -11,7 +10,9 @@ const BREADCRUMB_ITEMS = [
   { label: "Backfill references" },
 ];
 
-export default function ReferencesBackfillPage() {
+export default async function ReferencesBackfillPage() {
+  const queue = await readUnreferenced();
+
   return (
     <Layout
       subheader={
@@ -23,7 +24,7 @@ export default function ReferencesBackfillPage() {
           />
         </>
       }
-      content={<ReferencesBackfill />}
+      content={<ReferencesBackfill queue={queue} />}
     />
   );
 }

--- a/frontend/app/api.ts
+++ b/frontend/app/api.ts
@@ -17,11 +17,21 @@ const api = HTTP.client({ baseURL: process.env.NEXT_INTERNAL_API_URL });
  * uses.
  */
 export async function get<T>(path: string): Promise<T> {
+  return (await getWithHeaders<T>(path)).data;
+}
+
+/**
+ * The same read, with the response headers — some answers are partly in them
+ * (the index reports how many publications exist in `rb-total-count`).
+ */
+export async function getWithHeaders<T>(
+  path: string,
+): Promise<{ data: T; headers: Record<string, string> }> {
   const cookie = (await cookies()).get(SESSION_COOKIE);
 
-  const { data } = await api.get<T>(path, {
+  const { data, headers } = await api.get<T>(path, {
     headers: cookie ? { Cookie: `${cookie.name}=${cookie.value}` } : {},
   });
 
-  return data;
+  return { data, headers: headers as Record<string, string> };
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -17,12 +17,12 @@ export default async function Page({
 }) {
   const { publication, search } = await searchParams;
 
+  const opened = publication ? readPublication(publication) : undefined;
+  const index = await readIndex(search);
+
   return (
     <Suspense>
-      <Home
-        index={await readIndex(search)}
-        opened={publication ? readPublication(publication) : undefined}
-      />
+      <Home index={index} opened={opened} />
     </Suspense>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,25 +1,28 @@
 import { Suspense } from "react";
 import Home from "./Home";
-import { readPublication } from "./publications/read";
+import { readIndex, readPublication } from "./publications/read";
 
 // Server Component shell — the interactive index lives in the client `Home`,
 // Suspense-wrapped because it reads `useSearchParams()` (App Router requires the
 // boundary so static rendering can bail to the client cleanly).
 //
-// The publication the URL names is read here, from the address rather than from
-// whatever the index happens to have loaded. The promise is handed over
-// unawaited: the overlay opens on the URL alone and the record streams into it,
-// so a click is answered at once.
+// Both of the page's reads come from its address. The catalogue is awaited, so
+// the rows are in the first response rather than fetched again once it lands;
+// the publication an overlay would show is handed over unawaited, so the overlay
+// opens on the URL alone and the record streams into it.
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ publication?: string }>;
+  searchParams: Promise<{ publication?: string; search?: string }>;
 }) {
-  const { publication } = await searchParams;
+  const { publication, search } = await searchParams;
 
   return (
     <Suspense>
-      <Home opened={publication ? readPublication(publication) : undefined} />
+      <Home
+        index={await readIndex(search)}
+        opened={publication ? readPublication(publication) : undefined}
+      />
     </Suspense>
   );
 }

--- a/frontend/app/publications/read.ts
+++ b/frontend/app/publications/read.ts
@@ -1,5 +1,6 @@
-import { get } from "app/api";
+import { get, getWithHeaders } from "app/api";
 import { getSession } from "app/session";
+import { TOTAL_COUNT_HEADER } from "modules/api";
 import { withChanges, type WithChanges } from "modules/publication/history";
 import type {
   Publication,
@@ -45,3 +46,55 @@ export const readPublication = cache(
     return { publication, history: withChanges(entries) };
   },
 );
+
+/**
+ * A page of the catalogue: the rows, the keywords the search matched on, and how
+ * many publications exist in total — which the index reports in a header rather
+ * than in the body.
+ */
+export type PublicationIndex = {
+  entries: Publication[];
+  keywords: string[];
+  total: number | null;
+};
+
+/**
+ * Read the catalogue for a query, or the whole of it. This is the page's own
+ * content, so it is read where the page is rendered — the reader gets rows in
+ * the first response instead of an empty table and a spinner.
+ */
+export const readIndex = cache(
+  async (search?: string): Promise<PublicationIndex> => {
+    const query = search ? `?search=${encodeURIComponent(search)}` : "";
+    const { data, headers } = await getWithHeaders<{
+      entries: Publication[];
+      keywords?: string[];
+    }>(`/publications${query}`);
+
+    const total = headers[TOTAL_COUNT_HEADER];
+
+    return {
+      entries: data.entries,
+      keywords: data.keywords ?? [],
+      total: total === undefined ? null : parseInt(total),
+    };
+  },
+);
+
+/**
+ * The publications with no sources yet — the queue the backfill wizard steps
+ * through, in the order it will offer them.
+ */
+export const readUnreferenced = cache(async (): Promise<PublicationIndex> => {
+  const { data, headers } = await getWithHeaders<{ entries: Publication[] }>(
+    "/publications?unreferenced",
+  );
+
+  const total = headers[TOTAL_COUNT_HEADER];
+
+  return {
+    entries: data.entries,
+    keywords: [],
+    total: total === undefined ? null : parseInt(total),
+  };
+});

--- a/frontend/app/publications/read.ts
+++ b/frontend/app/publications/read.ts
@@ -6,6 +6,7 @@ import type {
   Publication,
   PublicationHistoryEntry,
 } from "modules/publication/model";
+import type { PublicationIndex } from "modules/publication/store";
 import { User } from "modules/users";
 import { cache } from "react";
 
@@ -47,54 +48,34 @@ export const readPublication = cache(
   },
 );
 
-/**
- * A page of the catalogue: the rows, the keywords the search matched on, and how
- * many publications exist in total — which the index reports in a header rather
- * than in the body.
- */
-export type PublicationIndex = {
-  entries: Publication[];
-  keywords: string[];
-  total: number | null;
-};
+export type { PublicationIndex };
+
+async function readCatalogue(query: string): Promise<PublicationIndex> {
+  const { data, headers } = await getWithHeaders<{
+    entries: Publication[];
+    keywords?: string[];
+  }>(`/publications${query}`);
+
+  const total = headers[TOTAL_COUNT_HEADER];
+
+  return {
+    entries: data.entries,
+    keywords: data.keywords ?? [],
+    total: total === undefined ? null : parseInt(total),
+  };
+}
 
 /**
  * Read the catalogue for a query, or the whole of it. This is the page's own
  * content, so it is read where the page is rendered — the reader gets rows in
  * the first response instead of an empty table and a spinner.
  */
-export const readIndex = cache(
-  async (search?: string): Promise<PublicationIndex> => {
-    const query = search ? `?search=${encodeURIComponent(search)}` : "";
-    const { data, headers } = await getWithHeaders<{
-      entries: Publication[];
-      keywords?: string[];
-    }>(`/publications${query}`);
-
-    const total = headers[TOTAL_COUNT_HEADER];
-
-    return {
-      entries: data.entries,
-      keywords: data.keywords ?? [],
-      total: total === undefined ? null : parseInt(total),
-    };
-  },
+export const readIndex = cache((search?: string) =>
+  readCatalogue(search ? `?search=${encodeURIComponent(search)}` : ""),
 );
 
 /**
  * The publications with no sources yet — the queue the backfill wizard steps
  * through, in the order it will offer them.
  */
-export const readUnreferenced = cache(async (): Promise<PublicationIndex> => {
-  const { data, headers } = await getWithHeaders<{ entries: Publication[] }>(
-    "/publications?unreferenced",
-  );
-
-  const total = headers[TOTAL_COUNT_HEADER];
-
-  return {
-    entries: data.entries,
-    keywords: [],
-    total: total === undefined ? null : parseInt(total),
-  };
-});
+export const readUnreferenced = cache(() => readCatalogue("?unreferenced"));

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -124,6 +124,13 @@ const Modal: FC<Props> = ({ children, isOpen, onClose, label = "Dialog" }) => {
                 <Header onClose={onClose} />
                 <motion.dialog
                   open
+                  // Its content can arrive after it opens — a record still being
+                  // read leaves a short "Loading…" in a tall dialog's place — so
+                  // it grows into what it is given instead of jumping.
+                  layout
+                  transition={{
+                    layout: { duration: 0.2, ease: "easeOut" },
+                  }}
                   role="dialog"
                   aria-modal="true"
                   aria-label={label}

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -124,9 +124,6 @@ const Modal: FC<Props> = ({ children, isOpen, onClose, label = "Dialog" }) => {
                 <Header onClose={onClose} />
                 <motion.dialog
                   open
-                  // Its content can arrive after it opens — a record still being
-                  // read leaves a short "Loading…" in a tall dialog's place — so
-                  // it grows into what it is given instead of jumping.
                   layout
                   transition={{
                     layout: { duration: 0.2, ease: "easeOut" },

--- a/frontend/components/PublicationSearch.mdx
+++ b/frontend/components/PublicationSearch.mdx
@@ -13,9 +13,17 @@ the workspace shows.
 ## Data source
 
 The input is **URL-driven**: on change it writes the current text to the
-`search` query param (`router.replace`, shallow), and on mount it hydrates its
-value back from that param, so a shared link reproduces the same search. The
-keyword layer below the input is **state-driven** — it reads the active
+`search` query param (`router.replace`), and on mount it hydrates its value back
+from that param, so a shared link reproduces the same search.
+
+Typing therefore **navigates** rather than fetching: the results for a query are
+read where the page is rendered, so the query living in the URL is all the page
+needs. The navigation runs in a transition — what is on screen stays until the
+new rows are ready — and is debounced, so a typist does not ask for a page per
+letter. "Searching…" shows while what has been typed and what the URL says have
+not met, or the page for it is still coming.
+
+The keyword layer below the input is **state-driven** — it reads the active
 keywords from the publication store (`useKeywords`) and, when any are present,
 renders "Showing results for" followed by each keyword as a link back to that
 single-term search. In stories the store is seeded through the shared fixtures:
@@ -32,8 +40,10 @@ seed(); // load the sample publications before the story renders
 
 - **Empty** — the default: the input renders with its placeholder and no
   keyword line below it.
-- **Typing** — entering text updates the input and the `search` param, which
-  debounces to the index endpoint. See the
+- **Typing** — entering text updates the input and, after a beat, the `search`
+  param the page reads its rows for. See the
   [Typing](?path=/story/publications-publication-search--typing) story.
+- **Searching** — the status line while the typed query and the URL have yet to
+  meet.
 - **Showing results** — when the store reports active keywords, the line under
   the input lists them as links.

--- a/frontend/components/PublicationSearch.stories.tsx
+++ b/frontend/components/PublicationSearch.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { seed } from "modules/publication/fixtures";
-import { isIndexLoadingAtom } from "modules/publication/store";
 import { store } from "modules/store";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 
@@ -40,16 +39,20 @@ export const FromUrlParam: Story = {
   },
 };
 
-/** While a search is in flight, the keyword line becomes an animated status. */
+/**
+ * While a search is in flight, the keyword line becomes an animated status. The
+ * query lives in the URL and the results are read for it, so "in flight" is what
+ * has been typed not having reached the URL yet.
+ */
 export const Searching: Story = {
-  beforeEach: () => {
-    seed(store);
-    store.set(isIndexLoadingAtom, true);
-  },
+  beforeEach: () => seed(store),
   play: async ({ canvasElement }) => {
-    await expect(
-      within(canvasElement).getByText(/Searching the collection/i),
-    ).toBeInTheDocument();
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByRole("textbox"), "mach");
+
+    await waitFor(() =>
+      expect(canvas.getByText(/Searching the collection/i)).toBeInTheDocument(),
+    );
   },
 };
 

--- a/frontend/components/PublicationSearch.tsx
+++ b/frontend/components/PublicationSearch.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import { useIsIndexLoading, useKeywords } from "modules/publication/hooks";
+import { useKeywords } from "modules/publication/hooks";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { ChangeEventHandler, FC, useState } from "react";
+import { ChangeEventHandler, FC, useState, useTransition } from "react";
+import useDebounce from "utils/useDebounce";
+
+/** Long enough that a typist does not query on every letter. */
+const SEARCH_DELAY_MS = 350;
 
 const PublicationSearch: FC = () => {
   const router = useRouter();
   const pathname = usePathname() ?? "";
   const searchParams = useSearchParams();
   const keywords = useKeywords();
-  const isLoading = useIsIndexLoading();
+  const [isNavigating, startTransition] = useTransition();
 
   const searchUrlParam = searchParams?.get("search") ?? "";
   const [search, setSearch] = useState(searchUrlParam);
@@ -21,14 +25,27 @@ const PublicationSearch: FC = () => {
     if (searchUrlParam) setSearch(searchUrlParam);
   }
 
+  // The query lives in the URL, and the results are read for it where the page is
+  // rendered — so typing navigates rather than fetching. In a transition, so what
+  // is on screen stays until the new rows are ready; debounced, so a typist does
+  // not ask for a page per letter.
+  const navigate = useDebounce(
+    (value: string) =>
+      startTransition(() => {
+        router.replace(
+          value ? `${pathname}?search=${encodeURIComponent(value)}` : pathname,
+        );
+      }),
+    SEARCH_DELAY_MS,
+  );
+
+  // What is typed and what the URL says have not met yet, or they have and the
+  // page is still coming: either way a search is in flight.
+  const isLoading = search !== searchUrlParam || isNavigating;
+
   const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     setSearch(e.target.value);
-
-    router.replace(
-      e.target.value
-        ? `${pathname}?search=${encodeURIComponent(e.target.value)}`
-        : pathname,
-    );
+    navigate(e.target.value);
   };
 
   return (

--- a/frontend/components/PublicationSearch.tsx
+++ b/frontend/components/PublicationSearch.tsx
@@ -3,7 +3,7 @@
 import { useKeywords } from "modules/publication/hooks";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { ChangeEventHandler, FC, useState, useTransition } from "react";
+import { ChangeEventHandler, FC, useRef, useState, useTransition } from "react";
 import useDebounce from "utils/useDebounce";
 
 /** Long enough that a typist does not query on every letter. */
@@ -20,24 +20,33 @@ const PublicationSearch: FC = () => {
   const [search, setSearch] = useState(searchUrlParam);
   const [previousParam, setPreviousParam] = useState(searchUrlParam);
 
+  // The last query this input asked the URL for. What it types travels to the URL
+  // and comes back, and typing does not stop while it is away: by the time
+  // "mach" arrives, the input may read "machado". So it follows the URL only
+  // when *someone else* changed it — a keyword link, the back button, a fresh
+  // arrival — and never when the URL is only catching up with what was typed.
+  const requested = useRef(searchUrlParam);
+
   if (searchUrlParam !== previousParam) {
     setPreviousParam(searchUrlParam);
-    if (searchUrlParam) setSearch(searchUrlParam);
+    if (searchUrlParam !== requested.current) {
+      requested.current = searchUrlParam;
+      setSearch(searchUrlParam);
+    }
   }
 
   // The query lives in the URL, and the results are read for it where the page is
   // rendered — so typing navigates rather than fetching. In a transition, so what
   // is on screen stays until the new rows are ready; debounced, so a typist does
   // not ask for a page per letter.
-  const navigate = useDebounce(
-    (value: string) =>
-      startTransition(() => {
-        router.replace(
-          value ? `${pathname}?search=${encodeURIComponent(value)}` : pathname,
-        );
-      }),
-    SEARCH_DELAY_MS,
-  );
+  const navigate = useDebounce((value: string) => {
+    requested.current = value;
+    startTransition(() => {
+      router.replace(
+        value ? `${pathname}?search=${encodeURIComponent(value)}` : pathname,
+      );
+    });
+  }, SEARCH_DELAY_MS);
 
   // What is typed and what the URL says have not met yet, or they have and the
   // page is still coming: either way a search is in flight.

--- a/frontend/components/PublicationSearch.tsx
+++ b/frontend/components/PublicationSearch.tsx
@@ -20,11 +20,6 @@ const PublicationSearch: FC = () => {
   const [search, setSearch] = useState(searchUrlParam);
   const [previousParam, setPreviousParam] = useState(searchUrlParam);
 
-  // The last query this input asked the URL for. What it types travels to the URL
-  // and comes back, and typing does not stop while it is away: by the time
-  // "mach" arrives, the input may read "machado". So it follows the URL only
-  // when *someone else* changed it — a keyword link, the back button, a fresh
-  // arrival — and never when the URL is only catching up with what was typed.
   const requested = useRef(searchUrlParam);
 
   if (searchUrlParam !== previousParam) {
@@ -35,10 +30,6 @@ const PublicationSearch: FC = () => {
     }
   }
 
-  // The query lives in the URL, and the results are read for it where the page is
-  // rendered — so typing navigates rather than fetching. In a transition, so what
-  // is on screen stays until the new rows are ready; debounced, so a typist does
-  // not ask for a page per letter.
   const navigate = useDebounce((value: string) => {
     requested.current = value;
     startTransition(() => {
@@ -48,8 +39,6 @@ const PublicationSearch: FC = () => {
     });
   }, SEARCH_DELAY_MS);
 
-  // What is typed and what the URL says have not met yet, or they have and the
-  // page is still coming: either way a search is in flight.
   const isLoading = search !== searchUrlParam || isNavigating;
 
   const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {

--- a/frontend/components/ReferencesBackfill.mdx
+++ b/frontend/components/ReferencesBackfill.mdx
@@ -12,10 +12,11 @@ on the right. Reached from the admin panel at `/admin/publications/references`.
 
 ## Composition
 
-- **`ReferencesBackfill`** (default export) — the orchestrator. On mount it loads
-  the reference-less publications (`index({ unreferenced: true })`) into the
-  store, tracks the current position and save state, and wires Save / Skip. It
-  resets the store on unmount, leaving it as it found it.
+- **`ReferencesBackfill`** (default export) — the orchestrator. It takes the
+  `queue` — the reference-less publications, read where the page is rendered —
+  brings the state the wizard edits them through, tracks the current position and
+  save state, and wires Save / Skip. The wizard opens on the first record rather
+  than on a spinner; there is no fetch on mount.
 - **`ReferencesBackfillView`** — the presentational shell. It takes the queue as
   an `ids` prop so its **loading** (`undefined`), **empty** (`[]`), and
   **populated** states can each be rendered and a11y-checked in isolation.
@@ -31,7 +32,9 @@ on the right. Reached from the admin panel at `/admin/publications/references`.
   publication selected. Fully interactive: click through the queue, edit
   references, and Skip / Save advance the position (persistence is the one
   part stubbed out).
-- **Loading** — while the queue is being fetched.
+- **Loading** — the shell's own empty-handed state (`ids: undefined`). The
+  wizard no longer reaches it in the app, since the queue arrives with the page;
+  the story keeps it because the shell still has to render it correctly.
 - **Empty** — nothing left to source ("All caught up").
 
 <Canvas of={ReferencesBackfillStories.Loading} />

--- a/frontend/components/ReferencesBackfill.tsx
+++ b/frontend/components/ReferencesBackfill.tsx
@@ -9,7 +9,7 @@ import {
   useUnreferencedPublicationCount,
 } from "modules/publication/hooks";
 import type { PublicationId } from "modules/publication/model";
-import { receiveIndex, type IndexPayload } from "modules/publication/store";
+import { receiveIndex, type PublicationIndex } from "modules/publication/store";
 import {
   PublicationStoreProvider,
   usePublicationStore,
@@ -237,13 +237,13 @@ export const ReferencesBackfillView: FC<{
   );
 };
 
-const ReferencesBackfill: FC<{ queue: IndexPayload }> = ({ queue }) => (
+const ReferencesBackfill: FC<{ queue: PublicationIndex }> = ({ queue }) => (
   <PublicationStoreProvider initialize={(store) => receiveIndex(store, queue)}>
     <Backfill queue={queue} />
   </PublicationStoreProvider>
 );
 
-const Backfill: FC<{ queue: IndexPayload }> = ({ queue }) => {
+const Backfill: FC<{ queue: PublicationIndex }> = ({ queue }) => {
   const store = usePublicationStore();
   const [position, setPosition] = useState(0);
   const [saving, setSaving] = useState(false);

--- a/frontend/components/ReferencesBackfill.tsx
+++ b/frontend/components/ReferencesBackfill.tsx
@@ -9,11 +9,12 @@ import {
   useUnreferencedPublicationCount,
 } from "modules/publication/hooks";
 import type { PublicationId } from "modules/publication/model";
+import { receiveIndex, type IndexPayload } from "modules/publication/store";
 import {
   PublicationStoreProvider,
   usePublicationStore,
 } from "modules/publication/workspace";
-import { index, update } from "modules/publication/remote";
+import { update } from "modules/publication/remote";
 import {
   discardEdit,
   overrideReferences,
@@ -236,25 +237,23 @@ export const ReferencesBackfillView: FC<{
   );
 };
 
-const ReferencesBackfill: FC = () => (
-  <PublicationStoreProvider>
-    <Backfill />
+const ReferencesBackfill: FC<{ queue: IndexPayload }> = ({ queue }) => (
+  <PublicationStoreProvider initialize={(store) => receiveIndex(store, queue)}>
+    <Backfill queue={queue} />
   </PublicationStoreProvider>
 );
 
-const Backfill: FC = () => {
+const Backfill: FC<{ queue: IndexPayload }> = ({ queue }) => {
   const store = usePublicationStore();
-  const [ids, setIds] = useState<PublicationId[]>();
   const [position, setPosition] = useState(0);
   const [saving, setSaving] = useState(false);
 
-  useEffect(() => {
-    index(store, { unreferenced: true }).then(setIds);
-    // Leave the store as we found it when the admin walks away.
-    return () => resetAll(store);
-  }, [store]);
+  // The store outlives nothing here, but the atom *caches* are module-level and
+  // do — drop what this queue put in them on the way out.
+  useEffect(() => () => resetAll(store), [store]);
 
-  const currentId = ids?.[position];
+  const ids = queue.entries.map(({ id }) => id!);
+  const currentId = ids[position];
 
   async function handleSave() {
     if (currentId === undefined) return;

--- a/frontend/components/ReferencesBackfill.tsx
+++ b/frontend/components/ReferencesBackfill.tsx
@@ -248,8 +248,6 @@ const Backfill: FC<{ queue: PublicationIndex }> = ({ queue }) => {
   const [position, setPosition] = useState(0);
   const [saving, setSaving] = useState(false);
 
-  // The store outlives nothing here, but the atom *caches* are module-level and
-  // do — drop what this queue put in them on the way out.
   useEffect(() => () => resetAll(store), [store]);
 
   const ids = queue.entries.map(({ id }) => id!);

--- a/frontend/e2e/browse-the-catalogue.spec.ts
+++ b/frontend/e2e/browse-the-catalogue.spec.ts
@@ -62,6 +62,25 @@ const BULK_CSV =
       `Author ${i};${1900 + i};US;Original ${i};Bulk Title ${i};Translator ${i};Publisher ${i};`,
   ).join("\n") + "\n";
 
+test("the catalogue arrives with the page, not after it", async ({
+  page,
+  request,
+  baseURL,
+}) => {
+  await seedCorpus(page);
+
+  // The raw response, before any script has run: the rows a reader asked for are
+  // already in it, and so is the count that goes with them. The index used to
+  // render a skeleton and fetch itself once the page was up.
+  const html = await (await request.get(`${baseURL}/?search=Machado`)).text();
+
+  expect(html).toContain("Dom Casmurro");
+  expect(html).toContain("Epitaph of a Small Winner");
+  expect(html).toContain("Showing results for");
+  // A publication the query excludes is not in it — the server ran the search.
+  expect(html).not.toContain("The Hour of the Star");
+});
+
 test("a large index virtualizes: far rows render as they scroll into view", async ({
   page,
 }) => {

--- a/frontend/modules/publication/hooks.ts
+++ b/frontend/modules/publication/hooks.ts
@@ -11,7 +11,6 @@ import {
   fieldValueFamily,
   focusedRowIdAtom,
   hiddenAttributesAtom,
-  isIndexLoadingAtom,
   isValidFamily,
   isValidatingAtom,
   keywordsAtom,
@@ -140,10 +139,6 @@ function useIsValidating() {
   return useAtomValue(isValidatingAtom);
 }
 
-function useIsIndexLoading() {
-  return useAtomValue(isIndexLoadingAtom);
-}
-
 function useKeywords() {
   return useAtomValue(keywordsAtom);
 }
@@ -172,7 +167,6 @@ export {
   useDiscardedPublicationCount,
   useHiddenAttributes,
   useIsAttributeVisible,
-  useIsIndexLoading,
   useIsPublicationFocused,
   useIsPublicationValid,
   useIsValidating,

--- a/frontend/modules/publication/remote.spec.ts
+++ b/frontend/modules/publication/remote.spec.ts
@@ -11,7 +11,6 @@ import { empty } from "./model";
 import {
   bulk,
   deletePublication,
-  index,
   restore,
   undo,
   update,
@@ -22,16 +21,14 @@ import {
 import {
   createId,
   errorFamily,
-  isIndexLoadingAtom,
   isValidatingAtom,
-  keywordsAtom,
   lastValidatedFamily,
   overrideFamily,
   overrideField,
   publicationFamily,
   publicationIdsAtom,
-  setAll,
   totalIndexCountAtom,
+  setAll,
   visiblePublicationFamily,
 } from "./store";
 
@@ -66,97 +63,6 @@ beforeEach(() => {
   // By default, `request(op)` runs the op against our fake http client.
   mockRequest.mockImplementation(((op: (client: AxiosInstance) => unknown) =>
     op(http as unknown as AxiosInstance)) as typeof request);
-});
-
-describe("index", () => {
-  test("loads entries, keywords and the total count", async () => {
-    http.get.mockResolvedValue({
-      data: {
-        entries: [
-          pub({ title: "Dom Casmurro", id: 7 }),
-          pub({ title: "The Hour of the Star", id: 12 }),
-        ],
-        keywords: ["machado"],
-      },
-      headers: { "rb-total-count": "42" },
-    });
-
-    await index(store);
-
-    const ids = store.get(publicationIdsAtom);
-    expect(ids).toEqual([7, 12]);
-    expect(store.get(publicationFamily(ids![0])).title).toBe("Dom Casmurro");
-    expect(store.get(publicationFamily(ids![1])).title).toBe(
-      "The Hour of the Star",
-    );
-    expect(store.get(totalIndexCountAtom)).toBe(42);
-    expect(store.get(keywordsAtom)).toEqual(["machado"]);
-    expect(http.get).toHaveBeenCalledWith("publications");
-  });
-
-  test("appends the search term to the query", async () => {
-    http.get.mockResolvedValue({
-      data: { entries: [], keywords: [] },
-      headers: {},
-    });
-
-    await index(store, { search: "Machado" });
-
-    expect(http.get).toHaveBeenCalledWith("publications?search=Machado");
-  });
-
-  test("keeps the previous rows on screen until the new results arrive", async () => {
-    const [a, b] = [createId(), createId()];
-    setAll(store, [
-      { id: a, publication: pub({ title: "Old A" }), errors: null },
-      { id: b, publication: pub({ title: "Old B" }), errors: null },
-    ]);
-
-    // Defer the response so we can inspect the store mid-fetch.
-    let resolve!: (value: unknown) => void;
-    http.get.mockReturnValue(new Promise((r) => (resolve = r)));
-
-    store.set(isIndexLoadingAtom, true);
-    const pending = index(store, { search: "new" });
-
-    // Mid-fetch: the old ids are still there — no reset-to-undefined, so the
-    // table shows the stale rows instead of blinking the skeleton.
-    expect(store.get(publicationIdsAtom)).toEqual([a, b]);
-
-    resolve({
-      data: { entries: [pub({ title: "New" })], keywords: [] },
-      headers: {},
-    });
-    await pending;
-
-    // The new results replace the old ones, and loading is cleared.
-    const ids = store.get(publicationIdsAtom);
-    expect(ids).toHaveLength(1);
-    expect(store.get(publicationFamily(ids![0])).title).toBe("New");
-    expect(store.get(isIndexLoadingAtom)).toBe(false);
-  });
-});
-
-describe("index(store, { unreferenced })", () => {
-  test("loads the reference-less publications and returns their ids", async () => {
-    http.get.mockResolvedValue({
-      data: {
-        entries: [
-          pub({ title: "Dom Casmurro", id: 7 }),
-          pub({ title: "The Hour of the Star", id: 12 }),
-        ],
-      },
-      headers: {},
-    });
-
-    const ids = await index(store, { unreferenced: true });
-
-    expect(http.get).toHaveBeenCalledWith("publications?unreferenced");
-    expect(ids).toEqual([7, 12]);
-    expect(store.get(publicationIdsAtom)).toEqual([7, 12]);
-    expect(store.get(publicationFamily(7)).title).toBe("Dom Casmurro");
-    expect(store.get(publicationFamily(12)).title).toBe("The Hour of the Star");
-  });
 });
 
 describe("bulk", () => {
@@ -503,7 +409,7 @@ describe("run (error handling)", () => {
   test("notifies with a friendly message and re-throws on failure", async () => {
     mockRequest.mockRejectedValueOnce("conflict");
 
-    await expect(index(store)).rejects.toBe("conflict");
+    await expect(bulk(store)).rejects.toBe("conflict");
 
     expect(mockNotify).toHaveBeenCalledWith({
       message: "A publication with this data already exists",

--- a/frontend/modules/publication/remote.ts
+++ b/frontend/modules/publication/remote.ts
@@ -2,12 +2,8 @@ import { request } from "app";
 import { AxiosError, AxiosInstance } from "axios";
 import { notify } from "components/Notifications";
 import { RESET } from "jotai/utils";
-import { TOTAL_COUNT_HEADER } from "modules/api";
 import type { Store } from "modules/store";
-import { usePublicationStore } from "./workspace";
 import hash from "object-hash";
-import { useCallback } from "react";
-import useDebounce from "utils/useDebounce";
 
 import type { Publication, PublicationHistoryEntry } from "./model";
 import {
@@ -19,10 +15,7 @@ import {
 import {
   createId,
   errorFamily,
-  hydrate,
-  isIndexLoadingAtom,
   isValidatingAtom,
-  keywordsAtom,
   lastValidatedFamily,
   overrideFamily,
   publicationFamily,
@@ -31,7 +24,6 @@ import {
   resetAll,
   setAll,
   setErrors,
-  totalIndexCountAtom,
   visibleIdsAtom,
   visiblePublicationFamily,
 } from "./store";
@@ -57,48 +49,6 @@ async function run<T>(op: (http: AxiosInstance) => Promise<T>): Promise<T> {
     notify({ message: message as string, level: "warning" });
     throw error;
   }
-}
-
-type IndexResult = { entries: Publication[]; keywords?: string[] };
-
-type IndexOptions = { search?: string; unreferenced?: boolean };
-
-/**
- * Load the publication index into the store and return its ids in order. Filter
- * by `search`, or to only the publications missing references (`unreferenced`) —
- * the queue the references backfill wizard steps through.
- */
-async function index(
-  store: Store,
-  { search, unreferenced }: IndexOptions = {},
-): Promise<PublicationId[]> {
-  return run(async (http) => {
-    const query = search
-      ? `?search=${search}`
-      : unreferenced
-        ? "?unreferenced"
-        : "";
-
-    // Leave the current rows on screen while the new results load — the skeleton
-    // is only for the first load (publicationIdsAtom starts undefined). The
-    // search bar shows a subtle loading bar instead (isIndexLoadingAtom).
-    try {
-      const { data, headers } = await http.get<IndexResult>(
-        `publications${query}`,
-      );
-      const { entries, keywords } = data;
-
-      // Read raw: the client no longer camelCases response headers (see modules/http).
-      if (headers[TOTAL_COUNT_HEADER]) {
-        store.set(totalIndexCountAtom, parseInt(headers[TOTAL_COUNT_HEADER]));
-      }
-      store.set(keywordsAtom, keywords ?? []);
-
-      return hydrate(store, entries);
-    } finally {
-      store.set(isIndexLoadingAtom, false);
-    }
-  });
 }
 
 /** Submit the current (visible) working set. */
@@ -336,30 +286,13 @@ async function upload(store: Store, payload: FormData): Promise<void> {
   });
 }
 
-/** Debounced index, for search-as-you-type, against the workspace's own store. */
-function usePublicationIndex() {
-  const store = usePublicationStore();
-  const debounced = useDebounce(index, 350);
-  // Flag loading immediately (before the debounce) so the search bar's loading
-  // bar spans the whole keystroke-to-results window, not just the fetch.
-  return useCallback(
-    (args?: { search?: string }) => {
-      store.set(isIndexLoadingAtom, true);
-      return debounced(store, args);
-    },
-    [debounced, store],
-  );
-}
-
 export {
   bulk,
-  index,
   deletePublication,
   restore,
   undo,
   update,
   upload,
-  usePublicationIndex,
   validate,
   validateUpdate,
 };

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -39,7 +39,6 @@ const publicationIdsAtom = atomWithReset<PublicationId[] | undefined>(
   undefined,
 );
 const isValidatingAtom = atom(false);
-const isIndexLoadingAtom = atom(false);
 const keywordsAtom = atom<string[] | undefined>(undefined);
 const areRowIdsVisibleAtom = atom(false);
 const focusedRowIdAtom = atomWithReset<PublicationId | undefined>(undefined);
@@ -235,6 +234,14 @@ const CELL_FAMILIES = [
   fieldErrorDescriptionFamily,
 ];
 
+/** What a read of the index answers with. */
+type IndexPayload = {
+  entries: Publication[];
+  keywords: string[];
+  /** How many exist in total, not how many matched. `null` when unreported. */
+  total: number | null;
+};
+
 /** Drop every atom these publications own — their values and their cached cells. */
 function forget(ids: Iterable<PublicationId>): void {
   const dropped = new Set(ids);
@@ -289,6 +296,22 @@ function hydrate(store: Store, publications: Publication[]): PublicationId[] {
  */
 function remember(store: Store, publication: Publication): void {
   store.set(publicationFamily(publication.id!), publication);
+}
+
+/**
+ * Take an index payload as the working set: the rows, the keywords the search
+ * matched on, and how many publications exist in total.
+ *
+ * One definition of "these are the results now", wherever they were read.
+ */
+function receiveIndex(
+  store: Store,
+  { entries, keywords, total }: IndexPayload,
+): PublicationId[] {
+  if (total !== null) store.set(totalIndexCountAtom, total);
+  store.set(keywordsAtom, keywords);
+
+  return hydrate(store, entries);
 }
 
 function setAll(store: Store, entries: PublicationEntry[]): void {
@@ -413,7 +436,6 @@ function resetAll(store: Store): void {
   store.set(errorFamily(DRAFT_ID), RESET);
   store.set(publicationIdsAtom, RESET);
   store.set(focusedRowIdAtom, RESET);
-  store.set(isIndexLoadingAtom, false);
 }
 
 function resetDiscarded(store: Store): void {
@@ -494,7 +516,6 @@ export {
   hydrate,
   knownIds,
   hiddenAttributesAtom,
-  isIndexLoadingAtom,
   isValidFamily,
   isValidatingAtom,
   keywordsAtom,
@@ -508,6 +529,7 @@ export {
   publicationIdsAtom,
   publicationOrNullFamily,
   publicationReferencesFamily,
+  receiveIndex,
   remember,
   removePublication,
   resetAll,
@@ -530,3 +552,4 @@ export {
   visibleIdsAtom,
   visiblePublicationFamily,
 };
+export type { IndexPayload };

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -234,8 +234,12 @@ const CELL_FAMILIES = [
   fieldErrorDescriptionFamily,
 ];
 
-/** What a read of the index answers with. */
-type IndexPayload = {
+/**
+ * A page of the catalogue: the rows, the keywords the search matched on, and how
+ * many publications exist in total — which the index reports in a header rather
+ * than in the body.
+ */
+type PublicationIndex = {
   entries: Publication[];
   keywords: string[];
   /** How many exist in total, not how many matched. `null` when unreported. */
@@ -306,7 +310,7 @@ function remember(store: Store, publication: Publication): void {
  */
 function receiveIndex(
   store: Store,
-  { entries, keywords, total }: IndexPayload,
+  { entries, keywords, total }: PublicationIndex,
 ): PublicationId[] {
   if (total !== null) store.set(totalIndexCountAtom, total);
   store.set(keywordsAtom, keywords);
@@ -552,4 +556,4 @@ export {
   visibleIdsAtom,
   visiblePublicationFamily,
 };
-export type { IndexPayload };
+export type { PublicationIndex };

--- a/frontend/utils/useDebounce.spec.ts
+++ b/frontend/utils/useDebounce.spec.ts
@@ -1,0 +1,72 @@
+import { act, renderHook } from "@testing-library/react";
+import useDebounce from "./useDebounce";
+
+const DELAY = 350;
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("useDebounce", () => {
+  test("calls in quick succession settle into one, with the last arguments", () => {
+    const run = vi.fn();
+    const { result } = renderHook(() => useDebounce(run, DELAY));
+
+    result.current("m");
+    result.current("ma");
+    result.current("mac");
+
+    act(() => void vi.advanceTimersByTime(DELAY));
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("mac");
+  });
+
+  test("a caller that passes a fresh function each render still shares one timer", () => {
+    const run = vi.fn();
+    // A component re-renders as it types, so the callback it hands over is a new
+    // one every keystroke. That must not buy each keystroke its own timer.
+    const { result, rerender } = renderHook(() =>
+      useDebounce((value: string) => run(value), DELAY),
+    );
+
+    result.current("m");
+    rerender();
+    result.current("ma");
+    rerender();
+    result.current("mac");
+
+    act(() => void vi.advanceTimersByTime(DELAY));
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("mac");
+  });
+
+  test("runs the callback the latest render supplied", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ run }: { run: (value: string) => void }) => useDebounce(run, DELAY),
+      { initialProps: { run: first } },
+    );
+
+    result.current("typed");
+    rerender({ run: second });
+
+    act(() => void vi.advanceTimersByTime(DELAY));
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledWith("typed");
+  });
+
+  test("waits out the delay before running at all", () => {
+    const run = vi.fn();
+    const { result } = renderHook(() => useDebounce(run, DELAY));
+
+    result.current("m");
+    act(() => void vi.advanceTimersByTime(DELAY - 1));
+    expect(run).not.toHaveBeenCalled();
+
+    act(() => void vi.advanceTimersByTime(1));
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/utils/useDebounce.ts
+++ b/frontend/utils/useDebounce.ts
@@ -19,13 +19,14 @@ function useDebounce<F extends (...args: never[]) => unknown>(
     latest.current = factory;
   });
 
+  const settings = useRef(opts);
+
   return useMemo(
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     () =>
       debounce(
         (...args: Parameters<F>) => latest.current(...args),
         delay,
-        opts,
+        settings.current,
       ),
     [delay],
   ) as unknown as F;

--- a/frontend/utils/useDebounce.ts
+++ b/frontend/utils/useDebounce.ts
@@ -1,16 +1,34 @@
 import { debounce, DebounceSettings } from "lodash";
-import { useCallback } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
+/**
+ * Debounce a callback, and run whichever one the latest render supplied.
+ *
+ * The debounced wrapper is made once, so a caller that hands over a fresh
+ * function each render — anything typed into, which re-renders as it goes —
+ * still shares one timer instead of buying each call its own.
+ */
 function useDebounce<F extends (...args: never[]) => unknown>(
   factory: F,
   delay: number,
   opts?: DebounceSettings,
 ): F {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  return useCallback(debounce(factory, delay, opts) as unknown as F, [
-    factory,
-    delay,
-  ]);
+  const latest = useRef(factory);
+
+  useEffect(() => {
+    latest.current = factory;
+  });
+
+  return useMemo(
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    () =>
+      debounce(
+        (...args: Parameters<F>) => latest.current(...args),
+        delay,
+        opts,
+      ),
+    [delay],
+  ) as unknown as F;
 }
 
 export default useDebounce;


### PR DESCRIPTION
The last two reads a page made of its own content were made after it: the index fetched itself on mount, and the backfill wizard fetched its queue. Both now come with the page — a reader gets rows in the first response instead of a skeleton and a round trip, and the wizard opens on a record instead of a spinner.

The store is seeded at creation, before anything renders, which is what makes this safe: writing to a store nobody has subscribed to yet cannot disagree with hydration. Later payloads — a new query, a re-read after a change — are applied as they arrive.

Search follows from that: the query is already in the URL, so typing navigates rather than fetching. Debounced, so a typist does not ask for a page per letter, and in a transition, so what is on screen stays until the new rows are ready. The client no longer reads the index at all, so the fetch, its debounced hook and the loading flag it existed to set are gone.

This finishes roadmap 23: every read that is a page's own content is made where the page is rendered, and what stays on the client is mutations and the typeahead that answers a keystroke.

Stacked on #392.
