### PR TITLE
Take Playwright 1.62, both halves at once

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,11 @@ updates:
           - "tailwindcss"
           - "@tailwindcss/*"
         update-types: ["minor", "patch"]
+      playwright:
+        patterns:
+          - "playwright"
+          - "@playwright/*"
+        update-types: ["minor", "patch"]
       eslint:
         patterns:
           - "eslint"
@@ -46,3 +51,9 @@ updates:
           - "@eslint/*"
           - "typescript-eslint"
         update-types: ["minor", "patch"]
+    # The Node types describe the runtime this project pins, so their major is
+    # not ours to choose: it follows `.tool-versions`, and a major ahead of it
+    # would have the compiler accept APIs that do not exist when the code runs.
+    ignore:
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -35,7 +35,7 @@
         "zod": "^4.4.3"
       },
       "devDependencies": {
-        "@playwright/test": "^1.61.1",
+        "@playwright/test": "^1.62.0",
         "@storybook/addon-a11y": "^10.5.5",
         "@storybook/addon-docs": "^10.5.5",
         "@storybook/addon-vitest": "^10.5.5",
@@ -60,7 +60,7 @@
         "eslint-config-next": "^16.2.12",
         "jsdom": "^30.0.0",
         "next-router-mock": "^1.0.5",
-        "playwright": "^1.61.1",
+        "playwright": "^1.62.0",
         "postcss": "^8.5.23",
         "prettier": "3.9.6",
         "storybook": "^10.5.5",
@@ -4497,19 +4497,19 @@
       ]
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@polka/url": {
@@ -12696,35 +12696,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.0"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/pngjs": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.61.1",
+    "@playwright/test": "^1.62.0",
     "@storybook/addon-a11y": "^10.5.5",
     "@storybook/addon-docs": "^10.5.5",
     "@storybook/addon-vitest": "^10.5.5",
@@ -69,7 +69,7 @@
     "eslint-config-next": "^16.2.12",
     "jsdom": "^30.0.0",
     "next-router-mock": "^1.0.5",
-    "playwright": "^1.61.1",
+    "playwright": "^1.62.0",
     "postcss": "^8.5.23",
     "prettier": "3.9.6",
     "storybook": "^10.5.5",


### PR DESCRIPTION
`playwright` and `@playwright/test` are released in lockstep and check each other's versions at startup, so they are one update rather than two — Dependabot opened them separately (#406, #408) because the config did not yet know about that family. It does now.

Also stops offering the Node types ahead of the runtime. `@types/node` describes the Node this project pins in `.tool-versions`; a major ahead of it makes the compiler accept APIs that will not exist when the code runs. That is not a judgement call to be re-made every week, so majors for it are ignored until the runtime itself moves.

Supersedes #406, #408 and #407.

Verified on this branch: 324 unit and story tests (which drive the browser through this same Playwright) and 18 E2E journeys, on the 1.62 runner and its matching Chromium.
