### PR TITLE
Watch the backend and the workflows too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,3 +57,35 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
+
+  # Elixir. The backend has its own lockfile and its own audit in CI, but nothing
+  # was watching it — every dependency update here has been a manual sweep.
+  - package-ecosystem: "mix"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      phoenix:
+        patterns:
+          - "phoenix"
+          - "phoenix_*"
+        update-types: ["minor", "patch"]
+      ecto:
+        patterns:
+          - "ecto"
+          - "ecto_*"
+          - "postgrex"
+        update-types: ["minor", "patch"]
+
+  # The workflows pin their actions, and those pins go stale silently — checkout
+  # is three majors behind.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Dependabot was watching `/frontend` and nothing else.

**Elixir.** The backend has its own lockfile and MixAudit runs against it on every pull request, but no updates were ever proposed — the dependency sweeps here have been manual. Phoenix and Ecto are grouped, since neither releases a package at a time, and majors stay out of the groups as they do on the frontend side.

**Actions.** The workflows pin their actions, and those pins go stale silently: `actions/checkout` is on v3, three majors behind. Grouped into one pull request, since they are updated together or not at all.

Both weekly, matching the frontend. No code changes.
