### PR TITLE
Bring the workflow actions up to date

### DIFF
--- a/.github/workflows/deploy-to-ifrs.yml
+++ b/.github/workflows/deploy-to-ifrs.yml
@@ -13,7 +13,7 @@ jobs:
           key: ${{ secrets.IFRS_SSH_KEY }}
           known_hosts: ${{ secrets.IFRS_SSH_HOST }}
           if_key_exists: fail
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - run: export TZ=America/Sao_Paulo
@@ -40,7 +40,7 @@ jobs:
           key: ${{ secrets.IFRS_SSH_KEY }}
           known_hosts: ${{ secrets.IFRS_SSH_HOST }}
           if_key_exists: fail
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - run: export TZ=America/Sao_Paulo

--- a/.github/workflows/run-backend-audit.yml
+++ b/.github/workflows/run-backend-audit.yml
@@ -7,12 +7,12 @@ jobs:
       run:
         working-directory: "backend"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           version-type: strict
           version-file: backend/.tool-versions
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             backend/deps

--- a/.github/workflows/run-backend-docs.yml
+++ b/.github/workflows/run-backend-docs.yml
@@ -10,12 +10,12 @@ jobs:
       run:
         working-directory: "backend"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           version-type: strict
           version-file: backend/.tool-versions
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             backend/deps

--- a/.github/workflows/run-backend-fingerprint-audit.yml
+++ b/.github/workflows/run-backend-fingerprint-audit.yml
@@ -19,12 +19,12 @@ jobs:
           POSTGRES_PASSWORD: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           version-type: strict
           version-file: backend/.tool-versions
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             backend/deps

--- a/.github/workflows/run-backend-formatter.yml
+++ b/.github/workflows/run-backend-formatter.yml
@@ -7,12 +7,12 @@ jobs:
       run:
         working-directory: "backend"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           version-type: strict
           version-file: backend/.tool-versions
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             backend/deps

--- a/.github/workflows/run-backend-linter.yml
+++ b/.github/workflows/run-backend-linter.yml
@@ -7,12 +7,12 @@ jobs:
       run:
         working-directory: "backend"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           version-type: strict
           version-file: backend/.tool-versions
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             backend/deps

--- a/.github/workflows/run-backend-tests.yml
+++ b/.github/workflows/run-backend-tests.yml
@@ -20,12 +20,12 @@ jobs:
           POSTGRES_PASSWORD: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: erlef/setup-beam@v1
         with:
           version-type: strict
           version-file: backend/.tool-versions
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             backend/deps
@@ -43,7 +43,7 @@ jobs:
       - run: mix coveralls | tee coverage.local.txt
       - name: Comment coverage on the PR
         if: ${{ success() && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require("fs");

--- a/.github/workflows/run-e2e-tests.yml
+++ b/.github/workflows/run-e2e-tests.yml
@@ -16,7 +16,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       # Backend toolchain + compile the :e2e app. Playwright's globalSetup then
       # creates/migrates the per-worker databases, and its webServer boots a
@@ -27,7 +27,7 @@ jobs:
           version-file: backend/.tool-versions
       # Hex deps + compiled build, keyed by toolchain and lockfile; the restore
       # key lets a lockfile bump start from the previous build instead of cold.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             backend/deps
@@ -50,7 +50,7 @@ jobs:
           node-version-file: frontend/.tool-versions
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
@@ -73,7 +73,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: frontend/playwright-report/

--- a/.github/workflows/run-frontend-audit.yml
+++ b/.github/workflows/run-frontend-audit.yml
@@ -7,7 +7,7 @@ jobs:
       run:
         working-directory: "frontend"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       # Advisory signal, not a deploy gate: a newly disclosed advisory should surface
       # here without wedging every release. `--audit-level=high` fails only on
       # high/critical, and audits the lockfile directly (no install needed).

--- a/.github/workflows/run-frontend-compiler.yml
+++ b/.github/workflows/run-frontend-compiler.yml
@@ -7,7 +7,7 @@ jobs:
       run:
         working-directory: "frontend"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/.tool-versions

--- a/.github/workflows/run-frontend-formatter.yml
+++ b/.github/workflows/run-frontend-formatter.yml
@@ -7,7 +7,7 @@ jobs:
       run:
         working-directory: "frontend"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/.tool-versions

--- a/.github/workflows/run-frontend-linter.yml
+++ b/.github/workflows/run-frontend-linter.yml
@@ -7,7 +7,7 @@ jobs:
       run:
         working-directory: "frontend"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/.tool-versions

--- a/.github/workflows/run-frontend-tests.yml
+++ b/.github/workflows/run-frontend-tests.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: "frontend"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/.tool-versions
@@ -21,7 +21,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       # The Chromium binary is cached by lockfile (which pins the Playwright
       # version); the install below is a no-op download when already present.
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
@@ -35,7 +35,7 @@ jobs:
       - run: npm run test:coverage
       - name: Comment coverage on the PR
         if: ${{ success() && github.event_name == 'pull_request' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require("fs");


### PR DESCRIPTION
`actions/checkout` was four majors behind; cache, upload-artifact and github-script two or three. They move in one pull request because they sit in the same workflow files, and because each of them runs on a pull request — so this one exercises all four.

`actions/github-script` v9 has a breaking change: `require('@actions/github')` no longer works, since the underlying package is ESM-only. Both inline scripts here only `require("fs")` and use the injected `github` client, so it does not reach them.

Left out deliberately: `stefanzweifel/git-auto-commit-action` v4 → v7 (#415). It appears only in `run-backend-docs.yml`, which triggers on pushes to `main` — no pull request can exercise it, so merging it would mean finding out afterwards, in the workflow that commits generated documentation. Worth taking on its own, with someone watching the first run on `main`.
