### PR TITLE
Let Phoenix hear about recompilation in development

### DIFF
--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -8,6 +8,7 @@ defmodule RichardBurton.MixProject do
       elixir: "~> 1.16",
       elixirc_paths: elixirc_paths(Mix.env()),
       compilers: Mix.compilers(),
+      listeners: [Phoenix.CodeReloader],
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       deps: deps(),


### PR DESCRIPTION
The dev server warned on every request it recompiled for, asking to be registered as a Mix listener. Registering it silences the warning and lets code reloading see compilation as it happens.

Development only — no runtime behaviour changes.