### PR TITLE
Stop a surface's teardown from emptying live state

### DIFF
--- a/frontend/app/admin/publications/new/page.tsx
+++ b/frontend/app/admin/publications/new/page.tsx
@@ -15,18 +15,10 @@ import ResetDiscarded from "components/ResetDiscarded";
 import ResetOverridden from "components/ResetOverridden";
 import RowIdToggle from "components/RowIdToggle";
 import { Publication } from "modules/publication/model";
-import {
-  resetAll,
-  setAll,
-  setAttributesVisible,
-} from "modules/publication/store";
-import {
-  PublicationStoreProvider,
-  usePublicationStore,
-} from "modules/publication/workspace";
+import { setAll, setAttributesVisible } from "modules/publication/store";
+import { PublicationStoreProvider } from "modules/publication/workspace";
 import type { Store } from "modules/store";
 import { useIsSelectionEmpty } from "modules/selection";
-import { useEffect } from "react";
 
 const BREADCRUMB_ITEMS = [
   { label: "Home", href: "/" },
@@ -40,10 +32,7 @@ function startEmpty(store: Store) {
 }
 
 function NewPublications() {
-  const store = usePublicationStore();
   const isSelectionEmpty = useIsSelectionEmpty();
-
-  useEffect(() => () => resetAll(store), [store]);
 
   return (
     <Layout

--- a/frontend/components/ReferencesBackfill.tsx
+++ b/frontend/components/ReferencesBackfill.tsx
@@ -15,11 +15,7 @@ import {
   usePublicationStore,
 } from "modules/publication/workspace";
 import { update } from "modules/publication/remote";
-import {
-  discardEdit,
-  overrideReferences,
-  resetAll,
-} from "modules/publication/store";
+import { discardEdit, overrideReferences } from "modules/publication/store";
 import Link from "next/link";
 import { FC, KeyboardEvent, useEffect, useRef, useState } from "react";
 
@@ -247,8 +243,6 @@ const Backfill: FC<{ queue: PublicationIndex }> = ({ queue }) => {
   const store = usePublicationStore();
   const [position, setPosition] = useState(0);
   const [saving, setSaving] = useState(false);
-
-  useEffect(() => () => resetAll(store), [store]);
 
   const ids = queue.entries.map(({ id }) => id!);
   const currentId = ids[position];

--- a/frontend/modules/publication/store.spec.ts
+++ b/frontend/modules/publication/store.spec.ts
@@ -377,6 +377,17 @@ describe("family lifecycle", () => {
 
     resetAll(store);
 
-    expect([...knownIds()]).not.toContain(99);
+    expect(store.get(publicationFamily(99))).toBeUndefined();
+  });
+
+  test("one store emptying itself leaves another store's publications alone", () => {
+    const other = createStore();
+    hydrate(other, [saved(1, "Dom Casmurro")]);
+
+    resetAll(store);
+
+    expect(store.get(publicationFamily(1))).toBeUndefined();
+    expect(other.get(publicationFamily(1))).toEqual(saved(1, "Dom Casmurro"));
+    expect(other.get(publicationIdsAtom)).toEqual([1]);
   });
 });

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -421,13 +421,20 @@ function duplicate(
   return newIds;
 }
 
+/**
+ * Empty a store, without reaching into any other.
+ *
+ * Values are the store's own, so resetting them is its business alone. The atom
+ * *caches* are not: they are keyed by id and shared by every store, so a surface
+ * emptying itself must not evict from them — another surface may be reading the
+ * same ids right now. `hydrate` prunes them instead, for the store that owns
+ * what is arriving.
+ *
+ * Every id the families know, not just the ones currently listed: a value set
+ * directly — as the specs do — would otherwise survive teardown.
+ */
 function resetAll(store: Store): void {
-  // Every id the families know, not just the ones currently listed: a value
-  // set directly — as the specs do — would otherwise survive teardown and leak
-  // into whatever runs next.
-  const known = knownIds();
-
-  known.forEach((id) => {
+  knownIds().forEach((id) => {
     store.set(publicationFamily(id), RESET);
     store.set(overrideFamily(id), RESET);
     store.set(errorFamily(id), RESET);
@@ -435,9 +442,6 @@ function resetAll(store: Store): void {
     store.set(lastValidatedFamily(id), RESET);
   });
 
-  forget([...known].filter((id) => id !== DRAFT_ID));
-  store.set(overrideFamily(DRAFT_ID), RESET);
-  store.set(errorFamily(DRAFT_ID), RESET);
   store.set(publicationIdsAtom, RESET);
   store.set(focusedRowIdAtom, RESET);
 }


### PR DESCRIPTION
Navigating into an admin workspace from the admin menu showed an empty grid: the queue arrived, but every title was blank and the counter read zero.

A publication store belongs to one surface now, but the atom caches behind it are keyed by id and shared by every store. Two consequences, both fixed here.

`resetAll` evicted from those shared caches, so one surface tearing down took another surface's live state with it.

Worse, both admin workspaces emptied their store from an unmount effect. State is seeded once, when the store is made — but that effect runs on every cleanup, and React re-mounts a page after tearing it down, so the store was emptied with nothing left to re-seed it. A store that goes with its surface has nothing to clean up on the way out.

A regression test covers the first: one store emptying itself now leaves another's publications alone.