### PR TITLE
Say what a change did, even when it opens the log

### DIFF
--- a/backend/lib/mix/tasks/rb.backfill_history.ex
+++ b/backend/lib/mix/tasks/rb.backfill_history.ex
@@ -1,0 +1,57 @@
+defmodule Mix.Tasks.Rb.BackfillHistory do
+  @shortdoc "Gives publications with no history a starting point"
+
+  @moduledoc """
+  Records a `created` entry for every publication whose history is empty.
+
+  A change is described by comparing a record against the entry before it, so
+  the first entry a record ever gets has nothing to compare against and reads as
+  a bare "updated". Publications inserted through the app open their log with a
+  `created` entry and never have this problem; ones loaded straight into the
+  database — the original corpus, a restored dump — start with no log at all.
+
+  This gives those a starting point: the record as it stands now, attributed to
+  the system. Only publications with an empty log are touched, so a record whose
+  first change is already recorded is left alone — its earlier state is gone and
+  no baseline can honestly be invented for it.
+
+  Safe to run more than once, and on a database that needs nothing.
+
+      mix rb.backfill_history
+  """
+
+  use Mix.Task
+
+  import Ecto.Query
+
+  alias RichardBurton.Publication
+  alias RichardBurton.Publication.History
+  alias RichardBurton.Repo
+
+  @impl Mix.Task
+  def run(_args) do
+    Mix.Task.run("app.start")
+
+    unlogged()
+    |> Enum.map(&record_baseline/1)
+    |> report()
+  end
+
+  defp unlogged do
+    logged = from(h in History, select: h.publication_id, distinct: true)
+
+    from(p in Publication, where: p.id not in subquery(logged), order_by: p.id)
+    |> Repo.all()
+    |> Publication.preload()
+  end
+
+  defp record_baseline(publication) do
+    History.record(:created, publication, History.system_actor())
+    publication
+  end
+
+  defp report([]), do: Mix.shell().info("Every publication already has a history.")
+
+  defp report(publications),
+    do: Mix.shell().info("Recorded a starting point for #{length(publications)} publications.")
+end

--- a/backend/test/mix/tasks/rb_backfill_history_test.exs
+++ b/backend/test/mix/tasks/rb_backfill_history_test.exs
@@ -1,0 +1,90 @@
+defmodule Mix.Tasks.Rb.BackfillHistoryTest do
+  @moduledoc """
+  Tests for the task that gives unlogged publications a starting point
+  """
+
+  use RichardBurton.DataCase
+
+  alias Mix.Tasks.Rb.BackfillHistory
+  alias RichardBurton.Country
+  alias RichardBurton.Publication
+  alias RichardBurton.Publication.History
+  alias RichardBurton.Publisher
+  alias RichardBurton.Repo
+  alias RichardBurton.TranslatedBook
+
+  @attrs %{
+    "title" => "Manuel de Moraes: A Chronicle of the Seventeenth Century",
+    "countries" => [%{"code" => "GB"}],
+    "year" => 1886,
+    "publishers" => [%{"name" => "Bickers & Son"}],
+    "translated_book" => %{
+      "authors" => [%{"name" => "Richard Burton"}],
+      "original_book" => %{
+        "authors" => [%{"name" => "J. M. Pereira da Silva"}],
+        "title" => "Manuel de Moraes: crônica do século XVII"
+      }
+    }
+  }
+
+  # A publication in the state the original corpus is in: in the catalogue,
+  # loaded straight into the database, with nothing in the log. The history table
+  # is append-only, so this is written the way such a record arrived rather than
+  # by clearing one that was recorded properly.
+  defp unlogged_publication do
+    %Publication{}
+    |> Publication.changeset(@attrs)
+    |> Country.link()
+    |> TranslatedBook.link()
+    |> Publisher.link()
+    |> Repo.insert!()
+    |> Publication.preload()
+  end
+
+  describe "run/1" do
+    test "gives a publication with no history a created entry for its current state" do
+      publication = unlogged_publication()
+
+      BackfillHistory.run([])
+
+      assert [entry] = History.of(publication.id)
+      assert entry.action == "created"
+      assert entry.version == 1
+      assert entry.actor == History.system_actor()
+      # The record as it stands, so the next change has something to compare to.
+      assert entry.snapshot["title"] == publication.title
+      assert entry.snapshot["year"] == publication.year
+      assert entry.snapshot["countries"] == "GB"
+    end
+
+    test "leaves a publication that already has history alone" do
+      {:ok, publication} = Publication.insert(@attrs)
+      before = History.of(publication.id)
+
+      BackfillHistory.run([])
+
+      assert History.of(publication.id) == before
+    end
+
+    test "adds nothing on a second run" do
+      publication = unlogged_publication()
+
+      BackfillHistory.run([])
+      logged = History.of(publication.id)
+      BackfillHistory.run([])
+
+      assert History.of(publication.id) == logged
+    end
+
+    test "an update after the backfill says what it changed" do
+      publication = unlogged_publication()
+      BackfillHistory.run([])
+
+      {:ok, updated} = Publication.update(publication.id, %{@attrs | "year" => 1887})
+
+      assert [entry | _] = History.of(updated.id)
+      assert entry.action == "updated"
+      assert %{fields: %{"year" => %{from: 1886, to: 1887}}} = entry.diff
+    end
+  end
+end

--- a/frontend/components/PublicationHistory.mdx
+++ b/frontend/components/PublicationHistory.mdx
@@ -38,3 +38,11 @@ the same entries as full cards, where they _are_ the page's subject.
   the absence is stated rather than hidden.
 
 <Canvas of={PublicationHistoryStories.Empty} />
+
+- **Without a baseline** — a change is described by comparing a record against
+  the entry before it, so a log that opens on an update has nothing to compare
+  against. That happens to records loaded straight into the database rather than
+  entered through the app; `mix rb.backfill_history` gives those a starting
+  point, and the entries already recorded without one say so.
+
+<Canvas of={PublicationHistoryStories.WithoutABaseline} />

--- a/frontend/components/PublicationHistory.stories.tsx
+++ b/frontend/components/PublicationHistory.stories.tsx
@@ -177,3 +177,32 @@ export const Empty: Story = {
     ).toBeInTheDocument();
   },
 };
+
+/**
+ * A record whose log opens on an update — loaded into the database rather than
+ * entered through the app, so its first change has no earlier version to be
+ * compared against. The entry says that, rather than listing nothing.
+ */
+export const WithoutABaseline: Story = {
+  args: {
+    entries: withChanges([
+      {
+        version: 1,
+        undoable: false,
+        action: "updated",
+        actor: "curator@rb.test",
+        timestamp: "2026-07-15T11:00:00",
+        snapshot: {
+          ...SNAPSHOT,
+          references: ["Caldwell, Helen. Introduction, 1953."],
+        },
+        diff: null,
+      },
+    ]),
+  },
+  play: async () => {
+    await expect(
+      screen.getByText(/Nothing earlier to compare with/),
+    ).toBeInTheDocument();
+  },
+};

--- a/frontend/components/PublicationHistory.tsx
+++ b/frontend/components/PublicationHistory.tsx
@@ -133,6 +133,15 @@ const Entry: FC<{
           by {entry.actor} · {formatTimestamp(entry.timestamp)}
         </p>
       )}
+      {entry.action === "updated" && entry.diff === null && (
+        <p
+          data-variant={variant}
+          className="mt-2 text-xs text-gray-500 italic data-[variant=card]:pl-22 data-[variant=plain]:pl-18"
+        >
+          Nothing earlier to compare with — this is where the record&apos;s log
+          starts.
+        </p>
+      )}
       {entry.changes.length > 0 && (
         <ul
           data-variant={variant}


### PR DESCRIPTION
Editing a publication and finding "Updated" with no account of what changed.

A change is described by comparing a record against the entry before it, so the first entry a record ever gets has nothing to compare against. Publications entered through the app open their log with a `created` entry and never hit this; the original corpus was loaded straight into the database and has no log at all, so its first edit reads blank. It has nothing to do with which field was edited — references were just where it was noticed.

Two halves.

`mix rb.backfill_history` records where an unlogged publication stands now, so its next change has something to be compared against. Only records with an empty log are touched: a record whose first change is already logged has lost the state it was in beforehand, and no baseline can honestly be invented for it. It ran over the development corpus here — 281 publications given a starting point, the 7 with real history left alone.

For the entries already recorded without one, the view now says so instead of showing an empty update.

Run `mix rb.backfill_history` once after deploying.