### PR TITLE
Ignore the IFRS repos, and drop a variable nothing reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ rel/
 credentials.md
 .claude
 /CLAUDE.md
+# IFRS GitLab deploy repos, cloned locally for reference — never part of this repo
+/ifrs-frontend/
+/ifrs-backend/
+/ifrs-deploy/

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -30,7 +30,6 @@ const stacks = Array.from({ length: WORKERS }, (_, i) => [
     env: {
       NEXT_PUBLIC_API_URL: `http://localhost:${backendPort(i)}/api`,
       NEXT_INTERNAL_API_URL: `http://localhost:${backendPort(i)}/api`,
-      NEXT_PUBLIC_FILES_URL: `http://localhost:${backendPort(i)}/files`,
       // A private build dir per worker so parallel `next dev`s don't share `.next`.
       E2E_DIST_DIR: `.next-e2e-${i}`,
       // Provided here so the harness doesn't depend on a local .env (absent in CI).


### PR DESCRIPTION
The three GitLab repos a release goes to are worth having beside this one when working on a deploy, so they are ignored: `ifrs-frontend`, `ifrs-backend`, `ifrs-deploy`.

`NEXT_PUBLIC_FILES_URL` had no reader. The CSV export goes through the same client as every other call, which builds its URL from `NEXT_PUBLIC_API_URL`; the variable was only being carried around. Removed here and from the deploy repo's compose files.