### PR TITLE
Let a search link reach its search, and every word narrow it

### DIFF
--- a/backend/lib/richard_burton/country.ex
+++ b/backend/lib/richard_burton/country.ex
@@ -37,21 +37,29 @@ defmodule RichardBurton.Country do
   end
 
   @doc """
-  The codes a word could be naming, so a country can be searched for by the name
-  a reader sees rather than the code the record stores.
+  The codes a term names, so a country can be searched for by the name a reader
+  sees rather than the code the record stores.
 
-  A partial word counts: "braz" names Brazil while it is still being typed.
+  The whole name, exactly: a code is two letters, and two letters are a word in
+  their own right in the languages this database holds. "UM" is the United
+  States Minor Outlying Islands and also "um" in half the Portuguese titles
+  here, so a code is only ever asked for when a country was actually named.
   """
-  def codes_named(word) when is_binary(word) do
-    folded = word |> String.downcase() |> String.trim()
+  def codes_named(term) when is_binary(term) do
+    named = term |> String.trim() |> String.downcase()
 
-    if String.length(folded) < 2 do
-      []
-    else
-      Countries.all()
-      |> Enum.filter(&String.starts_with?(String.downcase(&1.name), folded))
-      |> Enum.map(& &1.alpha2)
-    end
+    Countries.all()
+    |> Enum.filter(&(named in names_of(&1)))
+    |> Enum.map(& &1.alpha2)
+  end
+
+  # The official name and the ones people actually write: "United Kingdom" for
+  # a country officially of Great Britain and Northern Ireland, "Brasil" for
+  # the one this database is mostly about.
+  defp names_of(country) do
+    [country.name | Map.get(country, :unofficial_names) || []]
+    |> Enum.filter(&is_binary/1)
+    |> Enum.map(&String.downcase/1)
   end
 
   def validate_code(changeset) do

--- a/backend/lib/richard_burton/country.ex
+++ b/backend/lib/richard_burton/country.ex
@@ -37,13 +37,14 @@ defmodule RichardBurton.Country do
   end
 
   @doc """
-  The codes a term names, so a country can be searched for by the name a reader
-  sees rather than the code the record stores.
+  The country codes whose name is exactly this term, so a reader can search by
+  the name they see rather than the code the record stores.
 
-  The whole name, exactly: a code is two letters, and two letters are a word in
-  their own right in the languages this database holds. "UM" is the United
-  States Minor Outlying Islands and also "um" in half the Portuguese titles
-  here, so a code is only ever asked for when a country was actually named.
+  The match is on the whole name, not a prefix or a word of it. A code is two
+  letters, and a two-letter word is common in the languages here: "UM" is the
+  code for the United States Minor Outlying Islands and also the Portuguese
+  "um" in countless titles. Requiring the exact, full name keeps a stray "um"
+  from pulling in that country.
   """
   def codes_named(term) when is_binary(term) do
     named = term |> String.trim() |> String.downcase()
@@ -53,9 +54,9 @@ defmodule RichardBurton.Country do
     |> Enum.map(& &1.alpha2)
   end
 
-  # The official name and the ones people actually write: "United Kingdom" for
-  # a country officially of Great Britain and Northern Ireland, "Brasil" for
-  # the one this database is mostly about.
+  # A country's official name plus the names people actually write for it:
+  # "United Kingdom" for the country officially named after Great Britain and
+  # Northern Ireland, "Brasil" for the one this database is mostly about.
   defp names_of(country) do
     [country.name | Map.get(country, :unofficial_names) || []]
     |> Enum.filter(&is_binary/1)

--- a/backend/lib/richard_burton/country.ex
+++ b/backend/lib/richard_burton/country.ex
@@ -36,6 +36,24 @@ defmodule RichardBurton.Country do
     |> unique_constraint(:code)
   end
 
+  @doc """
+  The codes a word could be naming, so a country can be searched for by the name
+  a reader sees rather than the code the record stores.
+
+  A partial word counts: "braz" names Brazil while it is still being typed.
+  """
+  def codes_named(word) when is_binary(word) do
+    folded = word |> String.downcase() |> String.trim()
+
+    if String.length(folded) < 2 do
+      []
+    else
+      Countries.all()
+      |> Enum.filter(&String.starts_with?(String.downcase(&1.name), folded))
+      |> Enum.map(& &1.alpha2)
+    end
+  end
+
   def validate_code(changeset) do
     validate_change(changeset, :code, fn :code, code ->
       if Countries.exists?(:alpha2, code) do

--- a/backend/lib/richard_burton/flat_publication.ex
+++ b/backend/lib/richard_burton/flat_publication.ex
@@ -27,7 +27,8 @@ defmodule RichardBurton.FlatPublication do
   # and the bulk CSV import doesn't carry it.
   @writable_attributes [:references | @required_attributes]
 
-  @readable_attributes [:id | @writable_attributes]
+  # A snippet of the sources that answered a search, when they are what did.
+  @readable_attributes [:id, :source_match | @writable_attributes]
 
   @derive {Jason.Encoder, only: @readable_attributes}
   schema "flat_publications" do
@@ -43,6 +44,8 @@ defmodule RichardBurton.FlatPublication do
     field(:countries_fingerprint, :string)
     field(:translated_book_fingerprint, :string)
     field(:publishers_fingerprint, :string)
+
+    field(:source_match, :string, virtual: true)
   end
 
   @doc false

--- a/backend/lib/richard_burton/flat_publication.ex
+++ b/backend/lib/richard_burton/flat_publication.ex
@@ -27,7 +27,8 @@ defmodule RichardBurton.FlatPublication do
   # and the bulk CSV import doesn't carry it.
   @writable_attributes [:references | @required_attributes]
 
-  # A snippet of the sources that answered a search, when they are what did.
+  # A highlighted snippet of the references, set only when a search matched on
+  # them rather than on the record's own fields.
   @readable_attributes [:id, :source_match | @writable_attributes]
 
   @derive {Jason.Encoder, only: @readable_attributes}

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -156,7 +156,10 @@ defmodule RichardBurton.Publication.Index do
   # what it will be, and a finished one matches itself. A word that names a
   # country stands for its code too, which is what the record holds.
   defp as_written(words, attributes) do
-    query = Enum.map_join(words, " & ", &"(#{alternatives(&1)})")
+    query =
+      words
+      |> Enum.map_join(" & ", &"(#{alternatives(&1)})")
+      |> or_the_country_named(Enum.join(words, " "))
 
     case Repo.all(matching(query, attributes)) do
       [] -> {[], []}
@@ -167,6 +170,16 @@ defmodule RichardBurton.Publication.Index do
   defp alternatives(word) do
     ["#{lexeme(word)}:*" | Enum.map(Country.codes_named(word), &lexeme/1)]
     |> Enum.join(" | ")
+  end
+
+  # Most country names are one word, but the ones that are not would otherwise
+  # ask for words no record holds: nothing is published in a "kingdom". A term
+  # naming a country asks for its code as a whole, whatever it is made of.
+  defp or_the_country_named(query, term) do
+    case Country.codes_named(term) do
+      [] -> query
+      codes -> "(#{query}) | (#{Enum.map_join(codes, " | ", &lexeme/1)})"
+    end
   end
 
   # Nothing was written the way the index holds it, so each word asks for the

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -57,8 +57,10 @@ defmodule RichardBurton.Publication.Index do
     select(query, [fp], map(fp, ^attributes))
   end
 
+  # The index holds words with their accents folded away, so a term is folded
+  # the same way before it is compared to them.
   def search_keywords(term, :prefix) do
-    from(w in SearchKeyword, where: ilike(w.word, ^"#{term}%"))
+    from(w in SearchKeyword, where: ilike(w.word, fragment("unaccent(?)", ^"#{term}%")))
     |> Repo.all()
     |> Enum.map(&Map.get(&1, :word))
   end
@@ -66,7 +68,7 @@ defmodule RichardBurton.Publication.Index do
   def search_keywords(term, :fuzzy) do
     from(
       w in SearchKeyword,
-      where: fragment("similarity((?), (?)) > 0.3", w.word, ^term)
+      where: fragment("similarity((?), unaccent(?)) > 0.3", w.word, ^term)
     )
     |> Repo.all()
     |> Enum.map(&Map.get(&1, :word))
@@ -114,44 +116,52 @@ defmodule RichardBurton.Publication.Index do
   def search(term, select: attributes) when is_binary(term) do
     words = String.split(term, ~r/\s+/, trim: true)
 
-    case narrow(words, :prefix, attributes) do
-      {[], _keywords} -> found(narrow(words, :fuzzy, attributes))
+    case as_written(words, attributes) do
+      {[], _keywords} -> found(fuzzily(words, attributes))
       results -> found(results)
     end
   end
 
   defp found({results, keywords}), do: {:ok, results, keywords}
 
-  defp narrow(words, strategy, attributes) do
-    words
-    |> Enum.map(&search_keywords(&1, strategy))
-    |> answers(strategy)
-    |> case do
+  # Each word stands for what it starts, so a word still being typed matches
+  # what it will be, and a finished one matches itself.
+  defp as_written(words, attributes) do
+    case Repo.all(matching(Enum.map_join(words, " & ", &"#{lexeme(&1)}:*"), attributes)) do
       [] -> {[], []}
-      groups -> {Repo.all(matching(groups, attributes)), Enum.uniq(List.flatten(groups))}
+      results -> {results, Enum.flat_map(words, &search_keywords(&1, :prefix)) |> Enum.uniq()}
     end
   end
 
-  # Read as written, a word that names nothing means the term is not in the
-  # index as typed, and the whole term is better off going fuzzy.
-  defp answers(groups, :prefix), do: if(Enum.any?(groups, &(&1 == [])), do: [], else: groups)
-  defp answers(groups, :fuzzy), do: Enum.reject(groups, &(&1 == []))
+  # Nothing was written the way the index holds it, so each word asks for the
+  # keywords it resembles. One that resembles none is dropped: a typo should
+  # cost its own word rather than the whole term.
+  defp fuzzily(words, attributes) do
+    words
+    |> Enum.map(&search_keywords(&1, :fuzzy))
+    |> Enum.reject(&(&1 == []))
+    |> case do
+      [] ->
+        {[], []}
 
-  defp matching(groups, attributes) do
-    ranked = groups |> List.flatten() |> Enum.uniq() |> Enum.join(" OR ")
+      groups ->
+        query =
+          Enum.map_join(groups, " & ", &"(#{Enum.map_join(&1, " | ", fn w -> lexeme(w) end)})")
 
-    groups
-    |> Enum.reduce(
-      from(p in FlatPublication,
-        join: d in SearchDocument,
-        on: d.id == p.id,
-        order_by:
-          {:desc, fragment("ts_rank_cd(document, websearch_to_tsquery('simple', ?), 4)", ^ranked)}
-      ),
-      fn group, query ->
-        joint = Enum.join(group, " OR ")
-        where(query, fragment("document @@ websearch_to_tsquery('simple', ?)", ^joint))
-      end
+        {Repo.all(matching(query, attributes)), Enum.uniq(List.flatten(groups))}
+    end
+  end
+
+  # A word as a tsquery lexeme: quoted, so punctuation in it is read as part of
+  # the word rather than as syntax.
+  defp lexeme(word), do: "'" <> String.replace(word, "'", "''") <> "'"
+
+  defp matching(query, attributes) do
+    from(p in FlatPublication,
+      join: d in SearchDocument,
+      on: d.id == p.id,
+      where: fragment("document @@ to_tsquery('rb_search', ?)", ^query),
+      order_by: {:desc, fragment("ts_rank_cd(document, to_tsquery('rb_search', ?), 4)", ^query)}
     )
     |> maybe_select(attributes)
   end

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -153,12 +153,11 @@ defmodule RichardBurton.Publication.Index do
   end
 
   # Each word stands for what it starts, so a word still being typed matches
-  # what it will be, and a finished one matches itself. A word that names a
-  # country stands for its code too, which is what the record holds.
+  # what it will be, and a finished one matches itself.
   defp as_written(words, attributes) do
     query =
       words
-      |> Enum.map_join(" & ", &"(#{alternatives(&1)})")
+      |> Enum.map_join(" & ", &"(#{lexeme(&1)}:*)")
       |> or_the_country_named(Enum.join(words, " "))
 
     case Repo.all(matching(query, attributes)) do
@@ -167,18 +166,17 @@ defmodule RichardBurton.Publication.Index do
     end
   end
 
-  defp alternatives(word) do
-    ["#{lexeme(word)}:*" | Enum.map(Country.codes_named(word), &lexeme/1)]
-    |> Enum.join(" | ")
-  end
-
-  # Most country names are one word, but the ones that are not would otherwise
-  # ask for words no record holds: nothing is published in a "kingdom". A term
-  # naming a country asks for its code as a whole, whatever it is made of.
+  # A term naming a country asks for its code, which is what the record holds.
+  # The term as a whole, because a name of several words would otherwise ask for
+  # words no record has: nothing is published in a "kingdom".
+  #
+  # The code is asked for where a country is written and nowhere else: two
+  # letters are a word of their own in the languages here, and "NO" would
+  # otherwise answer for every Portuguese title carrying "no".
   defp or_the_country_named(query, term) do
     case Country.codes_named(term) do
       [] -> query
-      codes -> "(#{query}) | (#{Enum.map_join(codes, " | ", &lexeme/1)})"
+      codes -> "(#{query}) | (#{Enum.map_join(codes, " | ", &"#{lexeme(&1)}:C")})"
     end
   end
 

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -72,9 +72,25 @@ defmodule RichardBurton.Publication.Index do
     |> Enum.map(&Map.get(&1, :word))
   end
 
+  @doc """
+  The indexed words a search term is asking about.
+
+  A term is matched a word at a time. Both matches this rests on compare a
+  single word: a prefix is one, and trigram similarity to a whole phrase falls
+  away as the phrase grows, so a title asked for in full would resolve to
+  nothing at all. A word that names no keyword contributes none rather than
+  emptying the search.
+  """
   def search_keywords(term) when is_binary(term) do
-    case search_keywords(term, :prefix) do
-      [] -> search_keywords(term, :fuzzy)
+    term
+    |> String.split(~r/\s+/, trim: true)
+    |> Enum.flat_map(&keywords_naming/1)
+    |> Enum.uniq()
+  end
+
+  defp keywords_naming(word) do
+    case search_keywords(word, :prefix) do
+      [] -> search_keywords(word, :fuzzy)
       keywords when is_list(keywords) -> keywords
     end
   end
@@ -83,31 +99,60 @@ defmodule RichardBurton.Publication.Index do
     search(term, select: [])
   end
 
+  @doc """
+  The publications a term is asking for, and the indexed words it resolved to.
+
+  Every word narrows: a publication has to answer all of them, so a title asked
+  for in full returns the publication it names rather than everything sharing a
+  word with it. A word is answered by any of the keywords it names, which is
+  what lets a half-typed one stand for what it starts.
+
+  Words are read as written first. Only when that finds nothing does the whole
+  term go fuzzy, where a word naming nothing is dropped rather than emptying
+  the search: a typo should cost its own word, not the others.
+  """
   def search(term, select: attributes) when is_binary(term) do
-    case search_keywords(term) do
-      [] ->
-        {:ok, [], []}
+    words = String.split(term, ~r/\s+/, trim: true)
 
-      keywords when is_list(keywords) ->
-        joint_keywords = Enum.join(keywords, " OR ")
-
-        query =
-          from(p in FlatPublication,
-            join: d in SearchDocument,
-            on: d.id == p.id,
-            where: fragment("document @@ websearch_to_tsquery('simple', ?)", ^joint_keywords),
-            order_by:
-              {:desc,
-               fragment(
-                 "ts_rank_cd(document, websearch_to_tsquery('simple', ?), 4)",
-                 ^joint_keywords
-               )}
-          )
-          |> maybe_select(attributes)
-
-        results = Repo.all(query)
-
-        {:ok, results, keywords}
+    case narrow(words, :prefix, attributes) do
+      {[], _keywords} -> found(narrow(words, :fuzzy, attributes))
+      results -> found(results)
     end
+  end
+
+  defp found({results, keywords}), do: {:ok, results, keywords}
+
+  defp narrow(words, strategy, attributes) do
+    words
+    |> Enum.map(&search_keywords(&1, strategy))
+    |> answers(strategy)
+    |> case do
+      [] -> {[], []}
+      groups -> {Repo.all(matching(groups, attributes)), Enum.uniq(List.flatten(groups))}
+    end
+  end
+
+  # Read as written, a word that names nothing means the term is not in the
+  # index as typed, and the whole term is better off going fuzzy.
+  defp answers(groups, :prefix), do: if(Enum.any?(groups, &(&1 == [])), do: [], else: groups)
+  defp answers(groups, :fuzzy), do: Enum.reject(groups, &(&1 == []))
+
+  defp matching(groups, attributes) do
+    ranked = groups |> List.flatten() |> Enum.uniq() |> Enum.join(" OR ")
+
+    groups
+    |> Enum.reduce(
+      from(p in FlatPublication,
+        join: d in SearchDocument,
+        on: d.id == p.id,
+        order_by:
+          {:desc, fragment("ts_rank_cd(document, websearch_to_tsquery('simple', ?), 4)", ^ranked)}
+      ),
+      fn group, query ->
+        joint = Enum.join(group, " OR ")
+        where(query, fragment("document @@ websearch_to_tsquery('simple', ?)", ^joint))
+      end
+    )
+    |> maybe_select(attributes)
   end
 end

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -1,6 +1,14 @@
 defmodule RichardBurton.Publication.Index do
   @moduledoc """
-  Interface with the searchable publication index
+  Full-text search over the publication index.
+
+  A search runs in one of two modes. A plain term is split into words, each
+  word is matched on its own (as a prefix, or fuzzily if nothing matches as
+  typed), and the words are combined with AND so each one narrows the result.
+  A term that quotes a phrase or negates a word is instead passed to Postgres
+  verbatim, exactly as written. Either way the match runs against a `tsvector`
+  built with accents folded, so a term is folded the same way before it is
+  compared.
   """
 
   import Ecto.Query
@@ -76,13 +84,14 @@ defmodule RichardBurton.Publication.Index do
   end
 
   @doc """
-  The indexed words a search term is asking about.
+  The indexed words a search term matches.
 
-  A term is matched a word at a time. Both matches this rests on compare a
-  single word: a prefix is one, and trigram similarity to a whole phrase falls
-  away as the phrase grows, so a title asked for in full would resolve to
-  nothing at all. A word that names no keyword contributes none rather than
-  emptying the search.
+  The term is split into words and each word is matched on its own, because
+  both kinds of match only work word by word: a prefix is the start of a single
+  word, and trigram similarity between a word and a whole phrase drops toward
+  zero as the phrase grows. Matching a full title as one string would find
+  nothing. A word that matches no indexed word is simply left out, so one
+  unmatched word does not make the whole search return empty.
   """
   def search_keywords(term) when is_binary(term) do
     term
@@ -103,16 +112,17 @@ defmodule RichardBurton.Publication.Index do
   end
 
   @doc """
-  The publications a term is asking for, and the indexed words it resolved to.
+  The publications a term matches, and the indexed words it matched on.
 
-  Every word narrows: a publication has to answer all of them, so a title asked
-  for in full returns the publication it names rather than everything sharing a
-  word with it. A word is answered by any of the keywords it names, which is
-  what lets a half-typed one stand for what it starts.
+  The term's words are combined with AND, so each word narrows the result: a
+  publication must match every word. That is why searching a full title returns
+  just that title, not everything that shares a word with it. For a single
+  word, matching any of the indexed words it could be is enough, so a half-typed
+  word matches everything it might still become.
 
-  Words are read as written first. Only when that finds nothing does the whole
-  term go fuzzy, where a word naming nothing is dropped rather than emptying
-  the search: a typo should cost its own word, not the others.
+  The words are tried as typed first. Only if that matches nothing is the term
+  retried fuzzily, and there a word that matches nothing is dropped instead of
+  emptying the result — a typo costs only its own word, not the rest.
   """
   def search(term, select: attributes) when is_binary(term) do
     if spelled_out?(term) do
@@ -129,9 +139,10 @@ defmodule RichardBurton.Publication.Index do
 
   defp found({results, keywords}), do: {:ok, results, keywords}
 
-  # A term that quotes a phrase or excludes a word is saying precisely what it
-  # wants, so it is handed to Postgres as written and never widened: no
-  # prefixes, and nothing fuzzy to put back what the reader just excluded.
+  # A term that quotes a phrase or negates a word (-word) is stating exactly
+  # what it wants, so it is passed to Postgres as written and never widened:
+  # no prefix matching, and no fuzzy pass that could add back a word the reader
+  # just excluded.
   defp spelled_out?(term), do: String.contains?(term, ~s(")) or term =~ ~r/(^|\s)-\S/
 
   defp exactly(term, attributes) do
@@ -152,8 +163,8 @@ defmodule RichardBurton.Publication.Index do
     {Repo.all(query), []}
   end
 
-  # Each word stands for what it starts, so a word still being typed matches
-  # what it will be, and a finished one matches itself.
+  # `:*` makes each word a prefix, so a word still being typed matches every
+  # word that starts with it, and a complete word matches itself.
   defp as_written(words, attributes) do
     query =
       words
@@ -166,13 +177,14 @@ defmodule RichardBurton.Publication.Index do
     end
   end
 
-  # A term naming a country asks for its code, which is what the record holds.
-  # The term as a whole, because a name of several words would otherwise ask for
-  # words no record has: nothing is published in a "kingdom".
+  # A record stores a country as its code (US, GB), not its name, so a term
+  # that names a country also searches for that code. The whole term is matched
+  # against country names, not word by word: "United Kingdom" split into words
+  # would search for "kingdom", which no record holds.
   #
-  # The code is asked for where a country is written and nowhere else: two
-  # letters are a word of their own in the languages here, and "NO" would
-  # otherwise answer for every Portuguese title carrying "no".
+  # The code is added only where a country was actually named. A two-letter
+  # code is itself a word in these languages, so searching for "NO"
+  # unconditionally would match every Portuguese title containing "no".
   defp or_the_country_named(query, term) do
     case Country.codes_named(term) do
       [] -> query
@@ -180,9 +192,9 @@ defmodule RichardBurton.Publication.Index do
     end
   end
 
-  # Nothing was written the way the index holds it, so each word asks for the
-  # keywords it resembles. One that resembles none is dropped: a typo should
-  # cost its own word rather than the whole term.
+  # Nothing matched as typed, so each word is matched against the indexed words
+  # it resembles. A word that resembles none is dropped: a typo should cost its
+  # own word, not the whole term.
   defp fuzzily(words, attributes) do
     words
     |> Enum.map(&search_keywords(&1, :fuzzy))
@@ -203,8 +215,8 @@ defmodule RichardBurton.Publication.Index do
   # the word rather than as syntax.
   defp lexeme(word), do: "'" <> String.replace(word, "'", "''") <> "'"
 
-  # Rank first, then the title, then the id: equally relevant rows have to come
-  # back in the same order every time, or a page of them is not a page.
+  # Order by rank, then title, then id. Rows of equal rank must sort the same
+  # way every time, or paging through the results would repeat or skip some.
   defp matching(query, attributes) do
     from(p in FlatPublication,
       join: d in SearchDocument,
@@ -220,9 +232,9 @@ defmodule RichardBurton.Publication.Index do
     |> source_match(attributes, :parsed, query)
   end
 
-  # Why a row is here, when the answer is nowhere on it: a publication can match
-  # on its sources, which the index does not show. Only then is there a snippet,
-  # and the words that answered are wrapped for the reader to pick out.
+  # A publication can match on its references, which the index does not display.
+  # When it does, build a highlighted snippet of the matching source so the
+  # reader can see why the row is here; the matched words are wrapped in [[ ]].
   defp source_match(query, [], :parsed, term) do
     select_merge(query, [p], %{
       source_match:

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -5,6 +5,7 @@ defmodule RichardBurton.Publication.Index do
 
   import Ecto.Query
 
+  alias RichardBurton.Country
   alias RichardBurton.FlatPublication
   alias RichardBurton.Publication.Index.SearchDocument
   alias RichardBurton.Publication.Index.SearchKeyword
@@ -114,23 +115,58 @@ defmodule RichardBurton.Publication.Index do
   the search: a typo should cost its own word, not the others.
   """
   def search(term, select: attributes) when is_binary(term) do
-    words = String.split(term, ~r/\s+/, trim: true)
+    if spelled_out?(term) do
+      found(exactly(term, attributes))
+    else
+      words = String.split(term, ~r/\s+/, trim: true)
 
-    case as_written(words, attributes) do
-      {[], _keywords} -> found(fuzzily(words, attributes))
-      results -> found(results)
+      case as_written(words, attributes) do
+        {[], _keywords} -> found(fuzzily(words, attributes))
+        results -> found(results)
+      end
     end
   end
 
   defp found({results, keywords}), do: {:ok, results, keywords}
 
+  # A term that quotes a phrase or excludes a word is saying precisely what it
+  # wants, so it is handed to Postgres as written and never widened: no
+  # prefixes, and nothing fuzzy to put back what the reader just excluded.
+  defp spelled_out?(term), do: String.contains?(term, ~s(")) or term =~ ~r/(^|\s)-\S/
+
+  defp exactly(term, attributes) do
+    query =
+      from(p in FlatPublication,
+        join: d in SearchDocument,
+        on: d.id == p.id,
+        where: fragment("document @@ websearch_to_tsquery('rb_search', ?)", ^term),
+        order_by: [
+          desc: fragment("ts_rank_cd(document, websearch_to_tsquery('rb_search', ?), 4)", ^term),
+          asc: p.title,
+          asc: p.id
+        ]
+      )
+      |> maybe_select(attributes)
+      |> source_match(attributes, :spelled_out, term)
+
+    {Repo.all(query), []}
+  end
+
   # Each word stands for what it starts, so a word still being typed matches
-  # what it will be, and a finished one matches itself.
+  # what it will be, and a finished one matches itself. A word that names a
+  # country stands for its code too, which is what the record holds.
   defp as_written(words, attributes) do
-    case Repo.all(matching(Enum.map_join(words, " & ", &"#{lexeme(&1)}:*"), attributes)) do
+    query = Enum.map_join(words, " & ", &"(#{alternatives(&1)})")
+
+    case Repo.all(matching(query, attributes)) do
       [] -> {[], []}
       results -> {results, Enum.flat_map(words, &search_keywords(&1, :prefix)) |> Enum.uniq()}
     end
+  end
+
+  defp alternatives(word) do
+    ["#{lexeme(word)}:*" | Enum.map(Country.codes_named(word), &lexeme/1)]
+    |> Enum.join(" | ")
   end
 
   # Nothing was written the way the index holds it, so each word asks for the
@@ -156,13 +192,51 @@ defmodule RichardBurton.Publication.Index do
   # the word rather than as syntax.
   defp lexeme(word), do: "'" <> String.replace(word, "'", "''") <> "'"
 
+  # Rank first, then the title, then the id: equally relevant rows have to come
+  # back in the same order every time, or a page of them is not a page.
   defp matching(query, attributes) do
     from(p in FlatPublication,
       join: d in SearchDocument,
       on: d.id == p.id,
       where: fragment("document @@ to_tsquery('rb_search', ?)", ^query),
-      order_by: {:desc, fragment("ts_rank_cd(document, to_tsquery('rb_search', ?), 4)", ^query)}
+      order_by: [
+        desc: fragment("ts_rank_cd(document, to_tsquery('rb_search', ?), 4)", ^query),
+        asc: p.title,
+        asc: p.id
+      ]
     )
     |> maybe_select(attributes)
+    |> source_match(attributes, :parsed, query)
   end
+
+  # Why a row is here, when the answer is nowhere on it: a publication can match
+  # on its sources, which the index does not show. Only then is there a snippet,
+  # and the words that answered are wrapped for the reader to pick out.
+  defp source_match(query, [], :parsed, term) do
+    select_merge(query, [p], %{
+      source_match:
+        fragment(
+          "CASE WHEN to_tsvector('rb_search', array_to_string(?, ' ')) @@ to_tsquery('rb_search', ?) THEN ts_headline('rb_search', array_to_string(?, ' '), to_tsquery('rb_search', ?), 'StartSel=[[,StopSel=]],MaxFragments=1,MaxWords=16,MinWords=6') ELSE NULL END",
+          p.references,
+          ^term,
+          p.references,
+          ^term
+        )
+    })
+  end
+
+  defp source_match(query, [], :spelled_out, term) do
+    select_merge(query, [p], %{
+      source_match:
+        fragment(
+          "CASE WHEN to_tsvector('rb_search', array_to_string(?, ' ')) @@ websearch_to_tsquery('rb_search', ?) THEN ts_headline('rb_search', array_to_string(?, ' '), websearch_to_tsquery('rb_search', ?), 'StartSel=[[,StopSel=]],MaxFragments=1,MaxWords=16,MinWords=6') ELSE NULL END",
+          p.references,
+          ^term,
+          p.references,
+          ^term
+        )
+    })
+  end
+
+  defp source_match(query, _attributes, _kind, _term), do: query
 end

--- a/backend/priv/repo/migrations/20260724140000_soft_delete_publications.exs
+++ b/backend/priv/repo/migrations/20260724140000_soft_delete_publications.exs
@@ -38,7 +38,7 @@ defmodule RichardBurton.Repo.Migrations.SoftDeletePublications do
     execute(flat_publications_sql(live_only: true))
 
     create table(:publication_history) do
-      # No FK: the log is independent of the catalogue tables' lifecycle.
+      # No FK: the log is independent of the publication tables' lifecycle.
       add(:publication_id, :bigint, null: false)
       add(:version, :integer, null: false)
       add(:action, :string, null: false)

--- a/backend/priv/repo/migrations/20260729120000_weigh_and_fold_the_search_index.exs
+++ b/backend/priv/repo/migrations/20260729120000_weigh_and_fold_the_search_index.exs
@@ -1,0 +1,90 @@
+defmodule RichardBurton.Repo.Migrations.WeighAndFoldTheSearchIndex do
+  use Ecto.Migration
+
+  @moduledoc """
+  Three things the index could not do: tell a title from a year, find a word
+  written with its accents when it was asked for without them, and answer for a
+  publication's sources at all.
+
+  Fields carry weights now, `rb_search` folds accents on both sides of a search,
+  and the references join the document at the lowest weight — searchable, but
+  never outranking what the record itself says.
+  """
+
+  def up do
+    execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+
+    execute("CREATE TEXT SEARCH CONFIGURATION rb_search (COPY = simple)")
+
+    execute("""
+    ALTER TEXT SEARCH CONFIGURATION rb_search
+    ALTER MAPPING FOR hword, hword_part, word
+    WITH unaccent, simple
+    """)
+
+    # search_keywords reads search_documents, so it goes first and comes back last.
+    execute("DROP MATERIALIZED VIEW search_keywords")
+    execute("DROP MATERIALIZED VIEW search_documents")
+
+    execute("""
+    CREATE MATERIALIZED VIEW search_documents AS
+    SELECT
+      id,
+      setweight(to_tsvector('rb_search'::regconfig, title::text), 'A')                    ||
+      setweight(to_tsvector('rb_search'::regconfig, original_title::text), 'A')           ||
+      setweight(to_tsvector('rb_search'::regconfig, authors), 'B')                        ||
+      setweight(to_tsvector('rb_search'::regconfig, original_authors), 'B')               ||
+      setweight(to_tsvector('rb_search'::regconfig, publishers), 'C')                     ||
+      setweight(to_tsvector('rb_search'::regconfig, countries), 'C')                      ||
+      setweight(to_tsvector('rb_search'::regconfig, year::text), 'C')                     ||
+      setweight(to_tsvector('rb_search'::regconfig,
+        array_to_string("references", ' ')), 'D')                                         AS document
+    FROM
+      flat_publications
+    """)
+
+    execute("CREATE INDEX search_index ON search_documents USING gin(document)")
+    execute("CREATE UNIQUE INDEX search_documents_id_index ON search_documents (id)")
+
+    execute("""
+    CREATE MATERIALIZED VIEW search_keywords AS
+    SELECT word FROM ts_stat('SELECT document FROM search_documents')
+    """)
+
+    execute("CREATE INDEX search_trigram_index ON search_keywords USING gin(word gin_trgm_ops)")
+    execute("CREATE UNIQUE INDEX search_keywords_word_index ON search_keywords (word)")
+  end
+
+  def down do
+    execute("DROP MATERIALIZED VIEW search_keywords")
+    execute("DROP MATERIALIZED VIEW search_documents")
+
+    execute("""
+    CREATE MATERIALIZED VIEW search_documents AS
+    SELECT
+      id,
+      to_tsvector('simple'::regconfig, title::text)          ||
+      to_tsvector('simple'::regconfig, countries)            ||
+      to_tsvector('simple'::regconfig, publishers)           ||
+      to_tsvector('simple'::regconfig, year::text)           ||
+      to_tsvector('simple'::regconfig, authors)              ||
+      to_tsvector('simple'::regconfig, original_title::text) ||
+      to_tsvector('simple'::regconfig, original_authors)     AS document
+    FROM
+      flat_publications
+    """)
+
+    execute("CREATE INDEX search_index ON search_documents USING gin(document)")
+    execute("CREATE UNIQUE INDEX search_documents_id_index ON search_documents (id)")
+
+    execute("""
+    CREATE MATERIALIZED VIEW search_keywords AS
+    SELECT word FROM ts_stat('SELECT document FROM search_documents')
+    """)
+
+    execute("CREATE INDEX search_trigram_index ON search_keywords USING gin(word gin_trgm_ops)")
+    execute("CREATE UNIQUE INDEX search_keywords_word_index ON search_keywords (word)")
+
+    execute("DROP TEXT SEARCH CONFIGURATION rb_search")
+  end
+end

--- a/backend/priv/repo/migrations/20260729120000_weigh_and_fold_the_search_index.exs
+++ b/backend/priv/repo/migrations/20260729120000_weigh_and_fold_the_search_index.exs
@@ -2,13 +2,14 @@ defmodule RichardBurton.Repo.Migrations.WeighAndFoldTheSearchIndex do
   use Ecto.Migration
 
   @moduledoc """
-  Three things the index could not do: tell a title from a year, find a word
-  written with its accents when it was asked for without them, and answer for a
-  publication's sources at all.
+  Improves the search index in three ways:
 
-  Fields carry weights now, `rb_search` folds accents on both sides of a search,
-  and the references join the document at the lowest weight — searchable, but
-  never outranking what the record itself says.
+    - fields carry weights, so a match on the title outranks a match on the year;
+    - the `rb_search` configuration folds accents, so a word is found whether or
+      not the search typed its accents;
+    - a publication's references join the search document at the lowest weight,
+      so a search can match on them without their outranking the record's own
+      fields.
   """
 
   def up do

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -499,14 +499,19 @@ defmodule RichardBurton.Publication.IndexTest do
     test "does a prefix search" do
       term = "Mari"
 
-      assert {:ok, publications, ["marie", "marias"]} = Publication.Index.search(term)
+      assert {:ok, publications, keywords} = Publication.Index.search(term)
+
+      # "Mário" is held with its accent folded away, so a term written without
+      # one reaches it.
+      assert Enum.sort(keywords) == ["marias", "marie", "mario"]
 
       assert_search_results(
         publications,
         expect: [
           title: "The Three Marias",
           authors: "Marie Barrett",
-          original_title: "As três Marias"
+          original_title: "As três Marias",
+          original_authors: "Mário de Andrade"
         ]
       )
     end
@@ -514,16 +519,51 @@ defmodule RichardBurton.Publication.IndexTest do
     test "does a fuzzy search" do
       term = "Maries"
 
-      assert {:ok, publications, ["marie", "marias"]} = Publication.Index.search(term)
+      assert {:ok, publications, keywords} = Publication.Index.search(term)
+
+      assert Enum.sort(keywords) == ["marias", "marie", "mario"]
 
       assert_search_results(
         publications,
         expect: [
           title: "The Three Marias",
           authors: "Marie Barrett",
-          original_title: "As três Marias"
+          original_title: "As três Marias",
+          original_authors: "Mário de Andrade"
         ]
       )
+    end
+  end
+
+  describe "search/1 with accents" do
+    test "a term written without them finds the words that carry them" do
+      {:ok, folded, _} = Publication.Index.search("Angustia")
+      {:ok, written, _} = Publication.Index.search("Angústia")
+
+      assert_search_results(folded, expect: [original_title: "Angústia"])
+      assert Enum.map(folded, & &1.id) == Enum.map(written, & &1.id)
+    end
+
+    test "a term written with them finds what is held without" do
+      assert {:ok, publications, _} = Publication.Index.search("Frãulein")
+
+      assert_search_results(publications, expect: [title: "Fraulein"])
+    end
+  end
+
+  describe "search/1 over a publication's sources" do
+    test "finds a publication by a word only its references carry" do
+      assert {:ok, publications, _} = Publication.Index.search("Berkeley")
+
+      assert_search_results(publications,
+        expect: [title: "Posthumous Reminiscences of Brás Cubas"]
+      )
+    end
+
+    test "a title outranks a passing mention in someone else's sources" do
+      assert {:ok, [first | _], _} = Publication.Index.search("Three Marias")
+
+      assert first.title == "The Three Marias"
     end
   end
 

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -528,7 +528,7 @@ defmodule RichardBurton.Publication.IndexTest do
   end
 
   describe "search/1 with a composite term present in the dataset" do
-    test "retrieves publications matching any of the words" do
+    test "retrieves publications answering every word" do
       term = "Marie Barrett"
       split_term = String.split(term, " ")
       keywords = Enum.map(split_term, &String.downcase/1)
@@ -541,6 +541,36 @@ defmodule RichardBurton.Publication.IndexTest do
           authors: ["Linton Lemos Barrett", "Marie Barrett"]
         ]
       )
+    end
+  end
+
+  describe "search/1 with a whole title as the term" do
+    # A title is what the publication's own link searches for.
+    test "returns the publication the title belongs to, and not the rest" do
+      assert {:ok, publications, keywords} =
+               Publication.Index.search("Diary of a Civil Servant")
+
+      assert "diary" in keywords
+      assert "servant" in keywords
+
+      assert Enum.all?(publications, &(&1.title == "Diary of a Civil Servant"))
+    end
+
+    test "each word narrows what the one before it found" do
+      {:ok, one_word, _} = Publication.Index.search("Diary")
+      {:ok, three_words, _} = Publication.Index.search("Diary Civil Servant")
+
+      assert length(three_words) <= length(one_word)
+      assert Enum.any?(three_words, &(&1.title == "Diary of a Civil Servant"))
+    end
+
+    test "a word naming nothing does not empty the search" do
+      assert {:ok, publications, keywords} =
+               Publication.Index.search("Diary zzzzqqq Servant")
+
+      assert "diary" in keywords
+
+      assert Enum.any?(publications, &(&1.title == "Diary of a Civil Servant"))
     end
   end
 

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -535,6 +535,47 @@ defmodule RichardBurton.Publication.IndexTest do
     end
   end
 
+  describe "search/1 by country" do
+    test "a country's name finds what the record holds as a code" do
+      assert {:ok, publications, _} = Publication.Index.search("Brazil")
+
+      # The word itself still matches wherever it is written, so this asks only
+      # that the code was reached too.
+      assert Enum.any?(publications, &String.contains?(&1.countries, "BR"))
+    end
+
+    test "a name made of several words asks for the code as a whole" do
+      assert {:ok, publications, _} = Publication.Index.search("United Kingdom")
+
+      refute Enum.empty?(publications)
+      assert Enum.all?(publications, &String.contains?(&1.countries, "GB"))
+    end
+
+    test "the code still works" do
+      assert {:ok, publications, _} = Publication.Index.search("BR")
+
+      # Two letters are also the start of other words, which a term still being
+      # typed should reach, so this asks only that the code was among them.
+      assert Enum.any?(publications, &String.contains?(&1.countries, "BR"))
+    end
+  end
+
+  describe "search/1 spelled out" do
+    test "a quoted phrase is asked for as written" do
+      assert {:ok, publications, _} = Publication.Index.search(~s("Civil Servant"))
+
+      assert Enum.all?(publications, &(&1.title == "Diary of a Civil Servant"))
+    end
+
+    test "a word can be excluded" do
+      {:ok, all, _} = Publication.Index.search("Verissimo")
+      {:ok, fewer, _} = Publication.Index.search("Verissimo -Noite")
+
+      assert length(fewer) < length(all)
+      refute Enum.any?(fewer, &(&1.original_title == "Noite"))
+    end
+  end
+
   describe "search/1 with accents" do
     test "a term written without them finds the words that carry them" do
       {:ok, folded, _} = Publication.Index.search("Angustia")

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -159,6 +159,17 @@ defmodule RichardBurton.Publication.IndexTest do
       year: 1967
     },
     %FlatPublication{
+      authors: "Johnny Lorenz",
+      countries: "CA",
+      countries_fingerprint: "4B650E5C4785025DEE7BD65E3C5C527356717D7A1C0BFEF5B4ADA8CA1E9CBE17",
+      original_authors: "Clarice Lispector",
+      original_title: "Um sopro de vida: pulsações",
+      publishers: "New Directions",
+      publishers_fingerprint: "A092A747DE2B957ADC822F5FEE63B2078F4CEE237438789BBF9A6D10F9F104E2",
+      title: "A Breath of Life (Pulsations)",
+      year: 2012
+    },
+    %FlatPublication{
       authors: "Margaret Richardson Hollingsworth",
       countries: "US",
       countries_fingerprint: "9B202ECBC6D45C6D8901D989A918878397A3EB9D00E8F48022FC051B19D21A1D",
@@ -549,6 +560,14 @@ defmodule RichardBurton.Publication.IndexTest do
 
       refute Enum.empty?(publications)
       assert Enum.all?(publications, &String.contains?(&1.countries, "GB"))
+    end
+
+    # "UM" is the United States Minor Outlying Islands, and also the first word
+    # of half the Portuguese titles here.
+    test "a word that merely starts a country's name asks for no code" do
+      assert {:ok, publications, _} = Publication.Index.search("United")
+
+      refute Enum.any?(publications, &String.contains?(&1.original_title, "Um "))
     end
 
     test "the code still works" do

--- a/backend/test/richard_burton_web/controllers/publication_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/publication_controller_test.exs
@@ -432,7 +432,7 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
         |> post(publication_path(meta.conn, :create_all), input)
         |> json_response(201)
 
-      assert publications == Enum.map(result, &Map.drop(&1, ["id", "references"]))
+      assert publications == Enum.map(result, &Map.drop(&1, ["id", "references", "source_match"]))
     end
 
     test "bulk-inserts publications with their references", meta do
@@ -525,7 +525,7 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
 
       assert 3 == FlatPublication.all() |> length()
       assert ["GB", "US", "BR"] == Country.all() |> Enum.map(&Country.get_code/1)
-      assert output == Enum.map(result, &Map.drop(&1, ["id", "references"]))
+      assert output == Enum.map(result, &Map.drop(&1, ["id", "references", "source_match"]))
     end
 
     test "returns 201 and inserts publications with several publishers", meta do
@@ -602,7 +602,7 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
 
       assert 3 == FlatPublication.all() |> length()
       assert publishers == Publisher.all() |> Enum.map(&Publisher.get_name/1)
-      assert output == Enum.map(result, &Map.drop(&1, ["id", "references"]))
+      assert output == Enum.map(result, &Map.drop(&1, ["id", "references", "source_match"]))
     end
 
     test "returns 409 when publications are repeated, and returns the first repeated one", meta do

--- a/frontend/components/PublicationDetail.stories.tsx
+++ b/frontend/components/PublicationDetail.stories.tsx
@@ -4,7 +4,7 @@ import { withChanges } from "modules/publication/history";
 import { empty, type PublicationHistoryEntry } from "modules/publication/model";
 import { resetAll } from "modules/publication/store";
 import { SessionProvider } from "modules/session";
-import { expect, fn, screen, userEvent, waitFor } from "storybook/test";
+import { expect, screen, userEvent, waitFor } from "storybook/test";
 
 import PublicationDetail from "./PublicationDetail";
 
@@ -178,13 +178,13 @@ export const DeleteConfirmation: Story = {
 };
 
 /**
- * Following a search link tells the caller — an overlay uses it to close
- * itself, a page ignores it.
+ * Every value in the description is a link to a search for it, so a reader can
+ * leave for everything else by the same translator, publisher or country.
  */
-export const NotifiesOnNavigate: Story = {
-  args: { onNavigate: fn() },
-  play: async ({ args }) => {
-    await userEvent.click(screen.getByRole("link", { name: "Helen Caldwell" }));
-    await expect(args.onNavigate).toHaveBeenCalled();
+export const SearchLinks: Story = {
+  play: async () => {
+    await expect(
+      screen.getByRole("link", { name: "Helen Caldwell" }),
+    ).toHaveAttribute("href", "/?search=Helen Caldwell");
   },
 };

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -41,29 +41,23 @@ import ReferencesEditor from "./ReferencesEditor";
 import SectionHeading, { SECTION_HEADING } from "./SectionHeading";
 import Tooltip from "./Tooltip";
 
-const Searchable: FC<{
-  label: string;
-  value?: string;
-  onNavigate?: () => void;
-}> = ({ value, label, onNavigate }) => (
-  <Link
-    href={`/?search=${value || label}`}
-    className="anchor"
-    onClick={onNavigate}
-  >
+const Searchable: FC<{ label: string; value?: string }> = ({
+  value,
+  label,
+}) => (
+  <Link href={`/?search=${value || label}`} className="anchor">
     {label}
   </Link>
 );
 
 const SearchableList: FC<{
   items: { label: string; value?: string }[];
-  onNavigate?: () => void;
-}> = ({ items, onNavigate }) => (
+}> = ({ items }) => (
   <ul className="contents">
     {items.map((item, index) => (
       <li key={item.value} className="contents">
         {index != 0 && index === items.length - 1 && " and "}
-        <Searchable {...item} onNavigate={onNavigate} />
+        <Searchable {...item} />
         {index < items.length - 2 && ", "}
         {index === items.length - 1 && " "}
       </li>
@@ -88,10 +82,9 @@ const PublicationHeading: FC<{ publication: Publication }> = ({
   </div>
 );
 
-const PublicationDescription: FC<{
-  publication: Publication;
-  onNavigate?: () => void;
-}> = ({ publication: p, onNavigate }) => {
+const PublicationDescription: FC<{ publication: Publication }> = ({
+  publication: p,
+}) => {
   function getSearchableItems(p: Publication, key: PublicationKey) {
     return p[key]
       .split(",")
@@ -103,18 +96,14 @@ const PublicationDescription: FC<{
   }
 
   const list = (key: PublicationKey) => (
-    <SearchableList
-      items={getSearchableItems(p, key)}
-      onNavigate={onNavigate}
-    />
+    <SearchableList items={getSearchableItems(p, key)} />
   );
 
   return (
     <div>
-      <Searchable label={p.title} onNavigate={onNavigate} /> is a translation of{" "}
-      <Searchable label={p.originalTitle} onNavigate={onNavigate} />, by{" "}
-      {list("originalAuthors")}. It was written by {list("authors")} and
-      published in {list("countries")}
+      <Searchable label={p.title} /> is a translation of{" "}
+      <Searchable label={p.originalTitle} />, by {list("originalAuthors")}. It
+      was written by {list("authors")} and published in {list("countries")}
       in {p.year} by {list("publishers")}.
     </div>
   );
@@ -274,8 +263,6 @@ type PublicationDetailProps = {
    * who is the only reader allowed it.
    */
   history?: WithChanges<PublicationHistoryEntry>[];
-  /** Run when a search link is followed — an overlay uses it to close itself. */
-  onNavigate?: () => void;
   /**
    * Run once the record is gone. Defaults to leaving for the index, which is
    * what a page showing only this publication has to do; an overlay closes
@@ -293,7 +280,6 @@ const PublicationDetail: FC<PublicationDetailProps> = (props) => (
 const Detail: FC<PublicationDetailProps> = ({
   publication,
   history,
-  onNavigate,
   onDeleted,
 }) => {
   const id = publication.id!;
@@ -351,10 +337,7 @@ const Detail: FC<PublicationDetailProps> = ({
         />
       ) : (
         <>
-          <PublicationDescription
-            publication={publication}
-            onNavigate={onNavigate}
-          />
+          <PublicationDescription publication={publication} />
           <PublicationReferences references={publication.references} />
           {history && <PublicationHistorySection entries={history} />}
           {canEdit && (

--- a/frontend/components/PublicationIndexTable.tsx
+++ b/frontend/components/PublicationIndexTable.tsx
@@ -97,10 +97,10 @@ const ColumnHeader: FC<{ colId: ColId; toggleable?: boolean }> = ({
 };
 
 /**
- * Why a row is here when the answer is nowhere on it: a search can be answered
- * by a publication's sources, which the index does not show. The words that
- * answered arrive wrapped in `[[ ]]`, so the snippet reads as a sentence with
- * them picked out rather than as markup.
+ * A search can match a publication on its references, which the table does not
+ * show — so the row looks unexplained. This renders a snippet of the matching
+ * reference, with the matched words (arriving wrapped in `[[ ]]`) highlighted,
+ * so the reader can see why the row is here.
  */
 const SourceMatch: FC<{ rowId: RowId }> = ({ rowId }) => {
   const snippet = usePublicationSourceMatch(rowId);

--- a/frontend/components/PublicationIndexTable.tsx
+++ b/frontend/components/PublicationIndexTable.tsx
@@ -2,6 +2,7 @@
 
 import {
   useHiddenAttributes,
+  usePublicationSourceMatch,
   usePublicationStoredField,
   useVisiblePublicationIds,
 } from "modules/publication/hooks";
@@ -95,6 +96,30 @@ const ColumnHeader: FC<{ colId: ColId; toggleable?: boolean }> = ({
   );
 };
 
+/**
+ * Why a row is here when the answer is nowhere on it: a search can be answered
+ * by a publication's sources, which the index does not show. The words that
+ * answered arrive wrapped in `[[ ]]`, so the snippet reads as a sentence with
+ * them picked out rather than as markup.
+ */
+const SourceMatch: FC<{ rowId: RowId }> = ({ rowId }) => {
+  const snippet = usePublicationSourceMatch(rowId);
+
+  return snippet ? (
+    <span className="block text-xs text-gray-500 truncate">
+      {snippet.split(/\[\[|\]\]/).map((part, index) =>
+        index % 2 === 0 ? (
+          part
+        ) : (
+          <mark key={index} className="text-gray-700 bg-amber-100">
+            {part}
+          </mark>
+        ),
+      )}
+    </span>
+  ) : null;
+};
+
 const Content: FC<{
   rowId: RowId;
   colId: ColId;
@@ -106,6 +131,7 @@ const Content: FC<{
   return (
     <div className="px-2 py-1 truncate">
       {Publication.describeValue(value, colId)}
+      {colId === "title" && <SourceMatch rowId={rowId} />}
     </div>
   );
 };

--- a/frontend/components/PublicationOverlay.stories.tsx
+++ b/frontend/components/PublicationOverlay.stories.tsx
@@ -88,7 +88,12 @@ const meta = {
   title: "Publications/Publication overlay",
   component: PublicationOverlay,
   args: { view: READER_VIEW },
-  parameters: { layout: "fullscreen" },
+  // The overlay shows a publication only while the address is one; the mocked
+  // router would otherwise put these stories on the index.
+  parameters: {
+    layout: "fullscreen",
+    nextjs: { navigation: { pathname: "/publications/1" } },
+  },
 } satisfies Meta<typeof PublicationOverlay>;
 
 export default meta;

--- a/frontend/components/PublicationOverlay.tsx
+++ b/frontend/components/PublicationOverlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PublicationView } from "app/publications/read";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { FC, Suspense, use } from "react";
 import { Article } from "./Article";
 import CopyLink from "./CopyLink";
@@ -74,7 +74,6 @@ const Opened: FC<{
         <PublicationDetail
           publication={opened.publication}
           history={opened.history}
-          onNavigate={onClose}
           onDeleted={onClose}
         />
       }
@@ -103,16 +102,20 @@ const PublicationOverlay: FC<{
   closeTo?: string;
 }> = ({ view, closeTo }) => {
   const router = useRouter();
+  const pathname = usePathname();
 
   const close = closeTo ? () => router.push(closeTo) : router.back;
 
-  return (
+  // A parallel slot keeps what it was showing when the route around it changes,
+  // so leaving by a link inside the overlay would otherwise carry the overlay
+  // along. The address is what says whether a publication is being read.
+  return pathname.startsWith("/publications/") ? (
     <Modal isOpen onClose={close} label="Publication details">
       <Suspense fallback={<Loading />}>
         <Opened view={view} onClose={close} />
       </Suspense>
     </Modal>
-  );
+  ) : null;
 };
 
 export default PublicationOverlay;

--- a/frontend/components/PublicationOverlay.tsx
+++ b/frontend/components/PublicationOverlay.tsx
@@ -106,9 +106,10 @@ const PublicationOverlay: FC<{
 
   const close = closeTo ? () => router.push(closeTo) : router.back;
 
-  // A parallel slot keeps what it was showing when the route around it changes,
-  // so leaving by a link inside the overlay would otherwise carry the overlay
-  // along. The address is what says whether a publication is being read.
+  // A parallel route slot keeps rendering its last content even after the URL
+  // navigates away, so a link inside the overlay would leave the overlay open
+  // over the new page. Gate on the URL instead: show it only while the path is
+  // still a publication's.
   return pathname.startsWith("/publications/") ? (
     <Modal isOpen onClose={close} label="Publication details">
       <Suspense fallback={<Loading />}>

--- a/frontend/e2e/browse-the-database.spec.ts
+++ b/frontend/e2e/browse-the-database.spec.ts
@@ -245,3 +245,18 @@ test("a search link in an open publication takes the reader to that search", asy
   await expect(rows.filter({ hasText: "Dom Casmurro" }).first()).toBeVisible();
   await expect(rows.filter({ hasText: "The Hour of the Star" })).toHaveCount(0);
 });
+
+test("a row answered by its sources says so", async ({ page }) => {
+  await seedCorpus(page);
+  // "Afterword" is in one publication's references and nowhere else in the
+  // corpus, so the row it returns has nothing on it explaining why.
+  await page.goto("/?search=Afterword");
+
+  const row = indexTable(page)
+    .getByRole("row")
+    .filter({ hasText: "The Hour of the Star" })
+    .first();
+
+  await expect(row.locator("mark")).toHaveText("Afterword");
+  await expect(row).toContainText("Pontiero");
+});

--- a/frontend/e2e/browse-the-database.spec.ts
+++ b/frontend/e2e/browse-the-database.spec.ts
@@ -224,3 +224,24 @@ test("a reader takes a publication's link, and the link stands on its own", asyn
   await expect(page.getByRole("dialog")).toHaveCount(0);
   await expect(page.getByText("Barren Lives")).toHaveCount(0);
 });
+
+test("a search link in an open publication takes the reader to that search", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/");
+
+  // Three of the corpus share this author, so the search has to narrow the
+  // index rather than leave it whole.
+  const dialog = await openPublicationModal(page, "Dom Casmurro");
+  await dialog.getByRole("link", { name: "Machado de Assis" }).first().click();
+
+  await expect(page).toHaveURL(
+    /\?search=Machado\+de\+Assis|\?search=Machado%20de%20Assis/,
+  );
+  await expect(dialog).toHaveCount(0);
+
+  const rows = indexTable(page).getByRole("row");
+  await expect(rows.filter({ hasText: "Dom Casmurro" }).first()).toBeVisible();
+  await expect(rows.filter({ hasText: "The Hour of the Star" })).toHaveCount(0);
+});

--- a/frontend/modules/publication/hooks.ts
+++ b/frontend/modules/publication/hooks.ts
@@ -19,6 +19,7 @@ import {
   overrideFamily,
   publicationOrNullFamily,
   publicationReferencesFamily,
+  publicationSourceMatchFamily,
   storedFieldValueFamily,
   storedReferencesFamily,
   totalCountAtom,
@@ -71,6 +72,10 @@ function usePublicationStoredField<K extends PublicationKey>(
   key: K,
 ) {
   return useAtomValue(storedFieldValueFamily({ id, key })) as Publication[K];
+}
+
+function usePublicationSourceMatch(id: PublicationId) {
+  return useAtomValue(publicationSourceMatchFamily(id));
 }
 
 function usePublicationReferences(id: PublicationId) {
@@ -181,6 +186,7 @@ export {
   usePublicationIndexCount,
   usePublicationOverride,
   usePublicationReferences,
+  usePublicationSourceMatch,
   usePublicationStoredField,
   useStoredPublicationReferences,
   useTotalPublicationCount,

--- a/frontend/modules/publication/model.ts
+++ b/frontend/modules/publication/model.ts
@@ -15,9 +15,16 @@ type Publication = {
   // The server PK: a real id on persisted rows (index/search), null on
   // unsaved/working rows. Read-only: never cast from client input.
   id: number | null;
+  // A snippet of the sources that answered a search, when they are what did.
+  // Present only on search results, and only for the rows the sources answered.
+  sourceMatch?: string;
 };
 
-type PublicationKey = keyof Omit<Publication, "id" | "references">;
+type PublicationKey = keyof Omit<
+  Publication,
+  "id" | "references" | "sourceMatch"
+>;
+
 type PublicationError = null | string | Record<PublicationKey, string>;
 type ValidationResult = { publication: Publication; errors: PublicationError };
 type PublicationEntry = ValidationResult & { id: number };

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -126,8 +126,8 @@ const publicationReferencesFamily = atomFamily((id: PublicationId) =>
   atom<string[]>((get) => get(visiblePublicationFamily(id)).references ?? []),
 );
 
-/** The snippet of a publication's sources that answered the current search,
- * present only when the sources are what answered it. */
+/** A highlighted snippet of a publication's references, present only when the
+ * current search matched on them rather than on the record's own fields. */
 const publicationSourceMatchFamily = atomFamily((id: PublicationId) =>
   atom<string | undefined>((get) => get(publicationFamily(id))?.sourceMatch),
 );

--- a/frontend/modules/publication/store.ts
+++ b/frontend/modules/publication/store.ts
@@ -126,6 +126,12 @@ const publicationReferencesFamily = atomFamily((id: PublicationId) =>
   atom<string[]>((get) => get(visiblePublicationFamily(id)).references ?? []),
 );
 
+/** The snippet of a publication's sources that answered the current search,
+ * present only when the sources are what answered it. */
+const publicationSourceMatchFamily = atomFamily((id: PublicationId) =>
+  atom<string | undefined>((get) => get(publicationFamily(id))?.sourceMatch),
+);
+
 /** A publication's *persisted* provenance list — ignores in-progress drafts,
  * the same stored-vs-visible distinction as `storedFieldValueFamily`. */
 const storedReferencesFamily = atomFamily((id: PublicationId) =>
@@ -537,6 +543,7 @@ export {
   publicationIdsAtom,
   publicationOrNullFamily,
   publicationReferencesFamily,
+  publicationSourceMatchFamily,
   receiveIndex,
   remember,
   removePublication,


### PR DESCRIPTION
Following an author, publisher or country link from an open publication landed back on the index with nothing searched, and asking for a whole title found nothing at all. Two separate faults behind one symptom.

## The link

The overlay closed itself when a link was followed, and closing is going back, so the search the link had just pushed was popped again straight away. On a publication's own page it was the same shape: a push to the index cancelled the search.

Leaving is what closes the overlay now. Because a parallel slot keeps what it was showing when the route around it changes, the overlay reads the address instead of history: a publication is open while one is being addressed.

## The search

A term was compared whole against the indexed words, and one word is all either match can do. A prefix is one word, and trigram similarity to a phrase falls away as the phrase grows, so `Ubirajara: A Legend of the Tupy Indians` resolved to no keywords and returned nothing. That is exactly what a publication's own title link asks for.

A term is read a word at a time now, and every word narrows: a publication has to answer all of them, and any of the keywords a word names counts as an answer, which is what still lets a half-typed word stand for what it starts. Words are read as written first; only when that finds nothing does the term go fuzzy, where a word naming nothing is dropped rather than emptying the search.

`Ubirajara: A Legend of the Tupy Indians` now returns that publication and nothing else. `Dom Casmurro` returns its five editions, `veri` still prefix-matches Verissimo, and `vera` still falls through to fuzzy.
