### PR TITLE
Index countries by name, not by code at query time

### DIFF
--- a/backend/lib/richard_burton/country.ex
+++ b/backend/lib/richard_burton/country.ex
@@ -10,9 +10,21 @@ defmodule RichardBurton.Country do
   alias RichardBurton.Publication
   alias RichardBurton.Fingerprint
 
+  # Names people search a country by, beyond the ones the ISO data carries:
+  # abbreviations readers type that are not in the official or unofficial names.
+  @extra_names %{
+    "US" => ["USA", "EUA"],
+    "GB" => ["UK"]
+  }
+
   @derive {Jason.Encoder, only: [:code]}
   schema "countries" do
     field(:code, :string)
+
+    # The names this country is searchable by, folded into the search index. Not
+    # user input: derived from the code, so the reader can search "Reino Unido"
+    # or "USA" and reach the record that stores "GB" or "US".
+    field(:names, {:array, :string}, default: [])
 
     many_to_many(:publications, Publication, join_through: "publication_countries")
 
@@ -37,31 +49,37 @@ defmodule RichardBurton.Country do
   end
 
   @doc """
-  The country codes whose name is exactly this term, so a reader can search by
-  the name they see rather than the code the record stores.
-
-  The match is on the whole name, not a prefix or a word of it. A code is two
-  letters, and a two-letter word is common in the languages here: "UM" is the
-  code for the United States Minor Outlying Islands and also the Portuguese
-  "um" in countless titles. Requiring the exact, full name keeps a stray "um"
-  from pulling in that country.
+  Every name a country is searchable by: its official name, the unofficial and
+  translated names the ISO data carries (which is where "Reino Unido" and
+  "Estados Unidos" come from), and a curated supplement of abbreviations the
+  data lacks. Deduplicated, in no particular order — the search index folds them
+  in, it does not display them.
   """
-  def codes_named(term) when is_binary(term) do
-    named = term |> String.trim() |> String.downcase()
+  def names_for(code) do
+    iso =
+      if Countries.exists?(:alpha2, code) do
+        country = Countries.get(code)
+        [country.name | Map.get(country, :unofficial_names) || []]
+      else
+        []
+      end
 
-    Countries.all()
-    |> Enum.filter(&(named in names_of(&1)))
-    |> Enum.map(& &1.alpha2)
-  end
-
-  # A country's official name plus the names people actually write for it:
-  # "United Kingdom" for the country officially named after Great Britain and
-  # Northern Ireland, "Brasil" for the one this database is mostly about.
-  defp names_of(country) do
-    [country.name | Map.get(country, :unofficial_names) || []]
+    (iso ++ Map.get(@extra_names, code, []))
     |> Enum.filter(&is_binary/1)
-    |> Enum.map(&String.downcase/1)
+    |> Enum.uniq()
   end
+
+  # Derived index data, not editor input, so it is set where a country is
+  # persisted rather than in the changeset — a changeset also shapes the codec's
+  # nested form, which has no business carrying it.
+  defp put_names(changeset = %Ecto.Changeset{valid?: true}) do
+    case get_field(changeset, :code) do
+      nil -> changeset
+      code -> put_change(changeset, :names, names_for(code))
+    end
+  end
+
+  defp put_names(changeset), do: changeset
 
   def validate_code(changeset) do
     validate_change(changeset, :code, fn :code, code ->
@@ -116,6 +134,7 @@ defmodule RichardBurton.Country do
   def maybe_insert!(attrs) do
     %__MODULE__{}
     |> changeset(attrs)
+    |> put_names()
     |> Repo.maybe_insert!([:code])
   end
 

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -13,7 +13,6 @@ defmodule RichardBurton.Publication.Index do
 
   import Ecto.Query
 
-  alias RichardBurton.Country
   alias RichardBurton.FlatPublication
   alias RichardBurton.Publication.Index.SearchDocument
   alias RichardBurton.Publication.Index.SearchKeyword
@@ -270,26 +269,12 @@ defmodule RichardBurton.Publication.Index do
   defp spelled_out?(term), do: String.contains?(term, ~s(")) or term =~ ~r/(^|\s)-\S/
 
   # `:*` makes each word a prefix, so a word still being typed matches every
-  # word that starts with it, and a complete word matches itself.
+  # word that starts with it, and a complete word matches itself. A country name
+  # is matched the same way as any other word: its names are folded into the
+  # document at index time, so "United Kingdom" reaches the record that stores
+  # the code "GB" with no special handling here.
   defp written_query(words) do
-    words
-    |> Enum.map_join(" & ", &"(#{lexeme(&1)}:*)")
-    |> or_the_country_named(Enum.join(words, " "))
-  end
-
-  # A record stores a country as its code (US, GB), not its name, so a term
-  # that names a country also searches for that code. The whole term is matched
-  # against country names, not word by word: "United Kingdom" split into words
-  # would search for "kingdom", which no record holds.
-  #
-  # The code is added only where a country was actually named. A two-letter
-  # code is itself a word in these languages, so searching for "NO"
-  # unconditionally would match every Portuguese title containing "no".
-  defp or_the_country_named(query, term) do
-    case Country.codes_named(term) do
-      [] -> query
-      codes -> "(#{query}) | (#{Enum.map_join(codes, " | ", &"#{lexeme(&1)}:C")})"
-    end
+    Enum.map_join(words, " & ", &"(#{lexeme(&1)}:*)")
   end
 
   # Nothing matched as typed, so each word is matched against the indexed words

--- a/backend/priv/repo/migrations/20260802120000_index_country_names.exs
+++ b/backend/priv/repo/migrations/20260802120000_index_country_names.exs
@@ -1,0 +1,93 @@
+defmodule RichardBurton.Repo.Migrations.IndexCountryNames do
+  use Ecto.Migration
+
+  @moduledoc """
+  Index countries by name instead of translating names to codes at query time.
+
+  A record stores a country as its code, so searching by the name a reader sees
+  (or an alternate, like "Reino Unido" or "USA") used to mean translating the
+  name to a code in the query. That path could not serve a quoted search, and a
+  two-letter code injected as a lexeme collided with common two-letter words.
+
+  Each country now carries its names, and the search document folds those names
+  in — at the country weight — in place of the code. Country search becomes an
+  ordinary word match, on every search path, with no code in the index to
+  collide with anything.
+  """
+
+  alias RichardBurton.Country
+  alias RichardBurton.Repo
+
+  import Ecto.Query
+
+  def up do
+    alter table(:countries) do
+      add(:names, {:array, :string}, null: false, default: [])
+    end
+
+    flush()
+
+    for {id, code} <- Repo.all(from(c in "countries", select: {c.id, c.code})) do
+      Repo.update_all(
+        from(c in "countries", where: c.id == ^id),
+        set: [names: Country.names_for(code)]
+      )
+    end
+
+    rebuild_search_documents(country_field: "coalesce(cn.names, '')", extra_join: lateral())
+  end
+
+  def down do
+    rebuild_search_documents(country_field: "countries", extra_join: "")
+
+    alter table(:countries) do
+      remove(:names)
+    end
+  end
+
+  # A record's countries, resolved to the words a reader would search them by.
+  defp lateral do
+    """
+    LEFT JOIN LATERAL (
+      SELECT string_agg(array_to_string(c.names, ' '), ' ') AS names
+      FROM countries c
+      WHERE c.code = ANY (string_to_array(fp.countries, ', '))
+    ) cn ON true
+    """
+  end
+
+  # search_keywords reads search_documents, so it goes first and comes back last.
+  defp rebuild_search_documents(country_field: country_field, extra_join: extra_join) do
+    execute("DROP MATERIALIZED VIEW search_keywords")
+    execute("DROP MATERIALIZED VIEW search_documents")
+
+    execute("""
+    CREATE MATERIALIZED VIEW search_documents AS
+    SELECT
+      fp.id,
+      setweight(to_tsvector('rb_search'::regconfig, fp.title::text), 'A')                 ||
+      setweight(to_tsvector('rb_search'::regconfig, fp.original_title::text), 'A')        ||
+      setweight(to_tsvector('rb_search'::regconfig, fp.authors), 'B')                     ||
+      setweight(to_tsvector('rb_search'::regconfig, fp.original_authors), 'B')            ||
+      setweight(to_tsvector('rb_search'::regconfig, fp.publishers), 'C')                  ||
+      setweight(to_tsvector('rb_search'::regconfig, #{country_field}), 'C')               ||
+      setweight(to_tsvector('rb_search'::regconfig, fp.year::text), 'C')                  ||
+      setweight(to_tsvector('rb_search'::regconfig,
+        array_to_string(fp."references", ' ')), 'D')                                      AS document
+    FROM
+      flat_publications fp
+      #{extra_join}
+    """)
+
+    execute("CREATE INDEX search_index ON search_documents USING gin(document)")
+    execute("CREATE UNIQUE INDEX search_documents_id_index ON search_documents (id)")
+
+    execute("""
+    CREATE MATERIALIZED VIEW search_keywords AS
+    SELECT word FROM ts_stat('SELECT document FROM search_documents')
+    """)
+
+    execute("CREATE INDEX search_trigram_index ON search_keywords USING gin(word gin_trgm_ops)")
+    execute("CREATE UNIQUE INDEX search_keywords_word_index ON search_keywords (word)")
+  end
+end

--- a/backend/test/richard_burton/country_test.exs
+++ b/backend/test/richard_burton/country_test.exs
@@ -101,6 +101,25 @@ defmodule RichardBurton.CountryTest do
     end
   end
 
+  describe "names_for/1" do
+    test "carries the official name and the ISO translations" do
+      names = Country.names_for("US")
+
+      assert "United States of America" in names
+      assert "Estados Unidos" in names
+    end
+
+    test "carries the curated abbreviations the ISO data lacks" do
+      assert "USA" in Country.names_for("US")
+      assert "EUA" in Country.names_for("US")
+      assert "UK" in Country.names_for("GB")
+    end
+
+    test "an unknown code has no names" do
+      assert [] == Country.names_for("XX")
+    end
+  end
+
   describe "validate_countries/1" do
     test "when countries is valid alpha2 code, is valid" do
       %Ecto.Changeset{errors: errors, valid?: valid} =
@@ -208,6 +227,14 @@ defmodule RichardBurton.CountryTest do
 
       assert preexistent_country == country
       assert [country] == Country.all()
+    end
+
+    test "stores the names the country is searchable by" do
+      country = Country.maybe_insert!(@valid_attrs)
+
+      assert "United Kingdom" in country.names
+      assert "Reino Unido" in country.names
+      assert "UK" in country.names
     end
   end
 

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -411,21 +411,6 @@ defmodule RichardBurton.Publication.IndexTest do
       )
     end
 
-    test "retrieves publications by country" do
-      term = "GB"
-      keyword = String.downcase(term)
-      expected_countries = ["GB"]
-
-      assert {:ok, publications, [^keyword]} = Publication.Index.search(term)
-
-      assert_search_results(
-        publications,
-        expect: [
-          countries: expected_countries
-        ]
-      )
-    end
-
     test "retrieves publications by author" do
       term = "Brakel"
       keyword = String.downcase(term)
@@ -630,35 +615,56 @@ defmodule RichardBurton.Publication.IndexTest do
   end
 
   describe "search/1 by country" do
-    test "a country's name finds what the record holds as a code" do
+    test "a country's name finds the records that store its code" do
       assert {:ok, publications, _} = Publication.Index.search("Brazil")
 
-      # The word itself still matches wherever it is written, so this asks only
-      # that the code was reached too.
       assert Enum.any?(publications, &String.contains?(&1.countries, "BR"))
     end
 
-    test "a name made of several words asks for the code as a whole" do
+    test "a multi-word name finds the country" do
       assert {:ok, publications, _} = Publication.Index.search("United Kingdom")
 
       refute Enum.empty?(publications)
-      assert Enum.all?(publications, &String.contains?(&1.countries, "GB"))
+      assert Enum.any?(publications, &String.contains?(&1.countries, "GB"))
     end
 
-    # "UM" is the United States Minor Outlying Islands, and also the first word
-    # of half the Portuguese titles here.
-    test "a word that merely starts a country's name asks for no code" do
-      assert {:ok, publications, _} = Publication.Index.search("United")
+    test "an alternate or translated name finds the country too" do
+      assert {:ok, uk, _} = Publication.Index.search("Reino Unido")
+      assert Enum.any?(uk, &String.contains?(&1.countries, "GB"))
 
-      refute Enum.any?(publications, &String.contains?(&1.original_title, "Um "))
+      assert {:ok, us, _} = Publication.Index.search("USA")
+      assert Enum.any?(us, &String.contains?(&1.countries, "US"))
     end
 
-    test "the code still works" do
-      assert {:ok, publications, _} = Publication.Index.search("BR")
+    test "a quoted name finds the country, which the literal path could not do before" do
+      assert {:ok, publications, _} = Publication.Index.search(~s("United Kingdom"))
 
-      # Two letters are also the start of other words, which a term still being
-      # typed should reach, so this asks only that the code was among them.
-      assert Enum.any?(publications, &String.contains?(&1.countries, "BR"))
+      assert Enum.any?(publications, &String.contains?(&1.countries, "GB"))
+    end
+
+    # A country code doubles as a common word (pt "um" is UM, "no" is NO).
+    # Indexing names rather than codes keeps such a word in a record's title
+    # from dragging in an unrelated country.
+    test "a country whose code spells a common word is not pulled by that word" do
+      {:ok, bait} =
+        %{
+          "title" => "A Certain Captain",
+          "original_title" => "Um Homem no Mundo",
+          "original_authors" => "Autor Teste",
+          "authors" => "Test Translator",
+          "year" => "1970",
+          "countries" => "BR",
+          "publishers" => "Editora Teste"
+        }
+        |> Publication.Codec.nest()
+        |> Publication.insert()
+
+      Publication.Index.Refresher.refresh()
+
+      for term <- ["Norway", "United"] do
+        assert {:ok, results, _} = Publication.Index.search(term)
+        refute Enum.any?(results, &(&1.id == bait.id))
+      end
     end
   end
 


### PR DESCRIPTION
A record stores a country as its code (`GB`, `US`), so searching by the name a reader sees used to mean translating the name to a code inside each query. That approach had two flaws: it could not serve a quoted or negated search (those bypass the translation), and injecting a two-letter code as a search lexeme collided with common two-letter words — `UM` (US Minor Outlying Islands) is also the Portuguese "um", `NO` (Norway) is "no".

Each country now carries its **names** — the official name, the translated and unofficial names the ISO data holds (which is where "Reino Unido" and "Estados Unidos" come from), and a small curated supplement of abbreviations the data lacks ("USA", "EUA", "UK"). The search document folds those names in, at the country weight, in place of the code. Country search is now an ordinary word match on every search path:

- quoted `"United Kingdom"` finds the country (previously returned nothing);
- alternate and Portuguese names — "Reino Unido", "Estados Unidos", "USA" — find it;
- no code is in the index, so no two-letter word can drag in an unrelated country.

This removes the query-time country machinery entirely (`Country.codes_named/1`, `names_of/1`, and the query's `or_the_country_named/2`). Searching by the raw two-letter code is dropped — a reader searches names, not ISO codes.

Builds on #425 (the search work it simplifies); base it there, retarget to main once #425 lands.
