### PR TITLE
Merge duplicate publications into one

### DIFF
--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -225,6 +225,120 @@ defmodule RichardBurton.Publication do
     |> then(&update(id, &1, actor))
   end
 
+  @doc """
+  Collapse publications into one.
+
+  The winner keeps its identity and everything that names it — title, year, the
+  work it translates, who wrote and translated it. What the losers add is what
+  a record can hold more of: their countries and publishers join the winner's,
+  and their sources are appended to its own. A source already recorded is not
+  recorded twice; elsewhere a publication may list the same line twice, but a
+  merge saying it twice is the merge showing, not the record meaning it.
+
+  The losers are then soft-deleted and recorded as merged, which is not the
+  same as deleted and is not undoable: putting one back would leave what it
+  brought with the winner as well, and there would be two of everything again.
+
+  Answers `{:error, :conflict}` when the merged record would collide with a
+  third publication, `{:error, :not_found}` when any of them is not here, and
+  `{:error, :self}` when a publication is asked to merge into itself.
+  """
+  def merge(winner_id, loser_ids = [_ | _], actor \\ History.system_actor()) do
+    with {:ok, winner, losers} <- assemble(winner_id, loser_ids),
+         {:ok, merged} <- merge_and_record(winner, losers, actor) do
+      # One signal per operation, after commit (the new-write-path rule).
+      Index.Refresher.refresh()
+      {:ok, merged}
+    end
+  end
+
+  defp assemble(winner_id, loser_ids) do
+    loser_ids = loser_ids |> Enum.map(&to_string/1) |> Enum.uniq()
+
+    if to_string(winner_id) in loser_ids,
+      do: {:error, :self},
+      else: gathered([winner_id | loser_ids])
+  end
+
+  defp gathered(ids) do
+    publications = Enum.map(ids, &get(&1, deleted: false))
+
+    if Enum.any?(publications, &is_nil/1) do
+      {:error, :not_found}
+    else
+      [winner | losers] = Enum.map(publications, &preload/1)
+      {:ok, winner, losers}
+    end
+  end
+
+  defp merge_and_record(winner, losers, actor) do
+    attrs = reconciled(winner, losers)
+
+    Repo.transaction(fn ->
+      winner
+      |> changeset(attrs)
+      |> link_assocs()
+      |> Repo.update()
+      |> case do
+        {:ok, updated} -> absorbing(updated, losers, actor)
+        {:error, changeset} -> Repo.rollback(rejection(changeset))
+      end
+    end)
+  end
+
+  defp absorbing(winner, losers, actor) do
+    winner = preload(winner)
+    History.record(:updated, winner, actor)
+    Enum.each(losers, &absorb(&1, actor))
+    winner
+  end
+
+  # The merged record would be one that already exists: the composite key is
+  # reported against the title.
+  defp rejection(changeset = %{errors: errors}) do
+    if Keyword.has_key?(errors, :title),
+      do: :conflict,
+      else: Validation.get_errors(changeset)
+  end
+
+  # A loser leaves the database the way a deleted publication does — the row,
+  # its sources and its history all survive — but the log says why.
+  defp absorb(loser, actor) do
+    loser
+    |> change(deleted_at: DateTime.utc_now(:second))
+    |> Repo.update()
+    |> case do
+      {:ok, _} -> History.record(:merged, loser, actor)
+      {:error, changeset} -> Repo.rollback(Validation.get_errors(changeset))
+    end
+  end
+
+  # What the merged record holds: the winner's own fields, the countries and
+  # publishers of all of them, and every source none of the others already said.
+  defp reconciled(winner, losers) do
+    flat = Enum.map([winner | losers], &Codec.flatten/1)
+    [kept | _] = flat
+
+    kept
+    |> Map.from_struct()
+    |> Map.drop([:__meta__, :id])
+    |> Map.merge(%{
+      countries: joined(flat, :countries),
+      publishers: joined(flat, :publishers),
+      references: flat |> Enum.flat_map(& &1.references) |> Enum.uniq()
+    })
+    |> Codec.nest()
+  end
+
+  defp joined(flat, field) do
+    flat
+    |> Enum.flat_map(&String.split(Map.get(&1, field) || "", ",", trim: true))
+    |> Enum.map(&String.trim/1)
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.join(", ")
+  end
+
   @doc "Bring a soft-deleted publication back into the database."
   def restore(id, actor \\ History.system_actor()) do
     case get(id, deleted: true) do

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -225,6 +225,74 @@ defmodule RichardBurton.Publication do
     |> then(&update(id, &1, actor))
   end
 
+  # Taking a merge apart: the record that survived gives back what it absorbed
+  # and the records that left come back, in one transaction and under one entry
+  # — the same shape as the merge, which is what makes an un-merge undoable in
+  # its turn.
+  defp compensate(entry = %{action: "merged", publication_id: id}, previous, head, actor) do
+    unmerge(entry, previous, head, id, actor)
+  end
+
+  # And undoing an un-merge is the merge again, by the same route.
+  defp compensate(%{action: "unmerged", publication_id: id} = entry, _previous, _head, actor) do
+    merge(id, History.absorbed_ids(entry), actor)
+  end
+
+  defp unmerge(entry, previous, head, winner_id, actor) do
+    restored_ids = History.absorbed_ids(entry)
+
+    Repo.transaction(fn ->
+      with {:ok, restored} <- restore_absorbed(restored_ids),
+           {:ok, winner} <- revert_winner(winner_id, entry, previous, head) do
+        History.record(:unmerged, preload(winner), actor, restored)
+        preload(winner)
+      else
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+    |> tap(fn
+      {:ok, _} -> Index.Refresher.refresh()
+      _ -> :ok
+    end)
+  end
+
+  # The rows never left, so putting them back is lifting the tombstone. A key
+  # taken by something else in the meantime is the same conflict a restore hits.
+  defp restore_absorbed(ids) do
+    Enum.reduce_while(ids, {:ok, []}, fn id, {:ok, restored} ->
+      case get(id, deleted: true) do
+        nil ->
+          {:halt, {:error, :not_found}}
+
+        publication ->
+          publication
+          |> change(deleted_at: nil)
+          |> Repo.update()
+          |> case do
+            {:ok, back} -> {:cont, {:ok, [preload(back) | restored]}}
+            {:error, _} -> {:halt, {:error, :conflict}}
+          end
+      end
+    end)
+  end
+
+  # The winner returns to what it held before it absorbed anything — the same
+  # revert an undone update performs, over the fields the merge changed.
+  defp revert_winner(_id, _entry, nil, _head), do: {:error, :conflict}
+
+  defp revert_winner(id, entry, previous, head) do
+    entry
+    |> History.reverted_snapshot(previous, head)
+    |> Codec.nest()
+    |> then(&(id |> get(deleted: false) |> preload() |> changeset(&1)))
+    |> link_assocs()
+    |> Repo.update()
+    |> case do
+      {:ok, winner} -> {:ok, winner}
+      {:error, changeset} -> {:error, rejection(changeset)}
+    end
+  end
+
   @doc """
   Collapse publications into one.
 
@@ -286,10 +354,14 @@ defmodule RichardBurton.Publication do
     end)
   end
 
+  # One act, one entry: the record that survives holds it, and names the ones
+  # that did not. The losers get no entry of their own — nothing happened *to*
+  # them that the merge does not already say, and an entry each would be a
+  # merge that has to be undone in pieces.
   defp absorbing(winner, losers, actor) do
     winner = preload(winner)
-    History.record(:updated, winner, actor)
-    Enum.each(losers, &absorb(&1, actor))
+    Enum.each(losers, &absorb/1)
+    History.record(:merged, winner, actor, Enum.map(losers, &preload/1))
     winner
   end
 
@@ -302,13 +374,14 @@ defmodule RichardBurton.Publication do
   end
 
   # A loser leaves the database the way a deleted publication does — the row,
-  # its sources and its history all survive — but the log says why.
-  defp absorb(loser, actor) do
+  # its sources and its history all survive. Why it left is on the merge entry,
+  # which is also what brings it back.
+  defp absorb(loser) do
     loser
     |> change(deleted_at: DateTime.utc_now(:second))
     |> Repo.update()
     |> case do
-      {:ok, _} -> History.record(:merged, loser, actor)
+      {:ok, _} -> :ok
       {:error, changeset} -> Repo.rollback(Validation.get_errors(changeset))
     end
   end
@@ -407,16 +480,29 @@ defmodule RichardBurton.Publication do
   end
 
   # Of the given publications, those whose last recorded act was a merge.
+  # A record inside another one is not in the trash: nobody deleted it, and it
+  # comes back by taking the merge apart, not by being restored on its own. The
+  # merge entries name what they hold, newest last, so a later un-merge undoes
+  # an earlier merge's claim on a record.
   defp merged_away(ids) do
+    wanted = MapSet.new(ids)
+
     Ecto.Query.from(h in History,
-      where: h.publication_id in ^ids,
-      distinct: h.publication_id,
-      order_by: [asc: h.publication_id, desc: h.version],
-      select: {h.publication_id, h.action}
+      where: h.action in ["merged", "unmerged"],
+      order_by: [asc: h.id],
+      select: {h.action, h.absorbed}
     )
     |> Repo.all()
-    |> Enum.filter(fn {_id, action} -> action == "merged" end)
-    |> MapSet.new(fn {id, _action} -> id end)
+    |> Enum.reduce(MapSet.new(), fn {action, absorbed}, held ->
+      absorbed
+      |> Kernel.||(%{})
+      |> Map.keys()
+      |> Enum.map(&String.to_integer/1)
+      |> Enum.filter(&MapSet.member?(wanted, &1))
+      |> Enum.reduce(held, fn id, held ->
+        if action == "merged", do: MapSet.put(held, id), else: MapSet.delete(held, id)
+      end)
+    end)
   end
 
   @doc """

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -384,14 +384,39 @@ defmodule RichardBurton.Publication do
     end
   end
 
-  @doc "The soft-deleted publications, most recently deleted first."
+  @doc """
+  The publications someone deleted, most recently deleted first.
+
+  A record absorbed by a merge is out of the database the same way, but nobody
+  deleted it and there is no putting it back: restoring one would recreate the
+  duplicate the merge collapsed, with the survivor still holding what it took.
+  """
   def all_deleted do
-    Ecto.Query.from(p in Publication,
-      where: not is_nil(p.deleted_at),
-      order_by: [desc: p.deleted_at]
+    deleted =
+      Ecto.Query.from(p in Publication,
+        where: not is_nil(p.deleted_at),
+        order_by: [desc: p.deleted_at]
+      )
+      |> Repo.all()
+
+    absorbed = merged_away(Enum.map(deleted, & &1.id))
+
+    deleted
+    |> Enum.reject(&MapSet.member?(absorbed, &1.id))
+    |> preload()
+  end
+
+  # Of the given publications, those whose last recorded act was a merge.
+  defp merged_away(ids) do
+    Ecto.Query.from(h in History,
+      where: h.publication_id in ^ids,
+      distinct: h.publication_id,
+      order_by: [asc: h.publication_id, desc: h.version],
+      select: {h.publication_id, h.action}
     )
     |> Repo.all()
-    |> preload()
+    |> Enum.filter(fn {_id, action} -> action == "merged" end)
+    |> MapSet.new(fn {id, _action} -> id end)
   end
 
   @doc """

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -229,8 +229,8 @@ defmodule RichardBurton.Publication do
   # and the records that left come back, in one transaction and under one entry
   # — the same shape as the merge, which is what makes an un-merge undoable in
   # its turn.
-  defp compensate(entry = %{action: "merged", publication_id: id}, previous, head, actor) do
-    unmerge(entry, previous, head, id, actor)
+  defp compensate(entry = %{action: "merged"}, previous, head, actor) do
+    unmerge(entry, previous, head, actor)
   end
 
   # And undoing an un-merge is the merge again, by the same route.
@@ -238,14 +238,13 @@ defmodule RichardBurton.Publication do
     merge(id, History.absorbed_ids(entry), actor)
   end
 
-  defp unmerge(entry, previous, head, winner_id, actor) do
-    restored_ids = History.absorbed_ids(entry)
-
+  defp unmerge(entry, previous, head, actor) do
     Repo.transaction(fn ->
-      with {:ok, restored} <- restore_absorbed(restored_ids),
-           {:ok, winner} <- revert_winner(winner_id, entry, previous, head) do
-        History.record(:unmerged, preload(winner), actor, restored)
-        preload(winner)
+      with {:ok, restored} <- restore_absorbed(History.absorbed_ids(entry)),
+           {:ok, winner} <- revert_winner(entry, previous, head) do
+        winner = preload(winner)
+        History.record(:unmerged, winner, actor, restored)
+        winner
       else
         {:error, reason} -> Repo.rollback(reason)
       end
@@ -259,36 +258,34 @@ defmodule RichardBurton.Publication do
   # The rows never left, so putting them back is lifting the tombstone. A key
   # taken by something else in the meantime is the same conflict a restore hits.
   defp restore_absorbed(ids) do
-    Enum.reduce_while(ids, {:ok, []}, fn id, {:ok, restored} ->
-      case lift_tombstone(id) do
-        {:ok, back} -> {:cont, {:ok, [back | restored]}}
-        {:error, reason} -> {:halt, {:error, reason}}
+    tombstoned =
+      Ecto.Query.from(p in Publication, where: p.id in ^ids and not is_nil(p.deleted_at))
+      |> Repo.all()
+
+    if length(tombstoned) == length(ids),
+      do: lift_tombstones(tombstoned),
+      else: {:error, :not_found}
+  end
+
+  defp lift_tombstones(publications) do
+    publications
+    |> Enum.reduce_while({:ok, []}, fn publication, {:ok, lifted} ->
+      case publication |> tombstone(nil) |> Repo.update() do
+        {:ok, back} -> {:cont, {:ok, [back | lifted]}}
+        {:error, _} -> {:halt, {:error, :conflict}}
       end
     end)
-  end
-
-  defp lift_tombstone(id) do
-    case get(id, deleted: true) do
-      nil -> {:error, :not_found}
-      publication -> undelete(publication)
-    end
-  end
-
-  defp undelete(publication) do
-    publication
-    |> change(deleted_at: nil)
-    |> Repo.update()
     |> case do
-      {:ok, back} -> {:ok, preload(back)}
-      {:error, _} -> {:error, :conflict}
+      {:ok, lifted} -> {:ok, preload(lifted)}
+      error -> error
     end
   end
 
   # The winner returns to what it held before it absorbed anything — the same
   # revert an undone update performs, over the fields the merge changed.
-  defp revert_winner(_id, _entry, nil, _head), do: {:error, :conflict}
+  defp revert_winner(_entry, nil, _head), do: {:error, :conflict}
 
-  defp revert_winner(id, entry, previous, head) do
+  defp revert_winner(entry = %{publication_id: id}, previous, head) do
     entry
     |> History.reverted_snapshot(previous, head)
     |> Codec.nest()
@@ -311,15 +308,20 @@ defmodule RichardBurton.Publication do
   recorded twice; elsewhere a publication may list the same line twice, but a
   merge saying it twice is the merge showing, not the record meaning it.
 
-  The losers are then soft-deleted and recorded as merged, which is not the
-  same as deleted and is not undoable: putting one back would leave what it
-  brought with the winner as well, and there would be two of everything again.
+  The losers are then soft-deleted, and the whole act is recorded as one entry
+  on the winner naming what it took in — which is what lets it be undone as one
+  act too, by `undo/3`.
 
   Answers `{:error, :conflict}` when the merged record would collide with a
-  third publication, `{:error, :not_found}` when any of them is not here, and
-  `{:error, :self}` when a publication is asked to merge into itself.
+  third publication, `{:error, :not_found}` when any of them is not here,
+  `{:error, :self}` when a publication is asked to merge into itself, and
+  `{:error, :no_losers}` when nothing was named to merge in.
   """
-  def merge(winner_id, loser_ids = [_ | _], actor \\ History.system_actor()) do
+  def merge(winner_id, loser_ids, actor \\ History.system_actor())
+
+  def merge(_winner_id, [], _actor), do: {:error, :no_losers}
+
+  def merge(winner_id, loser_ids, actor) do
     with {:ok, winner, losers} <- assemble(winner_id, loser_ids),
          {:ok, merged} <- merge_and_record(winner, losers, actor) do
       # One signal per operation, after commit (the new-write-path rule).
@@ -336,13 +338,21 @@ defmodule RichardBurton.Publication do
       else: gathered([winner_id | loser_ids])
   end
 
+  # Read in one go and put back in the order asked, since the first id names
+  # the winner.
   defp gathered(ids) do
-    publications = Enum.map(ids, &get(&1, deleted: false))
+    by_id =
+      Ecto.Query.from(p in Publication, where: p.id in ^ids and is_nil(p.deleted_at))
+      |> Repo.all()
+      |> preload()
+      |> Map.new(&{to_string(&1.id), &1})
+
+    publications = Enum.map(ids, &Map.get(by_id, to_string(&1)))
 
     if Enum.any?(publications, &is_nil/1) do
       {:error, :not_found}
     else
-      [winner | losers] = Enum.map(publications, &preload/1)
+      [winner | losers] = publications
       {:ok, winner, losers}
     end
   end
@@ -369,7 +379,7 @@ defmodule RichardBurton.Publication do
   defp absorbing(winner, losers, actor) do
     winner = preload(winner)
     Enum.each(losers, &absorb/1)
-    History.record(:merged, winner, actor, Enum.map(losers, &preload/1))
+    History.record(:merged, winner, actor, losers)
     winner
   end
 
@@ -386,7 +396,7 @@ defmodule RichardBurton.Publication do
   # which is also what brings it back.
   defp absorb(loser) do
     loser
-    |> change(deleted_at: DateTime.utc_now(:second))
+    |> tombstone(DateTime.utc_now(:second))
     |> Repo.update()
     |> case do
       {:ok, _} -> :ok
@@ -394,15 +404,32 @@ defmodule RichardBurton.Publication do
     end
   end
 
+  # Stamping or clearing `deleted_at` moves the record in or out of the partial
+  # composite-key index — if the same record was written meanwhile, coming back
+  # is a conflict, not a crash.
+  defp tombstone(publication, deleted_at) do
+    publication
+    |> change(deleted_at: deleted_at)
+    |> unique_constraint(
+      [
+        :title,
+        :year,
+        :publishers_fingerprint,
+        :countries_fingerprint,
+        :translated_book_fingerprint
+      ],
+      name: "publications_composite_key"
+    )
+  end
+
   # What the merged record holds: the winner's own fields, the countries and
   # publishers of all of them, and every source none of the others already said.
   defp reconciled(winner, losers) do
-    flat = Enum.map([winner | losers], &Codec.flatten/1)
+    flat = Enum.map([winner | losers], &History.snapshot/1)
     [kept | _] = flat
 
     kept
-    |> Map.from_struct()
-    |> Map.drop([:__meta__, :id])
+    |> Map.delete(:id)
     |> Map.merge(%{
       countries: joined(flat, :countries),
       publishers: joined(flat, :publishers),
@@ -420,11 +447,28 @@ defmodule RichardBurton.Publication do
     |> Enum.join(", ")
   end
 
-  @doc "Bring a soft-deleted publication back into the database."
+  @doc """
+  Bring a soft-deleted publication back into the database.
+
+  Only one that someone deleted. A record absorbed by a merge is out of the
+  database the same way, but it is not in the trash and does not come back on
+  its own: `{:error, :absorbed}` says to take the merge apart instead.
+  """
   def restore(id, actor \\ History.system_actor()) do
-    case get(id, deleted: true) do
-      nil -> {:error, :not_found}
-      publication -> stamp_deleted(publication, nil, :restored, actor)
+    with {:ok, publication} <- deleted_on_its_own(id) do
+      stamp_deleted(publication, nil, :restored, actor)
+    end
+  end
+
+  # Putting an absorbed record back would recreate the duplicate the merge
+  # collapsed, with the survivor still holding everything it took from it.
+  defp deleted_on_its_own(id) do
+    publication = get(id, deleted: true)
+
+    cond do
+      is_nil(publication) -> {:error, :not_found}
+      MapSet.member?(History.absorbed(), publication.id) -> {:error, :absorbed}
+      true -> {:ok, publication}
     end
   end
 
@@ -434,19 +478,7 @@ defmodule RichardBurton.Publication do
     result =
       Repo.transaction(fn ->
         publication
-        |> change(deleted_at: deleted_at)
-        # Restoring re-enters the partial composite-key index — if the same
-        # record was re-imported meanwhile, that's a conflict, not a crash.
-        |> unique_constraint(
-          [
-            :title,
-            :year,
-            :publishers_fingerprint,
-            :countries_fingerprint,
-            :translated_book_fingerprint
-          ],
-          name: "publications_composite_key"
-        )
+        |> tombstone(deleted_at)
         |> Repo.update()
         |> case do
           {:ok, _} -> History.record(action, publication, actor)
@@ -480,59 +512,14 @@ defmodule RichardBurton.Publication do
       )
       |> Repo.all()
 
-    absorbed = merged_away(Enum.map(deleted, & &1.id))
+    # A record inside another one is not in the trash: nobody deleted it, and it
+    # comes back by taking the merge apart, not by being restored on its own.
+    absorbed = History.absorbed()
 
     deleted
     |> Enum.reject(&MapSet.member?(absorbed, &1.id))
     |> preload()
   end
-
-  # Of the given publications, those whose last recorded act was a merge.
-  # A record inside another one is not in the trash: nobody deleted it, and it
-  # comes back by taking the merge apart, not by being restored on its own. The
-  # merge entries name what they hold, newest last, so a later un-merge undoes
-  # an earlier merge's claim on a record.
-  defp merged_away(ids) do
-    MapSet.union(absorbed_by_a_merge(ids), marked_merged_itself(ids))
-  end
-
-  # Before a merge was one act, the record that left carried the mark itself.
-  # Those records are still inside another one, and still not in the trash.
-  defp marked_merged_itself(ids) do
-    Ecto.Query.from(h in History,
-      where: h.publication_id in ^ids,
-      distinct: h.publication_id,
-      order_by: [asc: h.publication_id, desc: h.version],
-      select: {h.publication_id, h.action}
-    )
-    |> Repo.all()
-    |> Enum.filter(fn {_id, action} -> action == "merged" end)
-    |> MapSet.new(fn {id, _action} -> id end)
-  end
-
-  defp absorbed_by_a_merge(ids) do
-    wanted = MapSet.new(ids)
-
-    Ecto.Query.from(h in History,
-      where: h.action in ["merged", "unmerged"],
-      order_by: [asc: h.id],
-      select: {h.action, h.absorbed}
-    )
-    |> Repo.all()
-    |> Enum.reduce(MapSet.new(), &hold_or_release(&1, &2, wanted))
-  end
-
-  defp hold_or_release({action, absorbed}, held, wanted) do
-    absorbed
-    |> Kernel.||(%{})
-    |> Map.keys()
-    |> Enum.map(&String.to_integer/1)
-    |> Enum.filter(&MapSet.member?(wanted, &1))
-    |> Enum.reduce(held, &hold(&2, &1, action))
-  end
-
-  defp hold(held, id, "merged"), do: MapSet.put(held, id)
-  defp hold(held, id, "unmerged"), do: MapSet.delete(held, id)
 
   @doc """
   One live publication, with its associations, or `nil`.

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -234,7 +234,7 @@ defmodule RichardBurton.Publication do
   end
 
   # And undoing an un-merge is the merge again, by the same route.
-  defp compensate(%{action: "unmerged", publication_id: id} = entry, _previous, _head, actor) do
+  defp compensate(entry = %{action: "unmerged", publication_id: id}, _previous, _head, actor) do
     merge(id, History.absorbed_ids(entry), actor)
   end
 
@@ -260,20 +260,28 @@ defmodule RichardBurton.Publication do
   # taken by something else in the meantime is the same conflict a restore hits.
   defp restore_absorbed(ids) do
     Enum.reduce_while(ids, {:ok, []}, fn id, {:ok, restored} ->
-      case get(id, deleted: true) do
-        nil ->
-          {:halt, {:error, :not_found}}
-
-        publication ->
-          publication
-          |> change(deleted_at: nil)
-          |> Repo.update()
-          |> case do
-            {:ok, back} -> {:cont, {:ok, [preload(back) | restored]}}
-            {:error, _} -> {:halt, {:error, :conflict}}
-          end
+      case lift_tombstone(id) do
+        {:ok, back} -> {:cont, {:ok, [back | restored]}}
+        {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
+  end
+
+  defp lift_tombstone(id) do
+    case get(id, deleted: true) do
+      nil -> {:error, :not_found}
+      publication -> undelete(publication)
+    end
+  end
+
+  defp undelete(publication) do
+    publication
+    |> change(deleted_at: nil)
+    |> Repo.update()
+    |> case do
+      {:ok, back} -> {:ok, preload(back)}
+      {:error, _} -> {:error, :conflict}
+    end
   end
 
   # The winner returns to what it held before it absorbed anything — the same
@@ -511,17 +519,20 @@ defmodule RichardBurton.Publication do
       select: {h.action, h.absorbed}
     )
     |> Repo.all()
-    |> Enum.reduce(MapSet.new(), fn {action, absorbed}, held ->
-      absorbed
-      |> Kernel.||(%{})
-      |> Map.keys()
-      |> Enum.map(&String.to_integer/1)
-      |> Enum.filter(&MapSet.member?(wanted, &1))
-      |> Enum.reduce(held, fn id, held ->
-        if action == "merged", do: MapSet.put(held, id), else: MapSet.delete(held, id)
-      end)
-    end)
+    |> Enum.reduce(MapSet.new(), &hold_or_release(&1, &2, wanted))
   end
+
+  defp hold_or_release({action, absorbed}, held, wanted) do
+    absorbed
+    |> Kernel.||(%{})
+    |> Map.keys()
+    |> Enum.map(&String.to_integer/1)
+    |> Enum.filter(&MapSet.member?(wanted, &1))
+    |> Enum.reduce(held, &hold(&2, &1, action))
+  end
+
+  defp hold(held, id, "merged"), do: MapSet.put(held, id)
+  defp hold(held, id, "unmerged"), do: MapSet.delete(held, id)
 
   @doc """
   One live publication, with its associations, or `nil`.

--- a/backend/lib/richard_burton/publication.ex
+++ b/backend/lib/richard_burton/publication.ex
@@ -485,6 +485,24 @@ defmodule RichardBurton.Publication do
   # merge entries name what they hold, newest last, so a later un-merge undoes
   # an earlier merge's claim on a record.
   defp merged_away(ids) do
+    MapSet.union(absorbed_by_a_merge(ids), marked_merged_itself(ids))
+  end
+
+  # Before a merge was one act, the record that left carried the mark itself.
+  # Those records are still inside another one, and still not in the trash.
+  defp marked_merged_itself(ids) do
+    Ecto.Query.from(h in History,
+      where: h.publication_id in ^ids,
+      distinct: h.publication_id,
+      order_by: [asc: h.publication_id, desc: h.version],
+      select: {h.publication_id, h.action}
+    )
+    |> Repo.all()
+    |> Enum.filter(fn {_id, action} -> action == "merged" end)
+    |> MapSet.new(fn {id, _action} -> id end)
+  end
+
+  defp absorbed_by_a_merge(ids) do
     wanted = MapSet.new(ids)
 
     Ecto.Query.from(h in History,

--- a/backend/lib/richard_burton/publication_history.ex
+++ b/backend/lib/richard_burton/publication_history.ex
@@ -211,6 +211,10 @@ defmodule RichardBurton.Publication.History do
   """
   def undoable?(entry, previous, head) do
     cond do
+      # An entry from before a merge was one act names nothing to give back, so
+      # there is nothing here to undo — the record it holds is reachable only
+      # through the merge that has it, and that merge was never written down.
+      entry.action in ["merged", "unmerged"] and absorbed_ids(entry) == [] -> false
       entry.action in ["merged", "unmerged"] -> entry.version == head.version
       entry.version == head.version -> true
       entry.action != "updated" -> false
@@ -253,7 +257,15 @@ defmodule RichardBurton.Publication.History do
   # What a reader should *see* is the frontend's business; keeping the wire
   # structural means one payload serves any presentation, in any language.
   defp diff(nil, _entry), do: nil
-  defp diff(previous, entry = %History{action: "updated"}), do: compare(previous, entry)
+
+  # A merge and an un-merge change the surviving record's own fields as surely
+  # as an edit does, so they are diffed the same way — what it gained, against
+  # what it gave back. Together with the records the entry names, that is the
+  # whole of what the act did to the data.
+  defp diff(previous, entry = %History{action: action})
+       when action in ["updated", "merged", "unmerged"],
+       do: compare(previous, entry)
+
   defp diff(_previous, _entry), do: nil
 
   defp compare(%History{snapshot: previous}, %History{snapshot: current}) do

--- a/backend/lib/richard_burton/publication_history.ex
+++ b/backend/lib/richard_burton/publication_history.ex
@@ -21,7 +21,7 @@ defmodule RichardBurton.Publication.History do
   alias RichardBurton.Publication.History
   alias RichardBurton.Repo
 
-  @actions ["created", "updated", "deleted", "restored", "merged"]
+  @actions ["created", "updated", "deleted", "restored", "merged", "unmerged"]
 
   # Mutations outside a request (seeds, mix tasks) are attributed to "system".
   @system_actor "system"
@@ -42,6 +42,12 @@ defmodule RichardBurton.Publication.History do
     field(:snapshot, :map)
     field(:actor, :string)
 
+    # The publications this entry took in, or gave back: each one's id against
+    # the state it was in. A merge and an un-merge change several records at
+    # once, and this is what makes them one entry rather than several — the
+    # record that survives holds the entry, and names the ones that did not.
+    field(:absorbed, :map)
+
     # What this version changed relative to the previous one.
     field(:diff, :map, virtual: true)
     # Whether this version can still be undone
@@ -53,7 +59,7 @@ defmodule RichardBurton.Publication.History do
   @doc false
   def changeset(history, attrs) do
     history
-    |> cast(attrs, [:publication_id, :version, :action, :snapshot, :actor])
+    |> cast(attrs, [:publication_id, :version, :action, :snapshot, :actor, :absorbed])
     |> validate_required([:publication_id, :version, :action, :snapshot, :actor])
     |> validate_inclusion(:action, @actions)
     |> unique_constraint([:publication_id, :version])
@@ -69,18 +75,32 @@ defmodule RichardBurton.Publication.History do
   the max-version read is stable; the unique index on (publication_id, version)
   turns any residual race into a loud error instead of silent corruption.
   """
-  def record(action, publication = %Publication{}, actor)
-      when action in [:created, :updated, :deleted, :restored, :merged] do
+  def record(action, publication = %Publication{}, actor, absorbed \\ [])
+      when action in [:created, :updated, :deleted, :restored, :merged, :unmerged] do
     %History{}
     |> changeset(%{
       publication_id: publication.id,
       version: next_version(publication.id),
       action: to_string(action),
       snapshot: snapshot(publication),
-      actor: actor
+      actor: actor,
+      absorbed: absorbed_snapshots(absorbed)
     })
     |> Repo.insert!()
   end
+
+  # The records an entry took in or gave back, against the state they were in.
+  # Keyed by id, since that is what putting one back needs to name.
+  defp absorbed_snapshots([]), do: nil
+
+  defp absorbed_snapshots(publications),
+    do: Map.new(publications, &{to_string(&1.id), snapshot(&1)})
+
+  @doc "The ids of the publications an entry took in, or gave back."
+  def absorbed_ids(%History{absorbed: nil}), do: []
+
+  def absorbed_ids(%History{absorbed: absorbed}),
+    do: absorbed |> Map.keys() |> Enum.map(&String.to_integer/1)
 
   @doc "The ordered history of one publication, newest first, each entry diffed."
   def of(publication_id) do
@@ -138,12 +158,35 @@ defmodule RichardBurton.Publication.History do
       |> Map.new()
 
     heads = Map.new(streams, fn {id, [head | _]} -> {id, head} end)
+    absorbed = absorbed_now(entries)
 
     Enum.map(entries, fn entry ->
       previous = Map.get(previous, {entry.publication_id, entry.version})
       head = Map.fetch!(heads, entry.publication_id)
 
-      %{entry | diff: diff(previous, entry), undoable: undoable?(entry, previous, head)}
+      undoable =
+        not MapSet.member?(absorbed, entry.publication_id) and
+          undoable?(entry, previous, head)
+
+      %{entry | diff: diff(previous, entry), undoable: undoable}
+    end)
+  end
+
+  # The publications that are inside another record right now. A merged record's
+  # own history is still here, but nothing in it can be undone while it is
+  # absorbed — it is the merge that holds it, and the merge that gives it back.
+  # Entries arrive newest first, so the first one naming a record decides.
+  defp absorbed_now(entries) do
+    entries
+    |> Enum.filter(&(&1.action in ["merged", "unmerged"]))
+    |> Enum.reverse()
+    |> Enum.reduce(MapSet.new(), fn entry, absorbed ->
+      ids = absorbed_ids(entry)
+
+      case entry.action do
+        "merged" -> Enum.reduce(ids, absorbed, &MapSet.put(&2, &1))
+        "unmerged" -> Enum.reduce(ids, absorbed, &MapSet.delete(&2, &1))
+      end
     end)
   end
 
@@ -160,15 +203,15 @@ defmodule RichardBurton.Publication.History do
     - never an older delete (a later restore already negated it) nor an older
       import or restore (compensating those would discard the edits that
       followed);
-    - never a merge, at any age: putting the record back would leave what it
-      brought with the publication it was merged into, and there would be two
-      of everything again. Undoing a merge means taking one apart, which is a
-      different thing from compensating a change.
+    - a merge or an un-merge, only as the latest entry — each is one act over
+      several records, so compensating it means taking the whole thing back:
+      the record that survived gives up what it absorbed, and the records that
+      left come back. An older one is not offered, for the same reason an older
+      import is not: what followed it was written against the merged record.
   """
   def undoable?(entry, previous, head) do
     cond do
-      entry.action == "merged" -> false
-      head.action == "merged" -> false
+      entry.action in ["merged", "unmerged"] -> entry.version == head.version
       entry.version == head.version -> true
       entry.action != "updated" -> false
       head.action == "deleted" -> false

--- a/backend/lib/richard_burton/publication_history.ex
+++ b/backend/lib/richard_burton/publication_history.ex
@@ -102,6 +102,22 @@ defmodule RichardBurton.Publication.History do
   def absorbed_ids(%History{absorbed: absorbed}),
     do: absorbed |> Map.keys() |> Enum.map(&String.to_integer/1)
 
+  @doc """
+  The publications an entry took in, or gave back, in a stable order.
+
+  Publications, not the map the log keys by id: keying is how a restore
+  addresses them, and a reader has no use for it beyond telling two records
+  with the same title apart — which the id each one carries already does.
+  """
+  def absorbed_records(%History{absorbed: nil}), do: []
+
+  def absorbed_records(%History{absorbed: absorbed}) do
+    absorbed
+    |> Map.values()
+    |> Enum.map(&Map.drop(&1, @derived -- ["id"]))
+    |> Enum.sort_by(& &1["id"])
+  end
+
   @doc "The ordered history of one publication, newest first, each entry diffed."
   def of(publication_id) do
     from(h in History, where: h.publication_id == ^publication_id, order_by: [desc: h.version])
@@ -158,7 +174,7 @@ defmodule RichardBurton.Publication.History do
       |> Map.new()
 
     heads = Map.new(streams, fn {id, [head | _]} -> {id, head} end)
-    absorbed = absorbed_now(entries)
+    absorbed = absorbed()
 
     Enum.map(entries, fn entry ->
       previous = Map.get(previous, {entry.publication_id, entry.version})
@@ -172,20 +188,33 @@ defmodule RichardBurton.Publication.History do
     end)
   end
 
-  # The publications that are inside another record right now. A merged record's
-  # own history is still here, but nothing in it can be undone while it is
-  # absorbed — it is the merge that holds it, and the merge that gives it back.
-  # Entries arrive newest first, so the first one naming a record decides.
-  defp absorbed_now(entries) do
-    entries
-    |> Enum.filter(&(&1.action in ["merged", "unmerged"]))
-    |> Enum.reverse()
-    |> Enum.reduce(MapSet.new(), fn entry, absorbed ->
-      ids = absorbed_ids(entry)
+  @doc """
+  The publications that are inside another record right now.
 
-      case entry.action do
-        "merged" -> Enum.reduce(ids, absorbed, &MapSet.put(&2, &1))
-        "unmerged" -> Enum.reduce(ids, absorbed, &MapSet.delete(&2, &1))
+  A merged record's own history is still here, but nothing in it can be undone
+  while it is absorbed — it is the merge that holds it, and the merge that gives
+  it back. The answer is the whole log's, not one stream's: the entry that holds
+  a record sits on the winner, so asking a loser's own history would never find
+  it.
+
+  Only the ids are read back: an entry's `absorbed` map carries a whole snapshot
+  per record, and none of it is needed to answer which ones are held.
+  """
+  def absorbed do
+    from(h in History,
+      where: h.action in ["merged", "unmerged"],
+      order_by: [asc: h.id],
+      select:
+        {h.action,
+         fragment("ARRAY(SELECT jsonb_object_keys(coalesce(?, '{}'::jsonb)))", h.absorbed)}
+    )
+    |> Repo.all()
+    |> Enum.reduce(MapSet.new(), fn {action, ids}, absorbed ->
+      ids = MapSet.new(ids, &String.to_integer/1)
+
+      case action do
+        "merged" -> MapSet.union(absorbed, ids)
+        "unmerged" -> MapSet.difference(absorbed, ids)
       end
     end)
   end
@@ -203,19 +232,14 @@ defmodule RichardBurton.Publication.History do
     - never an older delete (a later restore already negated it) nor an older
       import or restore (compensating those would discard the edits that
       followed);
-    - a merge or an un-merge, only as the latest entry — each is one act over
-      several records, so compensating it means taking the whole thing back:
-      the record that survived gives up what it absorbed, and the records that
-      left come back. An older one is not offered, for the same reason an older
-      import is not: what followed it was written against the merged record.
+    - a merge or an un-merge, only as the latest entry, by that same rule —
+      each is one act over several records, so compensating it means taking the
+      whole thing back: the record that survived gives up what it absorbed, and
+      the records that left come back. What followed an older one was written
+      against the merged record.
   """
   def undoable?(entry, previous, head) do
     cond do
-      # An entry from before a merge was one act names nothing to give back, so
-      # there is nothing here to undo — the record it holds is reachable only
-      # through the merge that has it, and that merge was never written down.
-      entry.action in ["merged", "unmerged"] and absorbed_ids(entry) == [] -> false
-      entry.action in ["merged", "unmerged"] -> entry.version == head.version
       entry.version == head.version -> true
       entry.action != "updated" -> false
       head.action == "deleted" -> false

--- a/backend/lib/richard_burton/publication_history.ex
+++ b/backend/lib/richard_burton/publication_history.ex
@@ -103,11 +103,10 @@ defmodule RichardBurton.Publication.History do
     do: absorbed |> Map.keys() |> Enum.map(&String.to_integer/1)
 
   @doc """
-  The publications an entry took in, or gave back, in a stable order.
+  The publications an entry took in, or gave back, ordered by id.
 
-  Publications, not the map the log keys by id: keying is how a restore
-  addresses them, and a reader has no use for it beyond telling two records
-  with the same title apart — which the id each one carries already does.
+  Each one carries its own id and none of the fingerprints: those are the
+  server's bookkeeping, not part of the record being shown.
   """
   def absorbed_records(%History{absorbed: nil}), do: []
 

--- a/backend/lib/richard_burton/publication_history.ex
+++ b/backend/lib/richard_burton/publication_history.ex
@@ -21,7 +21,7 @@ defmodule RichardBurton.Publication.History do
   alias RichardBurton.Publication.History
   alias RichardBurton.Repo
 
-  @actions ["created", "updated", "deleted", "restored"]
+  @actions ["created", "updated", "deleted", "restored", "merged"]
 
   # Mutations outside a request (seeds, mix tasks) are attributed to "system".
   @system_actor "system"
@@ -70,7 +70,7 @@ defmodule RichardBurton.Publication.History do
   turns any residual race into a loud error instead of silent corruption.
   """
   def record(action, publication = %Publication{}, actor)
-      when action in [:created, :updated, :deleted, :restored] do
+      when action in [:created, :updated, :deleted, :restored, :merged] do
     %History{}
     |> changeset(%{
       publication_id: publication.id,
@@ -159,10 +159,16 @@ defmodule RichardBurton.Publication.History do
       those fields and leaves later edits to others alone;
     - never an older delete (a later restore already negated it) nor an older
       import or restore (compensating those would discard the edits that
-      followed).
+      followed);
+    - never a merge, at any age: putting the record back would leave what it
+      brought with the publication it was merged into, and there would be two
+      of everything again. Undoing a merge means taking one apart, which is a
+      different thing from compensating a change.
   """
   def undoable?(entry, previous, head) do
     cond do
+      entry.action == "merged" -> false
+      head.action == "merged" -> false
       entry.version == head.version -> true
       entry.action != "updated" -> false
       head.action == "deleted" -> false

--- a/backend/lib/richard_burton_web/controllers/publication_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/publication_controller.ex
@@ -264,6 +264,9 @@ defmodule RichardBurtonWeb.PublicationController do
       snapshot: entry.snapshot,
       diff: entry.diff,
       undoable: entry.undoable,
+      # The records this entry took in, or gave back — what makes a merge one
+      # thing in the log rather than a change to each of them.
+      absorbed: entry.absorbed,
       timestamp: entry.inserted_at
     }
   end

--- a/backend/lib/richard_burton_web/controllers/publication_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/publication_controller.ex
@@ -162,6 +162,32 @@ defmodule RichardBurtonWeb.PublicationController do
     conn |> put_status(status) |> json(body)
   end
 
+  # Collapse publications into this one. The losers are named in the body, so
+  # the address stays the surviving record's own.
+  def merge(conn, %{"id" => id, "losers" => losers = [_ | _]}) do
+    case Publication.merge(id, losers, actor(conn)) do
+      {:ok, publication} ->
+        json(conn, Publication.Codec.flatten(publication))
+
+      {:error, :not_found} ->
+        conn |> put_status(:not_found) |> json(%{error: :not_found})
+
+      {:error, :self} ->
+        conn |> put_status(:bad_request) |> json(%{error: :self})
+
+      # The merged record would be a publication that already exists.
+      {:error, :conflict} ->
+        conn |> put_status(:conflict) |> json(%{error: :conflict})
+
+      {:error, errors} ->
+        conn |> put_status(:bad_request) |> json(%{errors: errors})
+    end
+  end
+
+  def merge(conn, _params) do
+    conn |> put_status(:bad_request) |> json(%{error: :losers_required})
+  end
+
   def delete(conn, %{"id" => id}) do
     case Publication.delete(id, actor(conn)) do
       {:ok, _publication} ->

--- a/backend/lib/richard_burton_web/controllers/publication_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/publication_controller.ex
@@ -164,7 +164,7 @@ defmodule RichardBurtonWeb.PublicationController do
 
   # Collapse publications into this one. The losers are named in the body, so
   # the address stays the surviving record's own.
-  def merge(conn, %{"id" => id, "losers" => losers = [_ | _]}) do
+  def merge(conn, %{"id" => id, "losers" => losers}) when is_list(losers) do
     case Publication.merge(id, losers, actor(conn)) do
       {:ok, publication} ->
         json(conn, Publication.Codec.flatten(publication))
@@ -172,8 +172,8 @@ defmodule RichardBurtonWeb.PublicationController do
       {:error, :not_found} ->
         conn |> put_status(:not_found) |> json(%{error: :not_found})
 
-      {:error, :self} ->
-        conn |> put_status(:bad_request) |> json(%{error: :self})
+      {:error, reason} when reason in [:self, :no_losers] ->
+        conn |> put_status(:bad_request) |> json(%{error: reason})
 
       # The merged record would be a publication that already exists.
       {:error, :conflict} ->
@@ -252,6 +252,10 @@ defmodule RichardBurtonWeb.PublicationController do
       # The same record was imported again while this one sat in the trash.
       {:error, :conflict} ->
         conn |> put_status(:conflict) |> json(%{error: :conflict})
+
+      # Held inside another record: an un-merge gives it back, a restore cannot.
+      {:error, :absorbed} ->
+        conn |> put_status(:conflict) |> json(%{error: :absorbed})
     end
   end
 
@@ -266,7 +270,7 @@ defmodule RichardBurtonWeb.PublicationController do
       undoable: entry.undoable,
       # The records this entry took in, or gave back — what makes a merge one
       # thing in the log rather than a change to each of them.
-      absorbed: entry.absorbed,
+      absorbed: Publication.History.absorbed_records(entry),
       timestamp: entry.inserted_at
     }
   end

--- a/backend/lib/richard_burton_web/router.ex
+++ b/backend/lib/richard_burton_web/router.ex
@@ -65,6 +65,7 @@ defmodule RichardBurtonWeb.Router do
       put("/:id", PublicationController, :update)
       delete("/:id", PublicationController, :delete)
       post("/:id/validate", PublicationController, :validate)
+      post("/:id/merge", PublicationController, :merge)
       post("/:id/restore", PublicationController, :restore)
       get("/:id/history", PublicationController, :history)
       post("/:id/history/:version/undo", PublicationController, :undo)

--- a/backend/priv/repo/migrations/20260803120000_record_a_merge_as_one_entry.exs
+++ b/backend/priv/repo/migrations/20260803120000_record_a_merge_as_one_entry.exs
@@ -1,0 +1,24 @@
+defmodule RichardBurton.Repo.Migrations.RecordAMergeAsOneEntry do
+  use Ecto.Migration
+
+  @moduledoc """
+  Let one history entry own a whole merge.
+
+  A merge changes several publications at once — the one that survives absorbs
+  what the others held, and they leave the database — but the log recorded that
+  as a change to each of them separately, so nothing in it stood for the merge
+  itself. Undoing it meant undoing one half.
+
+  An entry now carries the records it absorbed, which is what makes the merge a
+  single thing in the log: one entry to read, and one to undo.
+  """
+
+  def change do
+    alter table(:publication_history) do
+      # The publications this entry took in (a merge) or gave back (an
+      # un-merge): each one's id and the state it was in, which is what putting
+      # it back needs. Null for the entries that change one record only.
+      add(:absorbed, :map)
+    end
+  end
+end

--- a/backend/test/richard_burton/publication_test.exs
+++ b/backend/test/richard_burton/publication_test.exs
@@ -706,17 +706,32 @@ defmodule RichardBurton.PublicationTest do
       assert %Publication{deleted_at: %DateTime{}} = Repo.get(Publication, loser.id)
     end
 
-    test "the log says a loser was merged, not deleted, and will not undo it" do
+    test "the merge is one entry, on the record that survived it" do
       {winner, loser} = merge_pair()
 
       {:ok, _} = Publication.merge(winner.id, [loser.id], "someone@example.com")
 
-      assert [entry | _] = Publication.History.of(loser.id)
+      assert [entry | _] = Publication.History.of(winner.id)
       assert entry.action == "merged"
       assert entry.actor == "someone@example.com"
-      refute entry.undoable
+      assert Publication.History.absorbed_ids(entry) == [loser.id]
+    end
 
-      assert {:error, :conflict} = Publication.undo(loser.id, entry.version)
+    test "a loser's own log gains nothing, and offers no undo while it is held" do
+      {winner, loser} = merge_pair()
+      before = Publication.History.of(loser.id)
+
+      {:ok, _} = Publication.merge(winner.id, [loser.id])
+
+      # Nothing happened *to* the loser that the merge does not already say.
+      assert Enum.map(Publication.History.of(loser.id), & &1.version) ==
+               Enum.map(before, & &1.version)
+
+      # And nothing in its log can be undone while another record holds it —
+      # the merge holds it, and the merge is what gives it back.
+      assert Enum.all?(Publication.History.all(), fn entry ->
+               entry.publication_id != loser.id or not entry.undoable
+             end)
     end
 
     test "a record a merge absorbed is not in the trash to be restored" do
@@ -731,13 +746,57 @@ defmodule RichardBurton.PublicationTest do
       assert Enum.any?(Publication.all_deleted(), &(&1.id == winner.id))
     end
 
-    test "the winner's own change is recorded as an update" do
+    test "undoing a merge takes the whole thing back, under one entry" do
       {winner, loser} = merge_pair()
+
+      countries_before =
+        Publication.find(winner.id) |> Publication.Codec.flatten() |> Map.get(:countries)
 
       {:ok, _} = Publication.merge(winner.id, [loser.id])
 
-      assert [entry | _] = Publication.History.of(winner.id)
-      assert entry.action == "updated"
+      [merge | _] = Publication.History.of(winner.id)
+      assert merge.undoable
+
+      assert {:ok, _} = Publication.undo(winner.id, merge.version)
+
+      # The record that left is back, and live.
+      assert %Publication{deleted_at: nil} = Repo.get(Publication, loser.id)
+
+      # The one that survived gave up what it had absorbed.
+      assert Publication.find(winner.id) |> Publication.Codec.flatten() |> Map.get(:countries) ==
+               countries_before
+
+      # And the un-merge is one entry, naming what it gave back.
+      assert [undone | _] = Publication.History.of(winner.id)
+      assert undone.action == "unmerged"
+      assert Publication.History.absorbed_ids(undone) == [loser.id]
+    end
+
+    test "an un-merge is itself undoable, which merges them again" do
+      {winner, loser} = merge_pair()
+      {:ok, _} = Publication.merge(winner.id, [loser.id])
+      [merge | _] = Publication.History.of(winner.id)
+      {:ok, _} = Publication.undo(winner.id, merge.version)
+
+      [undone | _] = Publication.History.of(winner.id)
+      assert undone.undoable
+
+      assert {:ok, _} = Publication.undo(winner.id, undone.version)
+
+      assert %Publication{deleted_at: %DateTime{}} = Repo.get(Publication, loser.id)
+      assert [again | _] = Publication.History.of(winner.id)
+      assert again.action == "merged"
+    end
+
+    test "a record given back by an un-merge is out of hiding, and in the index" do
+      {winner, loser} = merge_pair()
+      {:ok, _} = Publication.merge(winner.id, [loser.id])
+      [merge | _] = Publication.History.of(winner.id)
+      {:ok, _} = Publication.undo(winner.id, merge.version)
+
+      # Not in the trash — nobody deleted it — but listed again.
+      refute Enum.any?(Publication.all_deleted(), &(&1.id == loser.id))
+      assert Enum.any?(Repo.all(FlatPublication), &(&1.id == loser.id))
     end
 
     test "refuses to merge a publication into itself" do

--- a/backend/test/richard_burton/publication_test.exs
+++ b/backend/test/richard_burton/publication_test.exs
@@ -788,6 +788,29 @@ defmodule RichardBurton.PublicationTest do
       assert again.action == "merged"
     end
 
+    test "a merge recorded before it was one act is inert, not half-undoable" do
+      {_winner, loser} = merge_pair()
+
+      # The shape the log had when a merge marked each record separately: the
+      # one that left carried the mark, and the mark named nothing.
+      loser
+      |> Ecto.Changeset.change(deleted_at: DateTime.utc_now(:second))
+      |> Repo.update!()
+
+      History.record(:merged, Publication.preload(loser), "someone@example.com")
+
+      [entry | _] = History.of(loser.id)
+      assert entry.action == "merged"
+
+      # Nothing to give back, so nothing to undo — rather than an undo that
+      # reverts a record and returns none of what it was merged into.
+      refute entry.undoable
+      assert {:error, :conflict} = Publication.undo(loser.id, entry.version)
+
+      # And it stays out of the trash, as it always did.
+      refute Enum.any?(Publication.all_deleted(), &(&1.id == loser.id))
+    end
+
     test "a record given back by an un-merge is out of hiding, and in the index" do
       {winner, loser} = merge_pair()
       {:ok, _} = Publication.merge(winner.id, [loser.id])

--- a/backend/test/richard_burton/publication_test.exs
+++ b/backend/test/richard_burton/publication_test.exs
@@ -638,4 +638,136 @@ defmodule RichardBurton.PublicationTest do
       assert {:error, :not_found} = Publication.restore(-1)
     end
   end
+
+  describe "merge/3" do
+    # Two records of the same work, each holding something the other lacks.
+    defp merge_pair do
+      winner =
+        insert_publication(
+          @valid_attrs
+          |> Map.put("countries", [%{"code" => "GB"}])
+          |> Map.put("references", [%{"content" => "A source", "position" => 0}])
+        )
+
+      loser =
+        insert_publication(
+          @valid_attrs
+          |> Map.put("title", "Manuel de Moraes: Another Printing")
+          |> Map.put("countries", [%{"code" => "US"}])
+          |> Map.put("publishers", [%{"name" => "Noonday Press"}])
+          |> Map.put("references", [%{"content" => "Another source", "position" => 0}])
+        )
+
+      {winner, loser}
+    end
+
+    test "the winner keeps what names it and gains what the loser held" do
+      {winner, loser} = merge_pair()
+
+      assert {:ok, merged} = Publication.merge(winner.id, [loser.id])
+
+      assert merged.id == winner.id
+      assert merged.title == winner.title
+
+      assert ["GB", "US"] == merged.countries |> Enum.map(& &1.code) |> Enum.sort()
+
+      assert ["Bickers & Son", "Noonday Press"] ==
+               merged.publishers |> Enum.map(& &1.name) |> Enum.sort()
+
+      assert ["A source", "Another source"] ==
+               merged.references |> Enum.map(& &1.content) |> Enum.sort()
+    end
+
+    test "a source both of them recorded is recorded once" do
+      winner =
+        insert_publication(
+          Map.put(@valid_attrs, "references", [%{"content" => "A source", "position" => 0}])
+        )
+
+      loser =
+        insert_publication(
+          @valid_attrs
+          |> Map.put("title", "Manuel de Moraes: Another Printing")
+          |> Map.put("references", [%{"content" => "A source", "position" => 0}])
+        )
+
+      assert {:ok, merged} = Publication.merge(winner.id, [loser.id])
+
+      assert ["A source"] == Enum.map(merged.references, & &1.content)
+    end
+
+    test "the losers leave the database, and the winner stays in it" do
+      {winner, loser} = merge_pair()
+
+      {:ok, _} = Publication.merge(winner.id, [loser.id])
+
+      assert [%{id: live}] = Repo.all(FlatPublication)
+      assert live == winner.id
+      assert %Publication{deleted_at: %DateTime{}} = Repo.get(Publication, loser.id)
+    end
+
+    test "the log says a loser was merged, not deleted, and will not undo it" do
+      {winner, loser} = merge_pair()
+
+      {:ok, _} = Publication.merge(winner.id, [loser.id], "someone@example.com")
+
+      assert [entry | _] = Publication.History.of(loser.id)
+      assert entry.action == "merged"
+      assert entry.actor == "someone@example.com"
+      refute entry.undoable
+
+      assert {:error, :conflict} = Publication.undo(loser.id, entry.version)
+    end
+
+    test "the winner's own change is recorded as an update" do
+      {winner, loser} = merge_pair()
+
+      {:ok, _} = Publication.merge(winner.id, [loser.id])
+
+      assert [entry | _] = Publication.History.of(winner.id)
+      assert entry.action == "updated"
+    end
+
+    test "refuses to merge a publication into itself" do
+      {winner, _loser} = merge_pair()
+
+      assert {:error, :self} = Publication.merge(winner.id, [winner.id])
+    end
+
+    test "refuses when a publication is not here" do
+      {winner, loser} = merge_pair()
+      {:ok, _} = Publication.delete(loser.id)
+
+      assert {:error, :not_found} = Publication.merge(winner.id, [loser.id])
+      assert {:error, :not_found} = Publication.merge(-1, [winner.id])
+    end
+
+    test "takes no merge that names nothing to merge in" do
+      {winner, _loser} = merge_pair()
+
+      assert_raise FunctionClauseError, fn -> Publication.merge(winner.id, []) end
+    end
+
+    test "surfaces a collision with a third publication rather than crashing" do
+      {winner, loser} = merge_pair()
+
+      # A third record already holds what the merged one would: the same title
+      # and year, and the countries and publishers the merge would union.
+      third =
+        insert_publication(
+          @valid_attrs
+          |> Map.put("countries", [%{"code" => "GB"}, %{"code" => "US"}])
+          |> Map.put("publishers", [
+            %{"name" => "Bickers & Son"},
+            %{"name" => "Noonday Press"}
+          ])
+        )
+
+      assert {:error, :conflict} = Publication.merge(winner.id, [loser.id])
+
+      # Nothing moved: the loser is still here and the third is untouched.
+      assert is_nil(Repo.get(Publication, loser.id).deleted_at)
+      assert %Publication{} = Repo.get(Publication, third.id)
+    end
+  end
 end

--- a/backend/test/richard_burton/publication_test.exs
+++ b/backend/test/richard_burton/publication_test.exs
@@ -719,6 +719,18 @@ defmodule RichardBurton.PublicationTest do
       assert {:error, :conflict} = Publication.undo(loser.id, entry.version)
     end
 
+    test "a record a merge absorbed is not in the trash to be restored" do
+      {winner, loser} = merge_pair()
+      {:ok, _} = Publication.merge(winner.id, [loser.id])
+
+      refute Enum.any?(Publication.all_deleted(), &(&1.id == loser.id))
+
+      # A record that is deleted after being merged into is there, though: the
+      # trash lists what someone deleted, whatever happened to it before.
+      {:ok, _} = Publication.delete(winner.id)
+      assert Enum.any?(Publication.all_deleted(), &(&1.id == winner.id))
+    end
+
     test "the winner's own change is recorded as an update" do
       {winner, loser} = merge_pair()
 

--- a/backend/test/richard_burton/publication_test.exs
+++ b/backend/test/richard_burton/publication_test.exs
@@ -788,27 +788,26 @@ defmodule RichardBurton.PublicationTest do
       assert again.action == "merged"
     end
 
-    test "a merge recorded before it was one act is inert, not half-undoable" do
-      {_winner, loser} = merge_pair()
+    test "a record held inside another one has nothing of its own to undo" do
+      {winner, loser} = merge_pair()
+      {:ok, _} = Publication.merge(winner.id, [loser.id])
 
-      # The shape the log had when a merge marked each record separately: the
-      # one that left carried the mark, and the mark named nothing.
-      loser
-      |> Ecto.Changeset.change(deleted_at: DateTime.utc_now(:second))
-      |> Repo.update!()
-
-      History.record(:merged, Publication.preload(loser), "someone@example.com")
-
+      # The merge lives on the winner, so the loser's own stream never names it
+      # — asking that stream must still answer that it is held.
       [entry | _] = History.of(loser.id)
-      assert entry.action == "merged"
-
-      # Nothing to give back, so nothing to undo — rather than an undo that
-      # reverts a record and returns none of what it was merged into.
       refute entry.undoable
       assert {:error, :conflict} = Publication.undo(loser.id, entry.version)
+    end
 
-      # And it stays out of the trash, as it always did.
-      refute Enum.any?(Publication.all_deleted(), &(&1.id == loser.id))
+    test "a record inside another one is not restored on its own" do
+      {winner, loser} = merge_pair()
+      {:ok, _} = Publication.merge(winner.id, [loser.id])
+
+      # Putting it back would recreate the duplicate while the winner keeps
+      # everything it took, so the trash is not the way back — the un-merge is.
+      assert {:error, :absorbed} = Publication.restore(loser.id)
+      assert %Publication{deleted_at: %DateTime{}} = Repo.get(Publication, loser.id)
+      refute Enum.any?(History.of(loser.id), &(&1.action == "restored"))
     end
 
     test "a record given back by an un-merge is out of hiding, and in the index" do
@@ -839,7 +838,7 @@ defmodule RichardBurton.PublicationTest do
     test "takes no merge that names nothing to merge in" do
       {winner, _loser} = merge_pair()
 
-      assert_raise FunctionClauseError, fn -> Publication.merge(winner.id, []) end
+      assert {:error, :no_losers} = Publication.merge(winner.id, [])
     end
 
     test "surfaces a collision with a third publication rather than crashing" do

--- a/backend/test/richard_burton_web/controllers/publication_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/publication_controller_test.exs
@@ -507,9 +507,12 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
       assert %{"entries" => [entry | _]} = json_response(conn, 200)
       assert entry["action"] == "merged"
       assert entry["actor"] == session_user_email()
-      # One act, so one thing to undo — and it says what it took in.
+      # One act, so one thing to undo — and it says what it took in, whole.
       assert entry["undoable"]
-      assert Map.keys(entry["absorbed"]) == ["#{meta.loser.id}"]
+      assert [absorbed] = entry["absorbed"]
+      assert absorbed["id"] == meta.loser.id
+      assert absorbed["title"] == meta.loser.title
+      refute Map.has_key?(absorbed, "countries_fingerprint")
     end
 
     test "merging a publication into itself is a bad request", meta do
@@ -537,6 +540,24 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
 
       conn = post(meta.conn, publication_path(meta.conn, :merge, meta.winner.id), %{})
       assert json_response(conn, 400) == %{"error" => "losers_required"}
+    end
+
+    test "a record it took in cannot be restored out of it", meta do
+      expect_auth_authorize_admin(3)
+
+      meta.conn
+      |> post(publication_path(meta.conn, :merge, meta.winner.id), %{
+        "losers" => [meta.loser.id]
+      })
+      |> json_response(200)
+
+      # The trash never offers it, and asking for it directly is refused all
+      # the same — a restore would undo half of the merge.
+      conn = get(meta.conn, publication_path(meta.conn, :index_deleted))
+      assert %{"entries" => []} = json_response(conn, 200)
+
+      conn = post(meta.conn, publication_path(meta.conn, :restore, meta.loser.id))
+      assert json_response(conn, 409) == %{"error" => "absorbed"}
     end
   end
 

--- a/backend/test/richard_burton_web/controllers/publication_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/publication_controller_test.exs
@@ -462,6 +462,82 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
     end
   end
 
+  describe "POST /publications/:id/merge" do
+    setup do
+      winner = insert_publication(@publication_attrs)
+
+      loser =
+        insert_publication(%{
+          @publication_attrs
+          | "countries" => "US",
+            "publishers" => "Noonday Press"
+        })
+
+      [winner: winner, loser: loser]
+    end
+
+    test "collapses the losers into the addressed publication", meta do
+      expect_auth_authorize_admin()
+
+      result =
+        meta.conn
+        |> post(publication_path(meta.conn, :merge, meta.winner.id), %{
+          "losers" => [meta.loser.id]
+        })
+        |> json_response(200)
+
+      assert result["id"] == meta.winner.id
+      assert result["countries"] == "GB, US"
+      assert result["publishers"] == "Bickers & Son, Noonday Press"
+
+      # Only the survivor is left in the index.
+      conn = get(build_conn(), publication_path(meta.conn, :index))
+      assert %{"entries" => [entry]} = json_response(conn, 200)
+      assert entry["id"] == meta.winner.id
+    end
+
+    test "records the merge in both publications' histories", meta do
+      expect_auth_authorize_admin(2)
+
+      meta.conn
+      |> post(publication_path(meta.conn, :merge, meta.winner.id), %{"losers" => [meta.loser.id]})
+      |> json_response(200)
+
+      conn = get(meta.conn, publication_path(meta.conn, :history, meta.loser.id))
+      assert %{"entries" => [entry | _]} = json_response(conn, 200)
+      assert entry["action"] == "merged"
+      assert entry["actor"] == session_user_email()
+      refute entry["undoable"]
+    end
+
+    test "merging a publication into itself is a bad request", meta do
+      expect_auth_authorize_admin()
+
+      conn =
+        post(meta.conn, publication_path(meta.conn, :merge, meta.winner.id), %{
+          "losers" => [meta.winner.id]
+        })
+
+      assert json_response(conn, 400) == %{"error" => "self"}
+    end
+
+    test "merging an unknown publication is not found", meta do
+      expect_auth_authorize_admin()
+
+      conn =
+        post(meta.conn, publication_path(meta.conn, :merge, -1), %{"losers" => [meta.loser.id]})
+
+      assert json_response(conn, 404) == %{"error" => "not_found"}
+    end
+
+    test "naming no losers is a bad request", meta do
+      expect_auth_authorize_admin()
+
+      conn = post(meta.conn, publication_path(meta.conn, :merge, meta.winner.id), %{})
+      assert json_response(conn, 400) == %{"error" => "losers_required"}
+    end
+  end
+
   describe "POST /publications/bulk" do
     test "returns 201 and the created publications when all the publications are valid", meta do
       expect_auth_authorize_admin()

--- a/backend/test/richard_burton_web/controllers/publication_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/publication_controller_test.exs
@@ -496,18 +496,20 @@ defmodule RichardBurtonWeb.PublicationControllerTest do
       assert entry["id"] == meta.winner.id
     end
 
-    test "records the merge in both publications' histories", meta do
+    test "records the merge as one entry, on the record that survived it", meta do
       expect_auth_authorize_admin(2)
 
       meta.conn
       |> post(publication_path(meta.conn, :merge, meta.winner.id), %{"losers" => [meta.loser.id]})
       |> json_response(200)
 
-      conn = get(meta.conn, publication_path(meta.conn, :history, meta.loser.id))
+      conn = get(meta.conn, publication_path(meta.conn, :history, meta.winner.id))
       assert %{"entries" => [entry | _]} = json_response(conn, 200)
       assert entry["action"] == "merged"
       assert entry["actor"] == session_user_email()
-      refute entry["undoable"]
+      # One act, so one thing to undo — and it says what it took in.
+      assert entry["undoable"]
+      assert Map.keys(entry["absorbed"]) == ["#{meta.loser.id}"]
     end
 
     test "merging a publication into itself is a bad request", meta do

--- a/frontend/components/PublicationDetail.mdx
+++ b/frontend/components/PublicationDetail.mdx
@@ -16,9 +16,9 @@ this decides where the publication came from — a page that read it on the
 server, or an overlay opened over the index — and the view itself does not
 fetch.
 
-An admin also gets the publication's mutation log and the controls to correct or
-remove it. Who may do what is settled here rather than by each caller, so the
-same publication offers the same affordances wherever it is read.
+An admin also gets the publication's mutation log and the controls to correct,
+merge or remove it. Who may do what is settled here rather than by each caller,
+so the same publication offers the same affordances wherever it is read.
 
 <Canvas of={PublicationDetailStories.Default} />
 
@@ -35,9 +35,12 @@ same publication offers the same affordances wherever it is read.
 
 - **Default** — a fully sourced record, read by anyone.
 - **Without references** — the section states the absence rather than hiding.
-- **As admin** — the history section and the edit/delete controls.
+- **As admin** — the history section and the edit/merge/delete controls.
 - **Editing** — the form the Edit control opens, in place.
 - **Delete confirmation** — the guard in front of the destructive action.
+- **Merging** — the
+  [merge dialog](?path=/docs/publications-publication-merge--docs), opened over
+  the record that survives it.
 - **Notifies on navigate** — following a link tells the caller.
 
 <Canvas of={PublicationDetailStories.WithoutReferences} />

--- a/frontend/components/PublicationDetail.stories.tsx
+++ b/frontend/components/PublicationDetail.stories.tsx
@@ -117,6 +117,7 @@ export const AsAdmin: Story = {
   decorators: [asAdmin],
   play: async () => {
     await expect(screen.getByRole("button", { name: "Edit" })).toBeVisible();
+    await expect(screen.getByRole("button", { name: "Merge" })).toBeVisible();
     await expect(screen.getByRole("button", { name: "Delete" })).toBeVisible();
 
     // The log came with the record: its entries are in the document while the
@@ -186,5 +187,28 @@ export const SearchLinks: Story = {
     await expect(
       screen.getByRole("link", { name: "Helen Caldwell" }),
     ).toHaveAttribute("href", "/?search=Helen Caldwell");
+  },
+};
+
+/**
+ * Duplicates are collapsed from the record that survives them: the control
+ * opens the merge dialog over it, already knowing what keeps its place.
+ */
+export const Merging: Story = {
+  decorators: [asAdmin],
+  play: async () => {
+    await userEvent.click(screen.getByRole("button", { name: "Merge" }));
+
+    const dialog = await screen.findByRole("dialog", {
+      name: "Merge publications",
+    });
+    await expect(dialog).toHaveTextContent(/Dom Casmurro/);
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("dialog", { name: "Merge publications" }),
+      ).not.toBeInTheDocument(),
+    );
   },
 };

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -37,6 +37,7 @@ import ConfirmationModal from "./ConfirmationModal";
 import DataInput from "./DataInput";
 import { useModal } from "./Modal";
 import PublicationHistory from "./PublicationHistory";
+import PublicationMerge from "./PublicationMerge";
 import ReferencesEditor from "./ReferencesEditor";
 import SectionHeading, { SECTION_HEADING } from "./SectionHeading";
 import Tooltip from "./Tooltip";
@@ -290,6 +291,7 @@ const Detail: FC<PublicationDetailProps> = ({
   const [editing, setEditing] = useState(false);
   const deleteConfirmation = useModal();
   const [deleting, setDeleting] = useState(false);
+  const mergeDialog = useModal();
 
   // An edit abandoned by closing the view is dropped, not kept: the overlay it
   // writes to is the same one the row behind it reads around.
@@ -350,6 +352,13 @@ const Detail: FC<PublicationDetailProps> = ({
                 onClick={startEditing}
               />
               <Button
+                label="Merge"
+                variant="outline"
+                width="fit"
+                size="medium"
+                onClick={() => mergeDialog.open()}
+              />
+              <Button
                 label="Delete"
                 variant="danger"
                 width="fit"
@@ -360,6 +369,15 @@ const Detail: FC<PublicationDetailProps> = ({
           )}
         </>
       )}
+      <PublicationMerge
+        publication={publication}
+        isOpen={mergeDialog.isOpen}
+        onClose={mergeDialog.close}
+        onMerged={() => {
+          mergeDialog.close();
+          router.refresh();
+        }}
+      />
       <ConfirmationModal
         isOpen={deleteConfirmation.isOpen}
         title="Delete this publication?"

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -87,13 +87,10 @@ const PublicationDescription: FC<{ publication: Publication }> = ({
   publication: p,
 }) => {
   function getSearchableItems(p: Publication, key: PublicationKey) {
-    return p[key]
-      .split(",")
-      .map((value) => value.trim())
-      .map((value) => ({
-        value,
-        label: Publication.describeValue(value, key),
-      }));
+    return Publication.items(p[key]).map((value) => ({
+      value,
+      label: Publication.describeValue(value, key),
+    }));
   }
 
   const list = (key: PublicationKey) => (

--- a/frontend/components/PublicationHistory.mdx
+++ b/frontend/components/PublicationHistory.mdx
@@ -7,7 +7,7 @@ import * as PublicationHistoryStories from "./PublicationHistory.stories";
 # Publication history
 
 A publication's mutation log, newest first: each entry names the action
-(created / updated / deleted / restored), the acting user, and the date, and
+(created / updated / deleted / restored / merged), the acting user, and the date, and
 **updates state exactly what changed**: scalar fields as `old → new`, and
 references as the precise entries added (+) and removed (−) — or a reorder, when
 the same entries merely moved.

--- a/frontend/components/PublicationHistory.tsx
+++ b/frontend/components/PublicationHistory.tsx
@@ -44,11 +44,22 @@ const ActionBadge: FC<{
       group-data-[action=deleted]:bg-red-100 group-data-[action=deleted]:text-red-700
       group-data-[action=restored]:bg-emerald-100 group-data-[action=restored]:text-emerald-700
       group-data-[action=merged]:bg-sky-100 group-data-[action=merged]:text-sky-700
+      group-data-[action=unmerged]:bg-sky-100 group-data-[action=unmerged]:text-sky-700
     "
   >
     {action}
   </span>
 );
+
+/**
+ * The records a merge took in, or an un-merge gave back, named as a reader
+ * would know them. A merge is one act over several publications; this is the
+ * entry saying which, since they are no longer listed on their own.
+ */
+const absorbedTitles = (entry: HistoryEntry): string[] =>
+  Object.values(entry.absorbed ?? {}).map(
+    (publication) => publication.title || "an untitled record",
+  );
 
 const Entry: FC<{
   entry: HistoryEntry;
@@ -125,6 +136,15 @@ const Entry: FC<{
           className="mt-0.5 text-gray-500 wrap-break-words data-[variant=card]:pl-22 data-[variant=plain]:pl-18"
         >
           by {entry.actor} · {formatDate(entry.timestamp)}
+        </p>
+      )}
+      {absorbedTitles(entry).length > 0 && (
+        <p
+          data-variant={variant}
+          className="mt-2 text-xs text-gray-600 data-[variant=card]:pl-22 data-[variant=plain]:pl-18"
+        >
+          {entry.action === "merged" ? "Took in " : "Gave back "}
+          {absorbedTitles(entry).join(", ")}
         </p>
       )}
       {entry.action === "updated" && entry.diff === null && (

--- a/frontend/components/PublicationHistory.tsx
+++ b/frontend/components/PublicationHistory.tsx
@@ -51,16 +51,6 @@ const ActionBadge: FC<{
   </span>
 );
 
-/**
- * The records a merge took in, or an un-merge gave back, named as a reader
- * would know them. A merge is one act over several publications; this is the
- * entry saying which, since they are no longer listed on their own.
- */
-const absorbedTitles = (entry: HistoryEntry): string[] =>
-  Object.values(entry.absorbed ?? {}).map(
-    (publication) => publication.title || "an untitled record",
-  );
-
 const Entry: FC<{
   entry: HistoryEntry;
   /**
@@ -138,15 +128,6 @@ const Entry: FC<{
           by {entry.actor} · {formatDate(entry.timestamp)}
         </p>
       )}
-      {absorbedTitles(entry).length > 0 && (
-        <p
-          data-variant={variant}
-          className="mt-2 text-xs text-gray-600 data-[variant=card]:pl-22 data-[variant=plain]:pl-18"
-        >
-          {entry.action === "merged" ? "Took in " : "Gave back "}
-          {absorbedTitles(entry).join(", ")}
-        </p>
-      )}
       {entry.action === "updated" && entry.diff === null && (
         <p
           data-variant={variant}
@@ -167,7 +148,7 @@ const Entry: FC<{
                 {change.label}: <s className="text-gray-500">{change.from}</s> →{" "}
                 <span className="text-gray-700">{change.to}</span>
               </li>
-            ) : (
+            ) : change.kind === "references" ? (
               <li key="references" className="text-xs text-gray-600">
                 References:{change.reordered ? " reordered" : null}
                 <ul className="space-y-0.5">
@@ -179,6 +160,34 @@ const Entry: FC<{
                   {change.added.map((reference) => (
                     <li key={`+ ${reference}`} className="text-emerald-700">
                       + {reference}
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ) : (
+              <li key="absorbed" className="mt-1 text-xs text-gray-600">
+                {change.direction === "in" ? "Took in" : "Gave back"}
+                <ul className="mt-1 space-y-1.5">
+                  {change.records.map((record) => (
+                    <li
+                      key={record.id}
+                      className="pl-2 border-l-2 border-sky-200"
+                    >
+                      <span className="font-medium text-gray-700">
+                        {record.title}
+                      </span>
+                      <ul className="space-y-0.5">
+                        {record.fields.map((field) => (
+                          <li key={field.label} className="text-gray-500">
+                            {field.label}: {field.value}
+                          </li>
+                        ))}
+                        {record.references.map((reference) => (
+                          <li key={reference} className="text-gray-500">
+                            Reference: {reference}
+                          </li>
+                        ))}
+                      </ul>
                     </li>
                   ))}
                 </ul>

--- a/frontend/components/PublicationHistory.tsx
+++ b/frontend/components/PublicationHistory.tsx
@@ -43,6 +43,7 @@ const ActionBadge: FC<{
       group-data-[action=updated]:bg-amber-100 group-data-[action=updated]:text-amber-800
       group-data-[action=deleted]:bg-red-100 group-data-[action=deleted]:text-red-700
       group-data-[action=restored]:bg-emerald-100 group-data-[action=restored]:text-emerald-700
+      group-data-[action=merged]:bg-sky-100 group-data-[action=merged]:text-sky-700
     "
   >
     {action}

--- a/frontend/components/PublicationHistoryFeed.tsx
+++ b/frontend/components/PublicationHistoryFeed.tsx
@@ -6,20 +6,13 @@ import type {
   FullHistoryEntry,
   PublicationHistoryAction,
 } from "modules/publication/model";
+import { HISTORY_ACTIONS } from "modules/publication/model";
 import { useRouter } from "next/navigation";
 import { FC, useState } from "react";
 import { undo } from "modules/publication/remote";
 import { Entry, UNDO_DISABLED } from "./PublicationHistory";
 
 type FeedEntry = WithChanges<FullHistoryEntry>;
-
-const ACTIONS: PublicationHistoryAction[] = [
-  "created",
-  "updated",
-  "deleted",
-  "restored",
-  "merged",
-];
 
 type Filter = { actions: PublicationHistoryAction[]; query: string };
 
@@ -84,7 +77,7 @@ const PublicationHistoryFeed: FC<{
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap gap-2 items-center">
-        {ACTIONS.map((action) => (
+        {HISTORY_ACTIONS.map((action) => (
           <button
             key={action}
             type="button"

--- a/frontend/components/PublicationHistoryFeed.tsx
+++ b/frontend/components/PublicationHistoryFeed.tsx
@@ -18,6 +18,7 @@ const ACTIONS: PublicationHistoryAction[] = [
   "updated",
   "deleted",
   "restored",
+  "merged",
 ];
 
 type Filter = { actions: PublicationHistoryAction[]; query: string };

--- a/frontend/components/PublicationMerge.mdx
+++ b/frontend/components/PublicationMerge.mdx
@@ -1,0 +1,55 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+
+import * as PublicationMergeStories from "./PublicationMerge.stories";
+
+<Meta of={PublicationMergeStories} />
+
+# Publication merge
+
+Collapses duplicates of a publication into it. The record the dialog is opened
+from is the one that survives: it keeps its identity, its address and its own
+fields, and gains the countries, publishers and sources the others hold. The
+records folded in leave the database, recorded as merged rather than deleted.
+
+<Canvas of={PublicationMergeStories.Previewing} />
+
+## Usage
+
+Controlled by the caller, like every dialog here: pair `isOpen` with
+`useModal()`, close it on `onClose`, and re-read the record on `onMerged` — the
+publication the caller is showing has changed.
+
+```tsx
+<PublicationMerge
+  publication={publication}
+  isOpen={mergeDialog.isOpen}
+  onClose={mergeDialog.close}
+  onMerged={() => {
+    mergeDialog.close();
+    router.refresh();
+  }}
+/>
+```
+
+`find` says how candidates are looked up, and defaults to searching the
+database. A caller that already knows the duplicates passes its own.
+
+## Why it previews
+
+A merge cannot be undone: putting a record back would leave what it brought
+with the survivor, and there would be two of everything again. So the dialog
+shows the outcome instead of describing it — everything gained is marked before
+the question is asked, and a merge that takes nothing says so.
+
+<Canvas of={PublicationMergeStories.NothingGained} />
+
+## States
+
+Nothing picked yet — the dialog names what survives and refuses to merge.
+
+<Canvas of={PublicationMergeStories.Default} />
+
+Searching offers every other record it finds, never the survivor itself and
+never one already picked.
+
+<Canvas of={PublicationMergeStories.Searching} />

--- a/frontend/components/PublicationMerge.stories.tsx
+++ b/frontend/components/PublicationMerge.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { empty, type Publication } from "modules/publication/model";
-import { expect, fn, screen, userEvent, waitFor } from "storybook/test";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
 
 import PublicationMerge from "./PublicationMerge";
 
@@ -107,12 +107,16 @@ export const Previewing: Story = {
     );
     await userEvent.click(screen.getAllByRole("button", { name: "Add" })[0]);
 
-    // The country and publisher it brings are the gain; the survivor's own stay.
-    await expect(await screen.findByText("Result")).toBeVisible();
-    await expect(screen.getByText("GB")).toBeVisible();
-    await expect(screen.getByText("W. H. Allen")).toBeVisible();
+    // The country and publisher it brings are the gain; the survivor's own
+    // stay. Asked of the result itself, since the records on offer now show
+    // every field they hold and would answer to the same text.
+    const result = within(
+      await screen.findByRole("region", { name: "Result" }),
+    );
+    await expect(result.getByText("GB")).toBeVisible();
+    await expect(result.getByText("W. H. Allen")).toBeVisible();
     await expect(
-      screen.getByText("Gledson, John. Deceptive Realism, 1984."),
+      result.getByText("Gledson, John. Deceptive Realism, 1984."),
     ).toBeVisible();
 
     await expect(

--- a/frontend/components/PublicationMerge.stories.tsx
+++ b/frontend/components/PublicationMerge.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { empty, type Publication } from "modules/publication/model";
+import { expect, fn, screen, userEvent, waitFor } from "storybook/test";
+
+import PublicationMerge from "./PublicationMerge";
+
+const DOM_CASMURRO: Publication = {
+  ...empty(),
+  id: 7,
+  title: "Dom Casmurro",
+  authors: "Helen Caldwell",
+  originalTitle: "Dom Casmurro",
+  originalAuthors: "Machado de Assis",
+  year: "1953",
+  countries: "US",
+  publishers: "Noonday Press",
+  references: ["Caldwell, Helen. Introduction, 1953."],
+};
+
+// Two records of the same book, entered separately: one adds a country and a
+// publisher, the other adds only a source.
+const DUPLICATES: Publication[] = [
+  {
+    ...DOM_CASMURRO,
+    id: 8,
+    countries: "GB",
+    publishers: "W. H. Allen",
+    references: ["Gledson, John. Deceptive Realism, 1984."],
+  },
+  {
+    ...DOM_CASMURRO,
+    id: 9,
+    references: ["Caldwell, Helen. Introduction, 1953."],
+  },
+];
+
+const meta = {
+  title: "Publications/Publication merge",
+  component: PublicationMerge,
+  parameters: {
+    layout: "fullscreen",
+    docs: { story: { inline: false, height: "40rem" } },
+  },
+  args: {
+    publication: DOM_CASMURRO,
+    isOpen: true,
+    onClose: fn(),
+    onMerged: fn(),
+    // Stories stand in for the database so the picker has something to offer;
+    // the confirmed merge needs the real server and is covered by the E2E suite.
+    find: async (term: string) =>
+      DUPLICATES.filter((p) =>
+        p.title.toLowerCase().includes(term.toLowerCase()),
+      ),
+  },
+} satisfies Meta<typeof PublicationMerge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Nothing picked yet: the dialog names what survives and refuses to merge. */
+export const Default: Story = {
+  play: async () => {
+    const dialog = await screen.findByRole("dialog", {
+      name: "Merge publications",
+    });
+    await expect(dialog).toHaveTextContent(
+      /Dom Casmurro.*1953.*keeps its place/,
+    );
+    await expect(
+      screen.getByRole("button", { name: "Merge publication" }),
+    ).toBeDisabled();
+  },
+};
+
+/** A search offers every other record it finds — never the survivor itself. */
+export const Searching: Story = {
+  play: async () => {
+    await screen.findByRole("dialog", { name: "Merge publications" });
+
+    await userEvent.type(
+      screen.getByLabelText("Search for publications to merge"),
+      "casmurro",
+    );
+
+    await waitFor(() =>
+      expect(screen.getAllByRole("button", { name: "Add" })).toHaveLength(2),
+    );
+  },
+};
+
+/**
+ * Picking a record shows what the survivor becomes: everything it gains is
+ * marked, so the outcome is visible before a merge that cannot be undone.
+ */
+export const Previewing: Story = {
+  play: async () => {
+    await screen.findByRole("dialog", { name: "Merge publications" });
+
+    await userEvent.type(
+      screen.getByLabelText("Search for publications to merge"),
+      "casmurro",
+    );
+    await waitFor(() =>
+      expect(screen.getAllByRole("button", { name: "Add" }).length).toBe(2),
+    );
+    await userEvent.click(screen.getAllByRole("button", { name: "Add" })[0]);
+
+    // The country and publisher it brings are the gain; the survivor's own stay.
+    await expect(await screen.findByText("Result")).toBeVisible();
+    await expect(screen.getByText("GB")).toBeVisible();
+    await expect(screen.getByText("W. H. Allen")).toBeVisible();
+    await expect(
+      screen.getByText("Gledson, John. Deceptive Realism, 1984."),
+    ).toBeVisible();
+
+    await expect(
+      screen.getByRole("button", { name: "Merge publication" }),
+    ).toBeEnabled();
+  },
+};
+
+/**
+ * A record that holds nothing new still leaves the database, so the dialog says
+ * the merge takes nothing rather than showing an empty result.
+ */
+export const NothingGained: Story = {
+  play: async () => {
+    await screen.findByRole("dialog", { name: "Merge publications" });
+
+    await userEvent.type(
+      screen.getByLabelText("Search for publications to merge"),
+      "casmurro",
+    );
+    await waitFor(() =>
+      expect(screen.getAllByRole("button", { name: "Add" }).length).toBe(2),
+    );
+    // The second duplicate repeats the survivor exactly.
+    await userEvent.click(screen.getAllByRole("button", { name: "Add" })[1]);
+
+    await expect(
+      await screen.findByText(/already says everything the others do/),
+    ).toBeVisible();
+  },
+};
+
+/** Backing out abandons the picks; nothing is asked of the server. */
+export const Cancelled: Story = {
+  play: async ({ args }) => {
+    await screen.findByRole("dialog", { name: "Merge publications" });
+
+    await userEvent.type(
+      screen.getByLabelText("Search for publications to merge"),
+      "casmurro",
+    );
+    await waitFor(() =>
+      expect(screen.getAllByRole("button", { name: "Add" }).length).toBe(2),
+    );
+    await userEvent.click(screen.getAllByRole("button", { name: "Add" })[0]);
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await expect(args.onClose).toHaveBeenCalled();
+    await expect(args.onMerged).not.toHaveBeenCalled();
+  },
+};

--- a/frontend/components/PublicationMerge.tsx
+++ b/frontend/components/PublicationMerge.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { Publication } from "modules/publication/model";
+import { merge, search } from "modules/publication/remote";
+import { usePublicationStore } from "modules/publication/workspace";
+import { ChangeEventHandler, FC, useState } from "react";
+import useDebounce from "utils/useDebounce";
+import Button from "./Button";
+import { Modal } from "./Modal";
+import SectionHeading from "./SectionHeading";
+
+/** Long enough that a typist does not query on every letter. */
+const SEARCH_DELAY_MS = 350;
+
+type Props = {
+  /** The record the others fold into: it keeps its identity and its address. */
+  publication: Publication;
+  isOpen: boolean;
+  onClose: () => void;
+  /** Run once the merge has happened, so the view showing the record can re-read it. */
+  onMerged: () => void;
+  /** How a term finds candidates. Defaults to searching the database. */
+  find?: (term: string) => Promise<Publication[]>;
+};
+
+/** One publication as a line: enough of it to tell two near-identical records apart. */
+const Summary: FC<{ publication: Publication }> = ({ publication: p }) => (
+  <div className="min-w-0">
+    <p className="text-sm truncate">
+      {p.title} <span className="text-gray-600">({p.year})</span>
+    </p>
+    <p className="text-xs text-gray-600 truncate">
+      {Publication.describeValue(p.countries, "countries")} · {p.publishers}
+    </p>
+  </div>
+);
+
+/**
+ * A field of the merged record, with what the merge adds to it set apart from
+ * what the survivor already said.
+ */
+const Gained: FC<{ label: string; kept: string[]; gained: string[] }> = ({
+  label,
+  kept,
+  gained,
+}) => (
+  <div className="flex gap-2 items-baseline text-sm">
+    <span className="w-24 text-xs text-gray-500 shrink-0">{label}</span>
+    <p className="flex flex-wrap gap-1.5">
+      {kept.map((value) => (
+        <span key={value} className="text-gray-700">
+          {value}
+        </span>
+      ))}
+      {gained.map((value) => (
+        <span
+          key={value}
+          className="px-1.5 rounded bg-emerald-100 text-emerald-800"
+        >
+          {value}
+        </span>
+      ))}
+    </p>
+  </div>
+);
+
+const items = (value: string) =>
+  value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+/**
+ * What the merge produces, before it is asked for: the survivor's countries,
+ * publishers and sources with everything the others bring marked as gained.
+ * A merge that adds nothing says so — picking a record that holds nothing new
+ * still removes it, and that should not look like an accident.
+ */
+const Preview: FC<{ winner: Publication; losers: Publication[] }> = ({
+  winner,
+  losers,
+}) => {
+  const result = Publication.merged(winner, losers);
+  const gained = (before: string[], after: string[]) =>
+    after.filter((value) => !before.includes(value));
+
+  const countries = gained(items(winner.countries), items(result.countries));
+  const publishers = gained(items(winner.publishers), items(result.publishers));
+  const references = gained(winner.references, result.references);
+
+  return (
+    <section className="space-y-2">
+      <SectionHeading>Result</SectionHeading>
+      <div className="space-y-1.5">
+        <Gained
+          label="Countries"
+          kept={items(winner.countries)}
+          gained={countries}
+        />
+        <Gained
+          label="Publishers"
+          kept={items(winner.publishers)}
+          gained={publishers}
+        />
+        <Gained
+          label="References"
+          kept={winner.references}
+          gained={references}
+        />
+      </div>
+      {countries.length + publishers.length + references.length === 0 && (
+        <p className="text-xs text-gray-500">
+          Nothing new to take — “{winner.title}” already says everything the
+          others do. Merging still removes them.
+        </p>
+      )}
+    </section>
+  );
+};
+
+/**
+ * Collapse duplicates of a publication into it: find them, see what the record
+ * becomes, and confirm.
+ *
+ * A merge is deliberately not undoable, so the dialog shows the outcome rather
+ * than describing it — everything the survivor gains is marked before the
+ * question is asked.
+ */
+const PublicationMerge: FC<Props> = ({
+  publication,
+  isOpen,
+  onClose,
+  onMerged,
+  find: findPublications = search,
+}) => {
+  const store = usePublicationStore();
+
+  const [term, setTerm] = useState("");
+  const [searching, setSearching] = useState(false);
+  const [candidates, setCandidates] = useState<Publication[]>([]);
+  const [chosen, setChosen] = useState<Publication[]>([]);
+  const [merging, setMerging] = useState(false);
+
+  const find = useDebounce(async (value: string) => {
+    if (!value.trim()) {
+      setCandidates([]);
+      setSearching(false);
+      return;
+    }
+    setCandidates(await findPublications(value));
+    setSearching(false);
+  }, SEARCH_DELAY_MS);
+
+  const handleTerm: ChangeEventHandler<HTMLInputElement> = (event) => {
+    setTerm(event.target.value);
+    setSearching(Boolean(event.target.value.trim()));
+    find(event.target.value);
+  };
+
+  // A record cannot be folded into itself, and one already picked is offered
+  // from the chosen list instead of twice.
+  const offered = candidates.filter(
+    (candidate) =>
+      candidate.id !== publication.id &&
+      !chosen.some((picked) => picked.id === candidate.id),
+  );
+
+  function reset() {
+    setTerm("");
+    setCandidates([]);
+    setChosen([]);
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  async function handleMerge() {
+    setMerging(true);
+    const merged = await merge(store, { winner: publication, losers: chosen });
+    setMerging(false);
+
+    if (merged) {
+      reset();
+      onMerged();
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} label="Merge publications">
+      <div className="flex flex-col gap-5 p-8 w-full max-h-[80vh] overflow-y-auto">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-normal">Merge into this publication</h1>
+          <p className="text-sm text-gray-500">
+            “{publication.title}” ({publication.year}) keeps its place. The
+            records you pick leave the database, and what they hold stays here.
+          </p>
+        </div>
+
+        <section className="space-y-2">
+          <SectionHeading>Find the duplicates</SectionHeading>
+          <input
+            className="w-full py-2 px-3 bg-white rounded border border-gray-300 transition-colors outline-none placeholder:text-sm focus:bg-gray-100 hover:bg-gray-100"
+            placeholder="Search by title, author, publisher or country"
+            aria-label="Search for publications to merge"
+            value={term}
+            onChange={handleTerm}
+          />
+          <div aria-live="polite">
+            {searching ? (
+              <p className="text-xs text-gray-500">Searching…</p>
+            ) : (
+              term.trim() &&
+              offered.length === 0 && (
+                <p className="text-xs text-gray-500">
+                  No other publication matches “{term}”.
+                </p>
+              )
+            )}
+          </div>
+          <ul className="space-y-1">
+            {offered.map((candidate) => (
+              <li
+                key={candidate.id}
+                className="flex gap-3 justify-between items-center py-1.5 px-3 rounded border border-gray-200"
+              >
+                <Summary publication={candidate} />
+                <Button
+                  label="Add"
+                  variant="outline-primary"
+                  width="fit"
+                  size="small"
+                  onClick={() => setChosen([...chosen, candidate])}
+                />
+              </li>
+            ))}
+          </ul>
+        </section>
+
+        {chosen.length > 0 && (
+          <section className="space-y-2">
+            <SectionHeading>Merging in</SectionHeading>
+            <ul className="space-y-1">
+              {chosen.map((picked) => (
+                <li
+                  key={picked.id}
+                  className="flex gap-3 justify-between items-center py-1.5 px-3 rounded border border-indigo-200 bg-indigo-50"
+                >
+                  <Summary publication={picked} />
+                  <Button
+                    label="Remove"
+                    variant="outline"
+                    width="fit"
+                    size="small"
+                    onClick={() =>
+                      setChosen(chosen.filter((p) => p.id !== picked.id))
+                    }
+                  />
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {chosen.length > 0 && <Preview winner={publication} losers={chosen} />}
+
+        <div className="flex gap-3 justify-end">
+          <Button
+            label="Cancel"
+            variant="outline"
+            width="fit"
+            size="medium"
+            onClick={handleClose}
+          />
+          <Button
+            label={
+              chosen.length > 1
+                ? `Merge ${chosen.length} publications`
+                : "Merge publication"
+            }
+            variant="danger"
+            width="fit"
+            size="medium"
+            loading={merging}
+            disabled={chosen.length === 0 || merging}
+            onClick={handleMerge}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default PublicationMerge;
+export type { Props as PublicationMergeProps };

--- a/frontend/components/PublicationMerge.tsx
+++ b/frontend/components/PublicationMerge.tsx
@@ -219,9 +219,6 @@ const PublicationMerge: FC<Props> = ({
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} label="Merge publications">
-      {/* The frame holds still: searching swaps what is listed, and a dialog
-          that grew and shrank under the reader as results arrived moved the
-          controls out from under the pointer. Only the results scroll. */}
       <div className="flex flex-col gap-5 p-8 w-full h-full sm:h-[70vh]">
         <div className="space-y-1 shrink-0">
           <h1 className="text-2xl font-normal">Merge into this publication</h1>
@@ -254,9 +251,6 @@ const PublicationMerge: FC<Props> = ({
           </div>
         </section>
 
-        {/* One scroll region for everything the search changes, so the frame
-            around it — the heading, the box being typed into, the buttons —
-            never moves. */}
         <div className="flex overflow-y-auto flex-col gap-5 pr-1 min-h-0 grow">
           <ul className="space-y-1">
             {offered.map((candidate) => (

--- a/frontend/components/PublicationMerge.tsx
+++ b/frontend/components/PublicationMerge.tsx
@@ -100,12 +100,6 @@ const Gained: FC<{ label: string; kept: string[]; gained: string[] }> = ({
   </div>
 );
 
-const items = (value: string) =>
-  value
-    .split(",")
-    .map((item) => item.trim())
-    .filter(Boolean);
-
 /**
  * What the merge produces, before it is asked for: the survivor's countries,
  * publishers and sources with everything the others bring marked as gained.
@@ -117,34 +111,34 @@ const Preview: FC<{ winner: Publication; losers: Publication[] }> = ({
   losers,
 }) => {
   const result = Publication.merged(winner, losers);
-  const gained = (before: string[], after: string[]) =>
-    after.filter((value) => !before.includes(value));
 
-  const countries = gained(items(winner.countries), items(result.countries));
-  const publishers = gained(items(winner.publishers), items(result.publishers));
-  const references = gained(winner.references, result.references);
+  const rows = [
+    {
+      label: "Countries",
+      kept: Publication.items(winner.countries),
+      all: Publication.items(result.countries),
+    },
+    {
+      label: "Publishers",
+      kept: Publication.items(winner.publishers),
+      all: Publication.items(result.publishers),
+    },
+    { label: "References", kept: winner.references, all: result.references },
+  ].map(({ label, kept, all }) => ({
+    label,
+    kept,
+    gained: all.filter((value) => !kept.includes(value)),
+  }));
 
   return (
     <section aria-label="Result" className="space-y-2">
       <SectionHeading>Result</SectionHeading>
       <div className="space-y-1.5">
-        <Gained
-          label="Countries"
-          kept={items(winner.countries)}
-          gained={countries}
-        />
-        <Gained
-          label="Publishers"
-          kept={items(winner.publishers)}
-          gained={publishers}
-        />
-        <Gained
-          label="References"
-          kept={winner.references}
-          gained={references}
-        />
+        {rows.map((row) => (
+          <Gained key={row.label} {...row} />
+        ))}
       </div>
-      {countries.length + publishers.length + references.length === 0 && (
+      {rows.every((row) => row.gained.length === 0) && (
         <p className="text-xs text-gray-500">
           Nothing new to take — “{winner.title}” already says everything the
           others do. Merging still removes them.
@@ -283,32 +277,32 @@ const PublicationMerge: FC<Props> = ({
           </ul>
 
           {chosen.length > 0 && (
-            <section className="space-y-2">
-              <SectionHeading>Merging in</SectionHeading>
-              <ul className="space-y-1">
-                {chosen.map((picked) => (
-                  <li
-                    key={picked.id}
-                    className="flex gap-3 justify-between items-start py-1.5 px-3 rounded border border-indigo-200 bg-indigo-50"
-                  >
-                    <Summary publication={picked} />
-                    <Button
-                      label="Remove"
-                      variant="outline"
-                      width="fit"
-                      size="small"
-                      onClick={() =>
-                        setChosen(chosen.filter((p) => p.id !== picked.id))
-                      }
-                    />
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
+            <>
+              <section className="space-y-2">
+                <SectionHeading>Merging in</SectionHeading>
+                <ul className="space-y-1">
+                  {chosen.map((picked) => (
+                    <li
+                      key={picked.id}
+                      className="flex gap-3 justify-between items-start py-1.5 px-3 rounded border border-indigo-200 bg-indigo-50"
+                    >
+                      <Summary publication={picked} />
+                      <Button
+                        label="Remove"
+                        variant="outline"
+                        width="fit"
+                        size="small"
+                        onClick={() =>
+                          setChosen(chosen.filter((p) => p.id !== picked.id))
+                        }
+                      />
+                    </li>
+                  ))}
+                </ul>
+              </section>
 
-          {chosen.length > 0 && (
-            <Preview winner={publication} losers={chosen} />
+              <Preview winner={publication} losers={chosen} />
+            </>
           )}
         </div>
 

--- a/frontend/components/PublicationMerge.tsx
+++ b/frontend/components/PublicationMerge.tsx
@@ -23,15 +23,51 @@ type Props = {
   find?: (term: string) => Promise<Publication[]>;
 };
 
-/** One publication as a line: enough of it to tell two near-identical records apart. */
+// Everything but the two the heading already carries.
+const DETAILED = Publication.ATTRIBUTES.filter(
+  (key) => key !== "title" && key !== "year",
+);
+
+/**
+ * One publication in full.
+ *
+ * A merge is irreversible in the reader's mind long before it is in the
+ * database — the question it asks is whether two records are the same book, and
+ * that is decided on the details that near-identical records differ in. So
+ * nothing here is summarised away or truncated: every field the record holds,
+ * and every source, is on the page while the choice is being made.
+ */
 const Summary: FC<{ publication: Publication }> = ({ publication: p }) => (
   <div className="min-w-0">
-    <p className="text-sm truncate">
+    <p className="text-sm">
       {p.title} <span className="text-gray-600">({p.year})</span>
     </p>
-    <p className="text-xs text-gray-600 truncate">
-      {Publication.describeValue(p.countries, "countries")} · {p.publishers}
-    </p>
+    <dl className="mt-0.5 text-xs text-gray-600">
+      {DETAILED.map((key) => {
+        const value = Publication.describeValue(p[key] as string, key);
+
+        return value ? (
+          <div key={key} className="flex gap-1">
+            <dt className="text-gray-600 shrink-0">
+              {Publication.ATTRIBUTE_LABELS[key]}:
+            </dt>
+            <dd className="wrap-break-words">{value}</dd>
+          </div>
+        ) : null;
+      })}
+      {p.references?.length > 0 && (
+        <div className="flex gap-1">
+          <dt className="text-gray-600 shrink-0">Sources:</dt>
+          <dd className="wrap-break-words">
+            <ul>
+              {p.references.map((reference) => (
+                <li key={reference}>{reference}</li>
+              ))}
+            </ul>
+          </dd>
+        </div>
+      )}
+    </dl>
   </div>
 );
 
@@ -89,7 +125,7 @@ const Preview: FC<{ winner: Publication; losers: Publication[] }> = ({
   const references = gained(winner.references, result.references);
 
   return (
-    <section className="space-y-2">
+    <section aria-label="Result" className="space-y-2">
       <SectionHeading>Result</SectionHeading>
       <div className="space-y-1.5">
         <Gained
@@ -189,8 +225,11 @@ const PublicationMerge: FC<Props> = ({
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} label="Merge publications">
-      <div className="flex flex-col gap-5 p-8 w-full max-h-[80vh] overflow-y-auto">
-        <div className="space-y-1">
+      {/* The frame holds still: searching swaps what is listed, and a dialog
+          that grew and shrank under the reader as results arrived moved the
+          controls out from under the pointer. Only the results scroll. */}
+      <div className="flex flex-col gap-5 p-8 w-full h-full sm:h-[70vh]">
+        <div className="space-y-1 shrink-0">
           <h1 className="text-2xl font-normal">Merge into this publication</h1>
           <p className="text-sm text-gray-500">
             “{publication.title}” ({publication.year}) keeps its place. The
@@ -198,16 +237,16 @@ const PublicationMerge: FC<Props> = ({
           </p>
         </div>
 
-        <section className="space-y-2">
+        <section className="space-y-2 shrink-0">
           <SectionHeading>Find the duplicates</SectionHeading>
           <input
-            className="w-full py-2 px-3 bg-white rounded border border-gray-300 transition-colors outline-none placeholder:text-sm focus:bg-gray-100 hover:bg-gray-100"
+            className="w-full py-2 px-3 bg-white rounded border border-gray-300 transition-colors outline-none placeholder:text-sm focus:bg-gray-100 hover:bg-gray-100 shrink-0"
             placeholder="Search by title, author, publisher or country"
             aria-label="Search for publications to merge"
             value={term}
             onChange={handleTerm}
           />
-          <div aria-live="polite">
+          <div aria-live="polite" className="shrink-0">
             {searching ? (
               <p className="text-xs text-gray-500">Searching…</p>
             ) : (
@@ -219,11 +258,17 @@ const PublicationMerge: FC<Props> = ({
               )
             )}
           </div>
+        </section>
+
+        {/* One scroll region for everything the search changes, so the frame
+            around it — the heading, the box being typed into, the buttons —
+            never moves. */}
+        <div className="flex overflow-y-auto flex-col gap-5 pr-1 min-h-0 grow">
           <ul className="space-y-1">
             {offered.map((candidate) => (
               <li
                 key={candidate.id}
-                className="flex gap-3 justify-between items-center py-1.5 px-3 rounded border border-gray-200"
+                className="flex gap-3 justify-between items-start py-1.5 px-3 rounded border border-gray-200"
               >
                 <Summary publication={candidate} />
                 <Button
@@ -236,36 +281,38 @@ const PublicationMerge: FC<Props> = ({
               </li>
             ))}
           </ul>
-        </section>
 
-        {chosen.length > 0 && (
-          <section className="space-y-2">
-            <SectionHeading>Merging in</SectionHeading>
-            <ul className="space-y-1">
-              {chosen.map((picked) => (
-                <li
-                  key={picked.id}
-                  className="flex gap-3 justify-between items-center py-1.5 px-3 rounded border border-indigo-200 bg-indigo-50"
-                >
-                  <Summary publication={picked} />
-                  <Button
-                    label="Remove"
-                    variant="outline"
-                    width="fit"
-                    size="small"
-                    onClick={() =>
-                      setChosen(chosen.filter((p) => p.id !== picked.id))
-                    }
-                  />
-                </li>
-              ))}
-            </ul>
-          </section>
-        )}
+          {chosen.length > 0 && (
+            <section className="space-y-2">
+              <SectionHeading>Merging in</SectionHeading>
+              <ul className="space-y-1">
+                {chosen.map((picked) => (
+                  <li
+                    key={picked.id}
+                    className="flex gap-3 justify-between items-start py-1.5 px-3 rounded border border-indigo-200 bg-indigo-50"
+                  >
+                    <Summary publication={picked} />
+                    <Button
+                      label="Remove"
+                      variant="outline"
+                      width="fit"
+                      size="small"
+                      onClick={() =>
+                        setChosen(chosen.filter((p) => p.id !== picked.id))
+                      }
+                    />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
 
-        {chosen.length > 0 && <Preview winner={publication} losers={chosen} />}
+          {chosen.length > 0 && (
+            <Preview winner={publication} losers={chosen} />
+          )}
+        </div>
 
-        <div className="flex gap-3 justify-end">
+        <div className="flex gap-3 justify-end shrink-0">
           <Button
             label="Cancel"
             variant="outline"

--- a/frontend/e2e/merge-duplicates.spec.ts
+++ b/frontend/e2e/merge-duplicates.spec.ts
@@ -169,9 +169,9 @@ test("an admin merges duplicate records into one; it keeps its place and gains w
   await page.goto("/admin/publications/history");
   await mergedEntries.first().getByRole("button", { name: "Undo" }).click();
 
-  await expect(page.locator('li[data-action="unmerged"]').first()).toContainText(
-    "Gave back",
-  );
+  await expect(
+    page.locator('li[data-action="unmerged"]').first(),
+  ).toContainText("Gave back");
 
   // The records that left are in the database again, and the survivor has
   // given up what it had absorbed.

--- a/frontend/e2e/merge-duplicates.spec.ts
+++ b/frontend/e2e/merge-duplicates.spec.ts
@@ -129,12 +129,11 @@ test("an admin merges duplicate records into one; it keeps its place and gains w
     await expect(merged.getByRole("link", { name: value })).toBeVisible();
   }
 
-  // The log tells the survivor's side of it as an ordinary update, and the
-  // merge itself is not on offer to undo.
+  // The record's own log carries the merge, on the record that survived it.
   await merged.getByText("History").click();
-  await expect(
-    merged.locator('li[data-action="updated"]').first(),
-  ).toBeVisible();
+  const mergeEntry = merged.locator('li[data-action="merged"]').first();
+  await expect(mergeEntry).toBeVisible();
+  await expect(mergeEntry).toContainText("Took in");
   await page.keyboard.press("Escape");
 
   // Search agrees the duplicates are gone: the title finds one row, and the
@@ -150,19 +149,35 @@ test("an admin merges duplicate records into one; it keeps its place and gains w
   ).toHaveCount(1);
   await search.clear();
 
-  // The feed keeps both merges, attributed and refusing to be undone.
+  // The feed carries the merge as one entry, however many records it took in,
+  // and says which they were.
   await page.goto("/admin/publications/history");
   const mergedEntries = page.locator('li[data-action="merged"]');
-  await expect(mergedEntries).toHaveCount(2);
+  await expect(mergedEntries).toHaveCount(1);
   await expect(mergedEntries.first()).toContainText(CANONICAL);
-  await expect(
-    mergedEntries.first().getByRole("button", { name: "Undo" }),
-  ).toHaveCount(0);
+  await expect(mergedEntries.first()).toContainText("Took in");
 
-  // And the trash stays empty: nobody deleted those records, a merge absorbed
-  // them, and there is no putting one back.
+  // The trash stays empty: nobody deleted those records, a merge absorbed them,
+  // and they come back by taking the merge apart rather than being restored.
   await page.goto("/admin/publications/deleted");
   await expect(
     page.getByText("no publication is currently deleted"),
   ).toBeVisible();
+
+  // One act, so one thing to undo — and undoing it gives back everything the
+  // merge took, at once.
+  await page.goto("/admin/publications/history");
+  await mergedEntries.first().getByRole("button", { name: "Undo" }).click();
+
+  await expect(page.locator('li[data-action="unmerged"]').first()).toContainText(
+    "Gave back",
+  );
+
+  // The records that left are in the database again, and the survivor has
+  // given up what it had absorbed.
+  await page.goto("/");
+  await expectPublicationCount(page, CORPUS_SIZE + 2);
+  await expect(
+    indexTable(page).getByRole("row").filter({ hasText: CANONICAL }),
+  ).toHaveCount(3);
 });

--- a/frontend/e2e/merge-duplicates.spec.ts
+++ b/frontend/e2e/merge-duplicates.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from "./fixtures";
+import {
+  addPublicationRow,
+  expectPublicationCount,
+  indexTable,
+  openPublicationModal,
+  seedCorpus,
+  submitWorkspace,
+  CORPUS_SIZE,
+} from "./helpers";
+
+// The record the corpus seeds, and the two the journey enters beside it: the
+// same translation, entered again by people who each knew a different part of
+// it. One adds a country, a publisher and a source; the other adds only a
+// source. Together they are what a merge is for.
+const CANONICAL = "Dom Casmurro";
+
+const BRITISH_PRINTING = {
+  title: CANONICAL,
+  originalTitle: "Dom Casmurro",
+  year: "1953",
+  authors: "Helen Caldwell",
+  originalAuthors: "Machado de Assis",
+  country: "United Kingdom",
+  publisher: "W. H. Allen",
+};
+
+const SOURCED_COPY = {
+  title: CANONICAL,
+  originalTitle: "Dom Casmurro",
+  year: "1953",
+  authors: "Helen Caldwell",
+  originalAuthors: "Machado de Assis",
+  country: "Brazil",
+  publisher: "Livraria Garnier",
+};
+
+test("an admin merges duplicate records into one; it keeps its place and gains what they held", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+
+  // Two more records of the book the corpus already holds, each with a source
+  // of its own so the merge has provenance to reconcile.
+  await page.goto("/admin/publications/new");
+  await addPublicationRow(page, BRITISH_PRINTING);
+  await addPublicationRow(page, SOURCED_COPY);
+  await submitWorkspace(page, 2);
+
+  await page.goto("/");
+  await expectPublicationCount(page, CORPUS_SIZE + 2);
+  await expect(
+    indexTable(page).getByRole("row").filter({ hasText: CANONICAL }),
+  ).toHaveCount(3);
+
+  // The merge is asked from the record that survives it: the one the corpus
+  // seeded, published in the US by Noonday Press.
+  const details = await openPublicationModal(page, CANONICAL);
+  await details.getByRole("button", { name: "Merge" }).click();
+
+  const merge = page.getByRole("dialog", { name: "Merge publications" });
+  await expect(merge).toBeVisible();
+  await expect(merge).toContainText(CANONICAL);
+  // Nothing picked yet, so there is nothing to ask for.
+  await expect(
+    merge.getByRole("button", { name: "Merge publication" }),
+  ).toBeDisabled();
+
+  // Searching offers the duplicates and never the record being merged into:
+  // three rows carry this title, and only two are on offer.
+  await merge
+    .getByRole("textbox", { name: "Search for publications to merge" })
+    .fill(CANONICAL);
+  const offered = merge.getByRole("button", { name: "Add" });
+  await expect(offered).toHaveCount(2);
+
+  // Taking one shows what the record becomes, before it becomes it.
+  await offered.first().click();
+  await expect(merge.getByText("Result")).toBeVisible();
+  await expect(offered).toHaveCount(1);
+
+  // Taking the second too: both are listed as merging in, and the button
+  // counts them.
+  await offered.first().click();
+  await expect(merge.getByRole("button", { name: "Remove" })).toHaveCount(2);
+  const confirm = merge.getByRole("button", { name: "Merge 2 publications" });
+  await expect(confirm).toBeEnabled();
+
+  // Backing out abandons the picks: the dialog reopens knowing nothing.
+  await merge.getByRole("button", { name: "Cancel" }).click();
+  await expect(merge).toHaveCount(0);
+  await details.getByRole("button", { name: "Merge" }).click();
+  await expect(
+    merge.getByRole("button", { name: "Merge publication" }),
+  ).toBeDisabled();
+
+  await merge
+    .getByRole("textbox", { name: "Search for publications to merge" })
+    .fill(CANONICAL);
+  await expect(merge.getByRole("button", { name: "Add" })).toHaveCount(2);
+  await merge.getByRole("button", { name: "Add" }).first().click();
+  await merge.getByRole("button", { name: "Add" }).first().click();
+  await merge.getByRole("button", { name: "Merge 2 publications" }).click();
+
+  await expect(
+    page.locator("section[aria-label='Notifications']"),
+  ).toContainText(/Merged 2 publications/);
+
+  // One record where there were three, and it holds every country and
+  // publisher the three of them named.
+  await page.goto("/");
+  await expectPublicationCount(page, CORPUS_SIZE);
+  const survivor = indexTable(page)
+    .getByRole("row")
+    .filter({ hasText: CANONICAL });
+  await expect(survivor).toHaveCount(1);
+
+  // Each is a search link in the record's own sentence — the history section
+  // below repeats the same words as a diff, so the sentence is what is asked.
+  const merged = await openPublicationModal(page, CANONICAL);
+  for (const value of [
+    "Brazil",
+    "United Kingdom",
+    "United States of America",
+    "Noonday Press",
+    "W. H. Allen",
+    "Livraria Garnier",
+  ]) {
+    await expect(merged.getByRole("link", { name: value })).toBeVisible();
+  }
+
+  // The log tells the survivor's side of it as an ordinary update, and the
+  // merge itself is not on offer to undo.
+  await merged.getByText("History").click();
+  await expect(
+    merged.locator('li[data-action="updated"]').first(),
+  ).toBeVisible();
+  await page.keyboard.press("Escape");
+
+  // Search agrees the duplicates are gone: the title finds one row, and the
+  // publisher only one of them named finds that same row.
+  const search = page.getByRole("textbox", { name: "Search publications" });
+  await search.fill(CANONICAL);
+  await expect(
+    indexTable(page).getByRole("row").filter({ hasText: CANONICAL }),
+  ).toHaveCount(1);
+  await search.fill("W. H. Allen");
+  await expect(
+    indexTable(page).getByRole("row").filter({ hasText: CANONICAL }),
+  ).toHaveCount(1);
+  await search.clear();
+
+  // The feed keeps both merges, attributed and refusing to be undone.
+  await page.goto("/admin/publications/history");
+  const mergedEntries = page.locator('li[data-action="merged"]');
+  await expect(mergedEntries).toHaveCount(2);
+  await expect(mergedEntries.first()).toContainText(CANONICAL);
+  await expect(
+    mergedEntries.first().getByRole("button", { name: "Undo" }),
+  ).toHaveCount(0);
+
+  // And the trash stays empty: nobody deleted those records, a merge absorbed
+  // them, and there is no putting one back.
+  await page.goto("/admin/publications/deleted");
+  await expect(
+    page.getByText("no publication is currently deleted"),
+  ).toBeVisible();
+});

--- a/frontend/modules/publication/history.spec.ts
+++ b/frontend/modules/publication/history.spec.ts
@@ -1,5 +1,5 @@
 import type { FullHistoryEntry, SnapshotDiff } from "./model";
-import { keyOf, presentChanges, withChanges } from "./history";
+import { keyOf, presentAbsorbed, presentChanges, withChanges } from "./history";
 
 function snapshot(
   fields: Partial<FullHistoryEntry["snapshot"]> = {},
@@ -106,5 +106,59 @@ describe("withChanges", () => {
 describe("keyOf", () => {
   test("identifies an entry by publication and version", () => {
     expect(keyOf(entry(7, 3, "updated"))).toBe("7:3");
+  });
+});
+
+describe("presentAbsorbed", () => {
+  const absorbing = (
+    action: FullHistoryEntry["action"],
+    absorbed: FullHistoryEntry["absorbed"],
+  ) => ({ ...entry(1, 2, action), absorbed });
+
+  test("spells out a record a merge took in, field by field", () => {
+    const [change] = presentAbsorbed(
+      absorbing("merged", {
+        "9": snapshot({ title: "A British Printing" }),
+      }),
+    );
+
+    expect(change).toMatchObject({ kind: "absorbed", direction: "in" });
+    if (change.kind !== "absorbed")
+      throw new Error("expected an absorbed change");
+
+    const [record] = change.records;
+    expect(record.title).toBe("A British Printing");
+    // Every field it held, so the log says what became of the data — not only
+    // that something was taken in.
+    expect(record.fields.map((field) => field.label)).toContain("Translators");
+    expect(record.fields.map((field) => field.label)).toContain("Year");
+    expect(record.fields.map((field) => field.label)).not.toContain("Title");
+  });
+
+  test("an un-merge gives them back", () => {
+    const [change] = presentAbsorbed(
+      absorbing("unmerged", { "9": snapshot() }),
+    );
+
+    expect(change).toMatchObject({ kind: "absorbed", direction: "back" });
+  });
+
+  test("an entry that moved no records adds nothing", () => {
+    expect(presentAbsorbed(entry(1, 2, "updated"))).toEqual([]);
+    expect(presentAbsorbed(absorbing("merged", {}))).toEqual([]);
+  });
+
+  test("the whole record travels with the entry, sources included", () => {
+    const [change] = presentAbsorbed(
+      absorbing("merged", {
+        "9": snapshot({ references: ["Sousa, J. Bibliografia, 1955."] }),
+      }),
+    );
+
+    if (change.kind !== "absorbed")
+      throw new Error("expected an absorbed change");
+    expect(change.records[0].references).toEqual([
+      "Sousa, J. Bibliografia, 1955.",
+    ]);
   });
 });

--- a/frontend/modules/publication/history.spec.ts
+++ b/frontend/modules/publication/history.spec.ts
@@ -117,9 +117,9 @@ describe("presentAbsorbed", () => {
 
   test("spells out a record a merge took in, field by field", () => {
     const [change] = presentAbsorbed(
-      absorbing("merged", {
-        "9": snapshot({ title: "A British Printing" }),
-      }),
+      absorbing("merged", [
+        { id: 9, ...snapshot({ title: "A British Printing" }) },
+      ]),
     );
 
     expect(change).toMatchObject({ kind: "absorbed", direction: "in" });
@@ -137,7 +137,7 @@ describe("presentAbsorbed", () => {
 
   test("an un-merge gives them back", () => {
     const [change] = presentAbsorbed(
-      absorbing("unmerged", { "9": snapshot() }),
+      absorbing("unmerged", [{ id: 9, ...snapshot() }]),
     );
 
     expect(change).toMatchObject({ kind: "absorbed", direction: "back" });
@@ -145,14 +145,17 @@ describe("presentAbsorbed", () => {
 
   test("an entry that moved no records adds nothing", () => {
     expect(presentAbsorbed(entry(1, 2, "updated"))).toEqual([]);
-    expect(presentAbsorbed(absorbing("merged", {}))).toEqual([]);
+    expect(presentAbsorbed(absorbing("merged", []))).toEqual([]);
   });
 
   test("the whole record travels with the entry, sources included", () => {
     const [change] = presentAbsorbed(
-      absorbing("merged", {
-        "9": snapshot({ references: ["Sousa, J. Bibliografia, 1955."] }),
-      }),
+      absorbing("merged", [
+        {
+          id: 9,
+          ...snapshot({ references: ["Sousa, J. Bibliografia, 1955."] }),
+        },
+      ]),
     );
 
     if (change.kind !== "absorbed")

--- a/frontend/modules/publication/history.ts
+++ b/frontend/modules/publication/history.ts
@@ -19,7 +19,28 @@ type ReferencesChange = {
   reordered: boolean;
 };
 
-type Change = FieldChange | ReferencesChange;
+/** One record a merge took in, or an un-merge gave back, in full. */
+type AbsorbedRecord = {
+  /** The record's own id — two records a merge took in may well share a title. */
+  id: string;
+  title: string;
+  fields: { label: string; value: string }[];
+  references: string[];
+};
+
+/**
+ * The records that changed hands. A merge is one act over several
+ * publications, and the entry's diff can only speak for the one that survived
+ * it — this is the other side: everything the records that left were holding,
+ * which is what a reader needs to judge what the merge did to the data.
+ */
+type AbsorbedChange = {
+  kind: "absorbed";
+  direction: "in" | "back";
+  records: AbsorbedRecord[];
+};
+
+type Change = FieldChange | ReferencesChange | AbsorbedChange;
 
 /** An entry carrying the changes its action made — what the views render. */
 type WithChanges<T> = T & { changes: Change[] };
@@ -57,6 +78,40 @@ function presentChanges(diff: SnapshotDiff | null): Change[] {
 }
 
 /**
+ * The records an entry took in or gave back, spelled out in full.
+ *
+ * A merge's own diff says what the surviving record gained; it cannot say what
+ * the records that left were holding, and they are no longer anywhere to be
+ * looked up. So the entry carries them, and this renders each one whole — every
+ * field it had, and its sources — so the log answers what happened to the data
+ * rather than only what happened to the survivor.
+ */
+function presentAbsorbed(entry: PublicationHistoryEntry): Change[] {
+  const absorbed = Object.entries(entry.absorbed ?? {});
+  if (absorbed.length === 0) return [];
+
+  const records = absorbed.map(([id, publication]) => ({
+    id,
+    title: publication.title || "an untitled record",
+    fields: Publication.ATTRIBUTES.filter((key) => key !== "title")
+      .map((key) => ({
+        label: Publication.ATTRIBUTE_LABELS[key],
+        value: String(publication[key] ?? ""),
+      }))
+      .filter(({ value }) => value !== ""),
+    references: publication.references ?? [],
+  }));
+
+  return [
+    {
+      kind: "absorbed",
+      direction: entry.action === "merged" ? "in" : "back",
+      records,
+    },
+  ];
+}
+
+/**
  * Each entry paired with its rendered changes — resolved once, when the log is
  * fetched, so no view recomputes a diff while painting.
  */
@@ -65,9 +120,9 @@ function withChanges<T extends PublicationHistoryEntry>(
 ): WithChanges<T>[] {
   return entries.map((entry) => ({
     ...entry,
-    changes: presentChanges(entry.diff),
+    changes: [...presentChanges(entry.diff), ...presentAbsorbed(entry)],
   }));
 }
 
-export { keyOf, presentChanges, withChanges };
-export type { Change, WithChanges };
+export { keyOf, presentAbsorbed, presentChanges, withChanges };
+export type { AbsorbedRecord, Change, WithChanges };

--- a/frontend/modules/publication/history.ts
+++ b/frontend/modules/publication/history.ts
@@ -22,7 +22,7 @@ type ReferencesChange = {
 /** One record a merge took in, or an un-merge gave back, in full. */
 type AbsorbedRecord = {
   /** The record's own id — two records a merge took in may well share a title. */
-  id: string;
+  id: number;
   title: string;
   fields: { label: string; value: string }[];
   references: string[];
@@ -87,11 +87,11 @@ function presentChanges(diff: SnapshotDiff | null): Change[] {
  * rather than only what happened to the survivor.
  */
 function presentAbsorbed(entry: PublicationHistoryEntry): Change[] {
-  const absorbed = Object.entries(entry.absorbed ?? {});
+  const absorbed = entry.absorbed ?? [];
   if (absorbed.length === 0) return [];
 
-  const records = absorbed.map(([id, publication]) => ({
-    id,
+  const records = absorbed.map((publication) => ({
+    id: publication.id,
     title: publication.title || "an untitled record",
     fields: Publication.ATTRIBUTES.filter((key) => key !== "title")
       .map((key) => ({
@@ -125,4 +125,4 @@ function withChanges<T extends PublicationHistoryEntry>(
 }
 
 export { keyOf, presentAbsorbed, presentChanges, withChanges };
-export type { AbsorbedRecord, Change, WithChanges };
+export type { Change, WithChanges };

--- a/frontend/modules/publication/model.spec.ts
+++ b/frontend/modules/publication/model.spec.ts
@@ -6,7 +6,9 @@ import {
   describeError,
   describeValue,
   empty,
+  merged,
 } from "./model";
+import type { Publication } from "./model";
 
 describe("empty", () => {
   test("returns a publication with every attribute blank", () => {
@@ -122,5 +124,63 @@ describe("autocomplete", () => {
 
   test("resolves to an empty list for attributes without suggestions", async () => {
     await expect(autocomplete("anything", "year")).resolves.toEqual([]);
+  });
+});
+
+describe("merged", () => {
+  const publication = (fields: Partial<Publication>): Publication => ({
+    ...empty(),
+    ...fields,
+  });
+
+  test("keeps the survivor's own identity", () => {
+    const winner = publication({ id: 1, title: "Iracema", year: "1886" });
+    const loser = publication({ id: 2, title: "Iraçéma", year: "1922" });
+
+    const result = merged(winner, [loser]);
+
+    expect(result.id).toBe(1);
+    expect(result.title).toBe("Iracema");
+    expect(result.year).toBe("1886");
+  });
+
+  test("unions the countries and publishers of all of them", () => {
+    const winner = publication({
+      countries: "GB",
+      publishers: "Bickers & Son",
+    });
+    const losers = [
+      publication({ countries: "US, GB", publishers: "Noonday Press" }),
+      publication({ countries: "BR", publishers: "Bickers & Son" }),
+    ];
+
+    const result = merged(winner, losers);
+
+    expect(result.countries).toBe("BR, GB, US");
+    expect(result.publishers).toBe("Bickers & Son, Noonday Press");
+  });
+
+  test("takes every source none of the others already gave", () => {
+    const winner = publication({ references: ["Alves, 1990"] });
+    const losers = [
+      publication({ references: ["Alves, 1990", "Costa, 2001"] }),
+      publication({ references: ["Dias, 2011"] }),
+    ];
+
+    expect(merged(winner, losers).references).toEqual([
+      "Alves, 1990",
+      "Costa, 2001",
+      "Dias, 2011",
+    ]);
+  });
+
+  test("merging nothing in leaves the record as it stands", () => {
+    const winner = publication({
+      countries: "GB, US",
+      publishers: "Bickers & Son",
+      references: ["Alves, 1990"],
+    });
+
+    expect(merged(winner, [])).toEqual(winner);
   });
 });

--- a/frontend/modules/publication/model.spec.ts
+++ b/frontend/modules/publication/model.spec.ts
@@ -35,11 +35,24 @@ describe("describeValue", () => {
     );
   });
 
+  test("maps every code of a list — what a merged record holds", () => {
+    const [first, second] = Object.keys(COUNTRIES);
+
+    expect(describeValue(`${first}, ${second}`, "countries")).toBe(
+      `${COUNTRIES[first].label}, ${COUNTRIES[second].label}`,
+    );
+  });
+
   test("returns an unknown country code unchanged", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     expect(describeValue("__nope__", "countries")).toBe("__nope__");
     expect(warn).toHaveBeenCalled();
+
+    // One unknown code in a list does not cost the others their labels.
+    expect(describeValue(`${knownCode}, __nope__`, "countries")).toBe(
+      `${COUNTRIES[knownCode].label}, __nope__`,
+    );
 
     warn.mockRestore();
   });

--- a/frontend/modules/publication/model.ts
+++ b/frontend/modules/publication/model.ts
@@ -168,16 +168,17 @@ function merged(winner: Publication, losers: Publication[]): Publication {
 
 function describeValue(value: string, attribute: PublicationKey): string {
   if (attribute === "countries") {
-    const country = COUNTRIES[value];
-    if (country) {
-      return value
-        .split(",")
-        .map((v) => COUNTRIES[v.trim()].label)
-        .join(", ");
-    } else {
-      console.warn("Unknown country code: ", value);
-      return value;
-    }
+    // One code or a list of them: a record published in several places names
+    // them all in the one field.
+    return value
+      .split(",")
+      .map((code) => {
+        const country = COUNTRIES[code.trim()];
+        if (country) return country.label;
+        console.warn("Unknown country code: ", code.trim());
+        return code.trim();
+      })
+      .join(", ");
   }
   return value;
 }

--- a/frontend/modules/publication/model.ts
+++ b/frontend/modules/publication/model.ts
@@ -31,7 +31,7 @@ type PublicationEntry = ValidationResult & { id: number };
 type PublicationId = NonNullable<Publication["id"]>;
 type PublicationKeyType = "array" | "text" | "enum" | "enumArray" | "number";
 type PublicationHistoryAction =
-  "created" | "updated" | "deleted" | "restored" | "merged";
+  "created" | "updated" | "deleted" | "restored" | "merged" | "unmerged";
 
 type SnapshotDiff = {
   fields: Partial<Record<PublicationKey, { from: unknown; to: unknown }>>;
@@ -46,6 +46,12 @@ type PublicationHistoryEntry = {
   snapshot: Omit<Publication, "id" | "year"> & { year: number };
   diff: SnapshotDiff | null;
   undoable: boolean;
+  /**
+   * The publications this entry took in (a merge) or gave back (an un-merge),
+   * keyed by id — a merge is one act over several records, and this is what
+   * says which. Absent on entries that change one record only.
+   */
+  absorbed?: Record<string, Publication> | null;
 };
 
 // The database-wide feed tags each entry with the publication it belongs to.

--- a/frontend/modules/publication/model.ts
+++ b/frontend/modules/publication/model.ts
@@ -38,12 +38,18 @@ type SnapshotDiff = {
   references: { added: string[]; removed: string[]; reordered: boolean } | null;
 };
 
+/**
+ * A publication as the log keeps it: the record's own fields, without the
+ * surrogate id, and with the year as the number it is stored as.
+ */
+type PublicationSnapshot = Omit<Publication, "id" | "year"> & { year: number };
+
 type PublicationHistoryEntry = {
   version: number;
   action: PublicationHistoryAction;
   actor: string;
   timestamp: string;
-  snapshot: Omit<Publication, "id" | "year"> & { year: number };
+  snapshot: PublicationSnapshot;
   diff: SnapshotDiff | null;
   undoable: boolean;
   /**
@@ -51,7 +57,7 @@ type PublicationHistoryEntry = {
    * keyed by id — a merge is one act over several records, and this is what
    * says which. Absent on entries that change one record only.
    */
-  absorbed?: Record<string, Publication> | null;
+  absorbed?: Record<string, PublicationSnapshot> | null;
 };
 
 // The database-wide feed tags each entry with the publication it belongs to.

--- a/frontend/modules/publication/model.ts
+++ b/frontend/modules/publication/model.ts
@@ -30,8 +30,17 @@ type ValidationResult = { publication: Publication; errors: PublicationError };
 type PublicationEntry = ValidationResult & { id: number };
 type PublicationId = NonNullable<Publication["id"]>;
 type PublicationKeyType = "array" | "text" | "enum" | "enumArray" | "number";
-type PublicationHistoryAction =
-  "created" | "updated" | "deleted" | "restored" | "merged" | "unmerged";
+/** Every act the log records, in the order a reader meets them. */
+const HISTORY_ACTIONS = [
+  "created",
+  "updated",
+  "deleted",
+  "restored",
+  "merged",
+  "unmerged",
+] as const;
+
+type PublicationHistoryAction = (typeof HISTORY_ACTIONS)[number];
 
 type SnapshotDiff = {
   fields: Partial<Record<PublicationKey, { from: unknown; to: unknown }>>;
@@ -44,6 +53,13 @@ type SnapshotDiff = {
  */
 type PublicationSnapshot = Omit<Publication, "id" | "year"> & { year: number };
 
+/**
+ * A publication a merge took in, or an un-merge gave back. Identified, unlike
+ * a snapshot: an entry names several of these at once, and two records that
+ * were merged may well share a title.
+ */
+type AbsorbedPublication = PublicationSnapshot & { id: number };
+
 type PublicationHistoryEntry = {
   version: number;
   action: PublicationHistoryAction;
@@ -53,11 +69,11 @@ type PublicationHistoryEntry = {
   diff: SnapshotDiff | null;
   undoable: boolean;
   /**
-   * The publications this entry took in (a merge) or gave back (an un-merge),
-   * keyed by id — a merge is one act over several records, and this is what
-   * says which. Absent on entries that change one record only.
+   * The publications this entry took in (a merge) or gave back (an un-merge) —
+   * a merge is one act over several records, and this is what says which.
+   * Absent on entries that change one record only.
    */
-  absorbed?: Record<string, PublicationSnapshot> | null;
+  absorbed?: AbsorbedPublication[] | null;
 };
 
 // The database-wide feed tags each entry with the publication it belongs to.
@@ -144,6 +160,18 @@ function empty(): Publication {
 }
 
 /**
+ * The individual values behind a multi-valued attribute. Countries, publishers
+ * and the like are held as one comma-joined string; this is the one place that
+ * knows it, so every reader of them counts and compares the same things.
+ */
+function items(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+/**
  * What one record would look like with others folded into it: the survivor's
  * own fields, the countries and publishers of all of them, and every source
  * none of the others already gave.
@@ -157,16 +185,7 @@ function merged(winner: Publication, losers: Publication[]): Publication {
   const all = [winner, ...losers];
 
   const union = (attribute: "countries" | "publishers") =>
-    Array.from(
-      new Set(
-        all.flatMap((p) =>
-          p[attribute]
-            .split(",")
-            .map((value) => value.trim())
-            .filter(Boolean),
-        ),
-      ),
-    )
+    Array.from(new Set(all.flatMap((p) => items(p[attribute]))))
       .sort()
       .join(", ");
 
@@ -270,6 +289,7 @@ const Publication = {
   describeError,
   describeValue,
   empty,
+  items,
   merged,
 };
 
@@ -285,10 +305,13 @@ export {
   describeError,
   describeValue,
   empty,
+  HISTORY_ACTIONS,
+  items,
   merged,
   Publication,
 };
 export type {
+  AbsorbedPublication,
   DeletedPublicationEntry,
   FullHistoryEntry,
   PublicationEntry,

--- a/frontend/modules/publication/model.ts
+++ b/frontend/modules/publication/model.ts
@@ -30,7 +30,8 @@ type ValidationResult = { publication: Publication; errors: PublicationError };
 type PublicationEntry = ValidationResult & { id: number };
 type PublicationId = NonNullable<Publication["id"]>;
 type PublicationKeyType = "array" | "text" | "enum" | "enumArray" | "number";
-type PublicationHistoryAction = "created" | "updated" | "deleted" | "restored";
+type PublicationHistoryAction =
+  "created" | "updated" | "deleted" | "restored" | "merged";
 
 type SnapshotDiff = {
   fields: Partial<Record<PublicationKey, { from: unknown; to: unknown }>>;
@@ -130,6 +131,41 @@ function empty(): Publication {
   };
 }
 
+/**
+ * What one record would look like with others folded into it: the survivor's
+ * own fields, the countries and publishers of all of them, and every source
+ * none of the others already gave.
+ *
+ * A preview, so an admin sees the outcome before asking for it. The server
+ * reconciles a merge itself and stays the authority on what it produces; the
+ * rules are simple enough to say twice, and saying them here is what lets the
+ * dialog show the result rather than describe it.
+ */
+function merged(winner: Publication, losers: Publication[]): Publication {
+  const all = [winner, ...losers];
+
+  const union = (attribute: "countries" | "publishers") =>
+    Array.from(
+      new Set(
+        all.flatMap((p) =>
+          p[attribute]
+            .split(",")
+            .map((value) => value.trim())
+            .filter(Boolean),
+        ),
+      ),
+    )
+      .sort()
+      .join(", ");
+
+  return {
+    ...winner,
+    countries: union("countries"),
+    publishers: union("publishers"),
+    references: Array.from(new Set(all.flatMap((p) => p.references))),
+  };
+}
+
 function describeValue(value: string, attribute: PublicationKey): string {
   if (attribute === "countries") {
     const country = COUNTRIES[value];
@@ -221,6 +257,7 @@ const Publication = {
   describeError,
   describeValue,
   empty,
+  merged,
 };
 
 export {
@@ -235,6 +272,7 @@ export {
   describeError,
   describeValue,
   empty,
+  merged,
   Publication,
 };
 export type {

--- a/frontend/modules/publication/remote.spec.ts
+++ b/frontend/modules/publication/remote.spec.ts
@@ -11,7 +11,9 @@ import { empty } from "./model";
 import {
   bulk,
   deletePublication,
+  merge,
   restore,
+  search,
   undo,
   update,
   upload,
@@ -240,6 +242,67 @@ describe("restore", () => {
       expect.objectContaining({
         level: "warning",
         detail: expect.stringContaining("imported again while deleted"),
+      }),
+    );
+  });
+});
+
+describe("search", () => {
+  test("asks the index for the term and answers with its entries", async () => {
+    const entries = [pub({ title: "Iracema" })];
+    http.get.mockResolvedValue({ data: { entries } });
+
+    const found = await search("iracema");
+
+    expect(http.get).toHaveBeenCalledWith("publications", {
+      params: { search: "iracema" },
+    });
+    expect(found).toBe(entries);
+  });
+
+  test("a failed search finds nothing rather than interrupting", async () => {
+    http.get.mockRejectedValue(new Error("offline"));
+
+    expect(await search("iracema")).toEqual([]);
+    // The view showing the search says so where the results would be.
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+});
+
+describe("merge", () => {
+  const winner = { ...pub({ title: "Iracema" }), id: 1 };
+  const losers = [
+    { ...pub({ title: "Iracema" }), id: 2 },
+    { ...pub({ title: "Iracema" }), id: 3 },
+  ];
+
+  test("names the losers in the body and drops them from the index", async () => {
+    losers.forEach((loser) => store.set(publicationFamily(loser.id), loser));
+    store.set(publicationIdsAtom, [1, 2, 3]);
+    http.post.mockResolvedValue({});
+
+    const ok = await merge(store, { winner, losers });
+
+    expect(ok).toBe(true);
+    expect(http.post).toHaveBeenCalledWith("publications/1/merge", {
+      losers: [2, 3],
+    });
+    expect(store.get(publicationIdsAtom)).toEqual([1]);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ level: "success" }),
+    );
+  });
+
+  test("a 409 explains the merged record would already exist", async () => {
+    http.post.mockRejectedValue({ response: { status: 409 } });
+
+    const ok = await merge(store, { winner, losers });
+
+    expect(ok).toBe(false);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        level: "warning",
+        detail: expect.stringContaining("already holds"),
       }),
     );
   });

--- a/frontend/modules/publication/remote.ts
+++ b/frontend/modules/publication/remote.ts
@@ -232,6 +232,63 @@ async function restore(id: PublicationId): Promise<boolean> {
 }
 
 /**
+ * The publications a term finds, for a view that has to look one up while it is
+ * open — the merge dialog searching for the duplicates of a record it is
+ * showing. A failed search finds nothing rather than interrupting: the dialog
+ * says so where the results would be.
+ */
+async function search(term: string): Promise<Publication[]> {
+  try {
+    const { data } = await request((http) =>
+      http.get<{ entries: Publication[] }>("publications", {
+        params: { search: term },
+      }),
+    );
+    return data.entries;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Collapse publications into one (admin). The survivor keeps its identity and
+ * gains what the others hold; they leave the database recorded as merged.
+ * Returns whether it succeeded — a conflict means the merged record would be
+ * one that already exists.
+ */
+async function merge(
+  store: Store,
+  { winner, losers }: { winner: Publication; losers: Publication[] },
+): Promise<boolean> {
+  const ids = losers.map((loser) => loser.id!);
+
+  try {
+    await request((http) =>
+      http.post(`publications/${winner.id}/merge`, { losers: ids }),
+    );
+
+    ids.forEach((id) => removePublication(store, id));
+    notify({
+      message: `Merged ${ids.length === 1 ? "1 publication" : `${ids.length} publications`}`,
+      detail: `“${winner.title}” now holds what they said.`,
+      level: "success",
+    });
+    return true;
+  } catch (error) {
+    notify({
+      message: isConflict(error)
+        ? "Could not merge — the result already exists"
+        : "Could not merge the publications",
+      detail: isConflict(error)
+        ? "Another publication already holds what the merged record would. Merge that one instead."
+        : "Nothing changed. Check your connection and try again.",
+      level: "warning",
+    });
+    return false;
+  }
+}
+
+/**
  * Live-validate a single publication's pending edits, excluding it from the
  * conflict check so an in-place edit doesn't collide with itself.
  */
@@ -313,7 +370,9 @@ export {
   bulk,
   deletePublication,
   loadDetails,
+  merge,
   restore,
+  search,
   undo,
   update,
   upload,


### PR DESCRIPTION
A record that says the same thing twice is one record whose countries, publishers and sources were entered piecemeal. An admin can now collapse duplicates into the publication that keeps its place: find them from the record itself, see what it becomes, and confirm.

The survivor keeps its identity and gains what the others hold; they leave the database recorded as merged rather than deleted, so the trash stays what someone deleted. A merge is deliberately not undoable — putting a record back would leave what it brought with the survivor, and there would be two of everything again — which is why the dialog shows the outcome before it asks.
