### PR TITLE
Suggest the original book as a whole

### DIFF
--- a/backend/lib/richard_burton/original_book.ex
+++ b/backend/lib/richard_burton/original_book.ex
@@ -4,6 +4,7 @@ defmodule RichardBurton.OriginalBook do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  import Ecto.Query
   import RichardBurton.Validation
 
   alias RichardBurton.Author
@@ -58,6 +59,53 @@ defmodule RichardBurton.OriginalBook do
 
   def all() do
     OriginalBook |> Repo.all() |> preload
+  end
+
+  @doc """
+  The original books a term names, by their title or by one of their authors.
+
+  A book is entered as a unit — a title and who wrote it — and looking it up
+  should work from whichever half the person typing happens to know. Prefixes
+  first, so what someone is part-way through typing wins; only when nothing
+  starts that way does the search fall back to similar spellings.
+  """
+  def search(term) when is_binary(term) do
+    case search(term, :prefix) do
+      [] -> search(term, :fuzzy)
+      books -> books
+    end
+  end
+
+  def search(term, :prefix) when is_binary(term) do
+    matching(
+      dynamic(
+        [b, a],
+        ilike(b.title, ^"#{term}%") or ilike(a.name, ^"#{term}%")
+      )
+    )
+  end
+
+  def search(term, :fuzzy) when is_binary(term) do
+    matching(
+      dynamic(
+        [b, a],
+        fragment("similarity((?), (?)) > 0.3", b.title, ^term) or
+          fragment("similarity((?), (?)) > 0.3", a.name, ^term)
+      )
+    )
+  end
+
+  # A book joined to its authors matches once per author, so the rows are
+  # deduplicated before they are counted as answers.
+  defp matching(condition) do
+    from(b in OriginalBook,
+      join: a in assoc(b, :authors),
+      where: ^condition,
+      distinct: true,
+      order_by: [asc: b.title]
+    )
+    |> Repo.all()
+    |> preload()
   end
 
   def preload(data) do

--- a/backend/lib/richard_burton/original_book.ex
+++ b/backend/lib/richard_burton/original_book.ex
@@ -77,21 +77,23 @@ defmodule RichardBurton.OriginalBook do
   end
 
   def search(term, :prefix) when is_binary(term) do
-    matching(
-      dynamic(
-        [b, a],
-        ilike(b.title, ^"#{term}%") or ilike(a.name, ^"#{term}%")
-      )
-    )
+    matching(dynamic(^starts_with(:book, :title, term) or ^starts_with(:author, :name, term)))
   end
 
   def search(term, :fuzzy) when is_binary(term) do
-    matching(
-      dynamic(
-        [b, a],
-        fragment("similarity((?), (?)) > 0.3", b.title, ^term) or
-          fragment("similarity((?), (?)) > 0.3", a.name, ^term)
-      )
+    matching(dynamic(^similar_to(:book, :title, term) or ^similar_to(:author, :name, term)))
+  end
+
+  defp starts_with(binding, field, term) do
+    dynamic(ilike(field(as(^binding), ^field), ^"#{term}%"))
+  end
+
+  # How much of a name a misspelling has to share to still answer for it.
+  @similarity 0.3
+
+  defp similar_to(binding, field, term) do
+    dynamic(
+      fragment("similarity((?), (?)) > ?", field(as(^binding), ^field), ^term, ^@similarity)
     )
   end
 
@@ -99,13 +101,31 @@ defmodule RichardBurton.OriginalBook do
   # deduplicated before they are counted as answers.
   defp matching(condition) do
     from(b in OriginalBook,
+      as: :book,
       join: a in assoc(b, :authors),
+      as: :author,
       where: ^condition,
       distinct: true,
       order_by: [asc: b.title]
     )
     |> Repo.all()
     |> preload()
+  end
+
+  @doc ~S"""
+  Flatten a book to the shape a form speaks of it in: a title, and its authors
+  as the one comma-separated string the field holds.
+
+  ## Examples
+
+    iex> RichardBurton.OriginalBook.flatten(%RichardBurton.OriginalBook{
+    ...>   title: "Dom Casmurro",
+    ...>   authors: [%RichardBurton.Author{name: "Machado de Assis"}]
+    ...> })
+    %{title: "Dom Casmurro", authors: "Machado de Assis"}
+  """
+  def flatten(book = %OriginalBook{}) do
+    %{title: book.title, authors: Author.flatten(book.authors)}
   end
 
   def preload(data) do

--- a/backend/lib/richard_burton_web/controllers/original_book_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/original_book_controller.ex
@@ -1,0 +1,20 @@
+defmodule RichardBurtonWeb.OriginalBookController do
+  use RichardBurtonWeb, :controller
+
+  alias RichardBurton.Author
+  alias RichardBurton.OriginalBook
+
+  def index(conn, %{"search" => query}) do
+    json(conn, Enum.map(OriginalBook.search(query), &flatten/1))
+  end
+
+  def index(conn, _params) do
+    json(conn, Enum.map(OriginalBook.all(), &flatten/1))
+  end
+
+  # A book as the form speaks of it: a title, and its authors as the one comma
+  # separated string the field holds.
+  defp flatten(book) do
+    %{title: book.title, authors: Author.flatten(book.authors)}
+  end
+end

--- a/backend/lib/richard_burton_web/controllers/original_book_controller.ex
+++ b/backend/lib/richard_burton_web/controllers/original_book_controller.ex
@@ -1,20 +1,13 @@
 defmodule RichardBurtonWeb.OriginalBookController do
   use RichardBurtonWeb, :controller
 
-  alias RichardBurton.Author
   alias RichardBurton.OriginalBook
 
   def index(conn, %{"search" => query}) do
-    json(conn, Enum.map(OriginalBook.search(query), &flatten/1))
+    json(conn, Enum.map(OriginalBook.search(query), &OriginalBook.flatten/1))
   end
 
   def index(conn, _params) do
-    json(conn, Enum.map(OriginalBook.all(), &flatten/1))
-  end
-
-  # A book as the form speaks of it: a title, and its authors as the one comma
-  # separated string the field holds.
-  defp flatten(book) do
-    %{title: book.title, authors: Author.flatten(book.authors)}
+    json(conn, Enum.map(OriginalBook.all(), &OriginalBook.flatten/1))
   end
 end

--- a/backend/lib/richard_burton_web/router.ex
+++ b/backend/lib/richard_burton_web/router.ex
@@ -56,6 +56,7 @@ defmodule RichardBurtonWeb.Router do
 
     get("/authors", AuthorController, :index)
     get("/publishers", PublisherController, :index)
+    get("/original-books", OriginalBookController, :index)
 
     scope "/publications" do
       post("/bulk", PublicationController, :create_all)

--- a/backend/test/richard_burton/original_book_test.exs
+++ b/backend/test/richard_burton/original_book_test.exs
@@ -219,4 +219,62 @@ defmodule RichardBurton.OriginalBookTest do
       assert is_nil(linked_fingerprint(changeset))
     end
   end
+
+  describe "search/1" do
+    setup [:search_fixture]
+
+    test "finds a book by the start of its title" do
+      assert ["Dom Casmurro"] = titles(OriginalBook.search("Dom Cas"))
+    end
+
+    test "finds a book by the start of an author's name" do
+      # The book is entered as a unit, so knowing either half is enough to
+      # find it.
+      assert ["Dom Casmurro", "Manuel de Moraes", "Memórias Póstumas"] =
+               titles(OriginalBook.search("Machado"))
+    end
+
+    test "answers each book once, however many of its authors match" do
+      assert ["Manuel de Moraes"] = titles(OriginalBook.search("J. M."))
+    end
+
+    test "falls back to similar spellings when nothing starts that way" do
+      assert [] == OriginalBook.search("Machada", :prefix)
+
+      assert ["Dom Casmurro", "Manuel de Moraes", "Memórias Póstumas"] =
+               titles(OriginalBook.search("Machada"))
+    end
+
+    test "carries the authors of every book it finds" do
+      assert [book] = OriginalBook.search("Dom Cas")
+      assert Author.flatten(book.authors) == "Machado de Assis"
+    end
+
+    defp titles(books), do: Enum.map(books, & &1.title)
+
+    defp search_fixture(_context) do
+      OriginalBook.maybe_insert!(%{
+        "title" => "Dom Casmurro",
+        "authors" => [%{"name" => "Machado de Assis"}]
+      })
+
+      OriginalBook.maybe_insert!(%{
+        "title" => "Memórias Póstumas",
+        "authors" => [%{"name" => "Machado de Assis"}]
+      })
+
+      # Two of its authors answer to "J. M.", so a search for that would find
+      # this book twice if the rows were not deduplicated.
+      OriginalBook.maybe_insert!(%{
+        "title" => "Manuel de Moraes",
+        "authors" => [
+          %{"name" => "Machado de Assis"},
+          %{"name" => "J. M. Pereira da Silva"},
+          %{"name" => "J. M. Velho da Silva"}
+        ]
+      })
+
+      :ok
+    end
+  end
 end

--- a/backend/test/richard_burton_web/controllers/original_book_controller_test.exs
+++ b/backend/test/richard_burton_web/controllers/original_book_controller_test.exs
@@ -1,0 +1,66 @@
+defmodule RichardBurtonWeb.OriginalBookControllerTest do
+  @moduledoc """
+  Tests for the OriginalBook controller
+  """
+  use RichardBurtonWeb.ConnCase
+  import Routes, only: [original_book_path: 2]
+
+  alias RichardBurton.OriginalBook
+
+  @books [
+    %{"title" => "Dom Casmurro", "authors" => [%{"name" => "Machado de Assis"}]},
+    %{
+      "title" => "Iracema",
+      "authors" => [%{"name" => "José de Alencar"}]
+    },
+    %{
+      "title" => "Manuel de Moraes",
+      "authors" => [
+        %{"name" => "Machado de Assis"},
+        %{"name" => "J. M. Pereira da Silva"}
+      ]
+    }
+  ]
+
+  def search_fixture(_) do
+    Enum.each(@books, &OriginalBook.maybe_insert!/1)
+    []
+  end
+
+  describe "GET /original-books" do
+    setup [:search_fixture]
+
+    test "returns every book, its authors as the one string the field holds",
+         %{conn: conn} do
+      expect_auth_authorize_admin()
+
+      assert [
+               %{"title" => "Dom Casmurro", "authors" => "Machado de Assis"},
+               %{"title" => "Iracema", "authors" => "José de Alencar"},
+               %{
+                 "title" => "Manuel de Moraes",
+                 "authors" => "Machado de Assis, J. M. Pereira da Silva"
+               }
+             ] = conn |> get(original_book_path(conn, :index)) |> json_response(200)
+    end
+
+    test "a search finds a book by its title or by one of its authors", %{conn: conn} do
+      expect_auth_authorize_admin(2)
+
+      assert [%{"title" => "Dom Casmurro"}] =
+               conn
+               |> get(original_book_path(conn, :index), %{"search" => "Dom"})
+               |> json_response(200)
+
+      assert [%{"title" => "Dom Casmurro"}, %{"title" => "Manuel de Moraes"}] =
+               conn
+               |> get(original_book_path(conn, :index), %{"search" => "Machado"})
+               |> json_response(200)
+    end
+
+    test "returns 401 without a session cookie", %{conn: conn} do
+      path = original_book_path(conn, :index)
+      assert build_conn() |> get(path) |> response(401) == "Unauthorized"
+    end
+  end
+end

--- a/frontend/components/DataInput.mdx
+++ b/frontend/components/DataInput.mdx
@@ -8,8 +8,11 @@ import * as DataInputStories from "./DataInput.stories";
 
 The editable table cell used across the publication workspace. It is a
 **dispatcher**: given a cell's `rowId` and `colId`, it looks up the column's
-attribute type (`text`, `number`, `array`, `enum`, or `enumArray`) and renders
-the matching concrete editor — one of the `Text*DataInput` variants below.
+attribute type (`text`, `number`, `array`, `enum`, `enumArray`, or `book`) and
+renders the matching concrete editor — one of the `Text*DataInput` variants
+below, or the
+[original book field](?path=/docs/publications-original-book-data-input--docs),
+which is the only `book` column and fills its neighbour as well as itself.
 
 ## Data flow
 

--- a/frontend/components/DataInput.tsx
+++ b/frontend/components/DataInput.tsx
@@ -10,6 +10,7 @@ import { validate } from "modules/publication/remote";
 import { usePublicationStore } from "modules/publication/workspace";
 import { overrideField } from "modules/publication/store";
 import { FC, FocusEvent, HTMLProps, Ref, forwardRef } from "react";
+import OriginalBookDataInput from "./OriginalBookDataInput";
 import TextArrayDataInput from "./TextArrayDataInput";
 import TextDataInput from "./TextDataInput";
 import TextEnumArrayDataInput from "./TextEnumArrayDataInput";
@@ -23,6 +24,7 @@ const COMPONENTS_PER_TYPE: Record<PublicationKeyType, FC<Props>> = {
   enumArray: TextEnumArrayDataInput,
   number: TextNumberDataInput,
   array: TextArrayDataInput,
+  book: OriginalBookDataInput,
 };
 
 /**

--- a/frontend/components/MenuProvider.tsx
+++ b/frontend/components/MenuProvider.tsx
@@ -15,14 +15,7 @@ import {
   useRole,
 } from "@floating-ui/react";
 import { isString } from "lodash";
-import {
-  cloneElement,
-  FC,
-  ReactElement,
-  Ref,
-  useMemo,
-  useRef,
-} from "react";
+import { cloneElement, FC, ReactElement, Ref, useMemo, useRef } from "react";
 import { mergeRefs } from "react-merge-refs";
 import Menu from "./Menu";
 import MenuItem from "./MenuItem";

--- a/frontend/components/MenuProvider.tsx
+++ b/frontend/components/MenuProvider.tsx
@@ -15,12 +15,23 @@ import {
   useRole,
 } from "@floating-ui/react";
 import { isString } from "lodash";
-import { cloneElement, ReactElement, Ref, useMemo, useRef } from "react";
+import {
+  cloneElement,
+  FC,
+  ReactElement,
+  Ref,
+  useMemo,
+  useRef,
+} from "react";
 import { mergeRefs } from "react-merge-refs";
 import Menu from "./Menu";
 import MenuItem from "./MenuItem";
 
-type Option = { id: string; label: string };
+/**
+ * An option, and optionally what qualifies it — a second line under the label,
+ * set quieter, for when the label alone does not tell two entries apart.
+ */
+type Option = { id: string; label: string; description?: string };
 
 type Props<OptionType extends Option | string> = {
   children: ReactElement;
@@ -34,6 +45,18 @@ type Props<OptionType extends Option | string> = {
   /** Shown in place of the list when there is nothing to offer. */
   emptyMessage?: string;
 };
+
+const OptionContent: FC<{ option: Option | string }> = ({ option }) =>
+  isString(option) ? (
+    <>{option}</>
+  ) : option.description ? (
+    <span className="flex flex-col">
+      <span>{option.label}</span>
+      <span className="text-xs text-gray-600">{option.description}</span>
+    </span>
+  ) : (
+    <>{option.label}</>
+  );
 
 const MenuProvider = <OptionType extends Option | string>({
   children,
@@ -140,7 +163,7 @@ const MenuProvider = <OptionType extends Option | string>({
                       },
                     })}
                   >
-                    {isString(option) ? option : option.label}
+                    <OptionContent option={option} />
                   </MenuItem>
                 ))
               )}

--- a/frontend/components/OriginalBookDataInput.mdx
+++ b/frontend/components/OriginalBookDataInput.mdx
@@ -1,0 +1,46 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+
+import * as OriginalBookDataInputStories from "./OriginalBookDataInput.stories";
+
+<Meta of={OriginalBookDataInputStories} />
+
+# Original book data input
+
+The original-title cell, offering the books already in the database. It is the
+field [`DataInput`](?path=/docs/publications-data-input--docs) picks for the
+`book` attribute type, which only `originalTitle` has.
+
+<Canvas of={OriginalBookDataInputStories.Suggesting} />
+
+## Why a whole book
+
+The original book is one entity — a title and its authors — and the publication's
+composite key is built from both. Entering them field by field is how the same
+book drifts into near-duplicates ("Machado de Assis" one day, "M. de Assis" the
+next), and a drifted book spawns a duplicate _publication_.
+
+So a suggestion carries the whole book and fills both fields at once, and a
+term finds a book by either half of it: the title, or one of its authors.
+
+<Canvas of={OriginalBookDataInputStories.FoundByItsAuthor} />
+
+## Usage
+
+Rendered by the dispatcher, never directly — it reads `rowId` to write the
+authors of the book that was picked into that row's own field, and takes its
+placeholder and `bordered` from whoever placed it.
+
+Free text stands: a book nobody has entered yet is typed, and the field keeps
+what it is given. A lookup that fails offers nothing rather than interrupting.
+
+<Canvas of={OriginalBookDataInputStories.FreeTextStands} />
+
+## States
+
+- **Suggesting** — a term offers whole books, title and authors.
+- **Found by its author** — the same search, reached from the other half.
+- **Fills both fields** — picking one writes the title here and the authors
+  there.
+- **Free text stands** — an unknown book is simply typed.
+
+<Canvas of={OriginalBookDataInputStories.FillsBothFields} />

--- a/frontend/components/OriginalBookDataInput.stories.tsx
+++ b/frontend/components/OriginalBookDataInput.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { OriginalBook, type OriginalBookValue } from "modules/original-book";
+import { empty } from "modules/publication/model";
+import {
+  publicationFamily,
+  resetAll,
+  visiblePublicationFamily,
+} from "modules/publication/store";
+import { store } from "modules/store";
+import { ComponentProps, FC, useState } from "react";
+import { expect, fn, screen, userEvent, waitFor, within } from "storybook/test";
+
+import OriginalBookDataInput from "./OriginalBookDataInput";
+
+const LIBRARY: OriginalBookValue[] = [
+  { title: "Dom Casmurro", authors: "Machado de Assis" },
+  { title: "Memórias Póstumas de Brás Cubas", authors: "Machado de Assis" },
+  {
+    title: "Manuel de Moraes",
+    authors: "Machado de Assis, J. M. Pereira da Silva",
+  },
+];
+
+/**
+ * Stand in for the database while a story runs. The module exposes its calls
+ * as one `REMOTE` object precisely so a caller can be given a different one.
+ */
+const withLibrary = (books: OriginalBookValue[]) => () => {
+  const answering = OriginalBook.REMOTE.search;
+
+  OriginalBook.REMOTE.search = async (term) =>
+    books.filter(
+      (book) =>
+        book.title.toLowerCase().includes(term.toLowerCase()) ||
+        book.authors.toLowerCase().includes(term.toLowerCase()),
+    );
+
+  return () => {
+    OriginalBook.REMOTE.search = answering;
+  };
+};
+
+// The field is controlled by the row it edits; hold the value here so what is
+// typed shows on screen.
+const Controlled: FC<ComponentProps<typeof OriginalBookDataInput>> = ({
+  value: initial,
+  onChange,
+  ...props
+}) => {
+  const [value, setValue] = useState(initial);
+
+  return (
+    <OriginalBookDataInput
+      {...props}
+      value={value}
+      onChange={(next) => {
+        setValue(next);
+        onChange?.(next);
+      }}
+    />
+  );
+};
+
+const ROW = 1;
+
+const meta = {
+  title: "Publications/Original book data input",
+  component: OriginalBookDataInput,
+  args: {
+    rowId: ROW,
+    colId: "originalTitle",
+    value: "",
+    error: "",
+    bordered: true,
+    // The dispatcher supplies this from the attribute's label; a story that
+    // renders the field on its own has to say it.
+    placeholder: "Original Title",
+    onChange: fn(),
+  },
+  render: (args) => <Controlled {...args} />,
+  beforeEach: [
+    () => {
+      resetAll(store);
+      store.set(publicationFamily(ROW), empty());
+    },
+    withLibrary(LIBRARY),
+  ],
+  decorators: [
+    (Story) => (
+      <div className="p-8 w-96 bg-white">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: "centered",
+    // The open menu renders focus guards (tabbable, aria-hidden) to trap focus
+    // — a deliberate pattern axe's aria-hidden-focus rule reads as a violation.
+    a11y: { config: { rules: [{ id: "aria-hidden-focus", enabled: false }] } },
+  },
+} satisfies Meta<typeof OriginalBookDataInput>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** A term offers whole books: the title, and who wrote it. */
+export const Suggesting: Story = {
+  play: async ({ canvasElement }) => {
+    await userEvent.type(
+      within(canvasElement).getByRole("combobox"),
+      "Dom Cas",
+    );
+
+    // `screen`, not the canvas: the menu is portalled out of the field.
+    await waitFor(async () =>
+      expect(
+        await screen.findByRole("option", {
+          name: "Dom Casmurro — Machado de Assis",
+        }),
+      ).toBeVisible(),
+    );
+  },
+};
+
+/** A term finds a book by its author too — either half of it will do. */
+export const FoundByItsAuthor: Story = {
+  play: async ({ canvasElement }) => {
+    await userEvent.type(
+      within(canvasElement).getByRole("combobox"),
+      "Machado",
+    );
+
+    await waitFor(async () =>
+      expect(await screen.findAllByRole("option")).toHaveLength(3),
+    );
+  },
+};
+
+/**
+ * Picking a book fills both fields: the title here, and the authors in the
+ * field that holds them. That is the point — entering the two apart is how the
+ * same book drifts into near-duplicates.
+ */
+export const FillsBothFields: Story = {
+  play: async ({ args, canvasElement }) => {
+    await userEvent.type(within(canvasElement).getByRole("combobox"), "Manuel");
+
+    await userEvent.click(
+      await screen.findByRole("option", {
+        name: "Manuel de Moraes — Machado de Assis, J. M. Pereira da Silva",
+      }),
+    );
+
+    await expect(args.onChange).toHaveBeenCalledWith("Manuel de Moraes");
+    // The other half went straight to its own field.
+    await waitFor(() =>
+      expect(store.get(visiblePublicationFamily(ROW)).originalAuthors).toBe(
+        "Machado de Assis, J. M. Pereira da Silva",
+      ),
+    );
+  },
+};
+
+/** A book nobody has entered yet is typed, and the field keeps what it is given. */
+export const FreeTextStands: Story = {
+  play: async ({ canvasElement }) => {
+    const input = within(canvasElement).getByRole("combobox");
+    await userEvent.type(input, "Uma Obra Inédita");
+
+    await expect(input).toHaveValue("Uma Obra Inédita");
+    await waitFor(async () =>
+      expect(screen.queryAllByRole("option")).toHaveLength(0),
+    );
+  },
+};

--- a/frontend/components/OriginalBookDataInput.stories.tsx
+++ b/frontend/components/OriginalBookDataInput.stories.tsx
@@ -116,7 +116,7 @@ export const Suggesting: Story = {
     await waitFor(async () =>
       expect(
         await screen.findByRole("option", {
-          name: "Dom Casmurro — Machado de Assis",
+          name: "Dom Casmurro Machado de Assis",
         }),
       ).toBeVisible(),
     );
@@ -148,7 +148,7 @@ export const FillsBothFields: Story = {
 
     await userEvent.click(
       await screen.findByRole("option", {
-        name: "Manuel de Moraes — Machado de Assis, J. M. Pereira da Silva",
+        name: "Manuel de Moraes Machado de Assis, J. M. Pereira da Silva",
       }),
     );
 

--- a/frontend/components/OriginalBookDataInput.tsx
+++ b/frontend/components/OriginalBookDataInput.tsx
@@ -10,8 +10,11 @@ import { DataInputProps } from "./DataInput";
 import MenuProvider from "./MenuProvider";
 import TextInput from "./TextInput";
 
-/** What a book is offered as: the title, and who wrote it. */
-const describe = (book: OriginalBookValue) => `${book.title} — ${book.authors}`;
+/**
+ * What tells one offered book from another. Two books can share a title, and
+ * two can share their authors, so neither half identifies one on its own.
+ */
+const identify = (book: OriginalBookValue) => `${book.title} — ${book.authors}`;
 
 /**
  * The original title, offering the books already in the database.
@@ -62,7 +65,7 @@ export default forwardRef<HTMLDivElement, DataInputProps>(
     }
 
     function handleSelect(option: { id: string; label: string }) {
-      const book = books.find((candidate) => describe(candidate) === option.id);
+      const book = books.find((candidate) => identify(candidate) === option.id);
       if (!book) return;
 
       // The other half of the book, written straight to its own field — the
@@ -75,8 +78,9 @@ export default forwardRef<HTMLDivElement, DataInputProps>(
     return (
       <MenuProvider
         options={books.map((book) => ({
-          id: describe(book),
-          label: describe(book),
+          id: identify(book),
+          label: book.title,
+          description: book.authors,
         }))}
         isOpen={isOpen}
         activeIndex={activeIndex}

--- a/frontend/components/OriginalBookDataInput.tsx
+++ b/frontend/components/OriginalBookDataInput.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import type { OriginalBookValue } from "modules/original-book";
+import { Publication } from "modules/publication/model";
+import { overrideField } from "modules/publication/store";
+import { usePublicationStore } from "modules/publication/workspace";
+import pDebounce from "p-debounce";
+import { FC, forwardRef, useCallback, useState } from "react";
+import { DataInputProps } from "./DataInput";
+import MenuProvider from "./MenuProvider";
+import TextInput from "./TextInput";
+
+/** What a book is offered as: the title, and who wrote it. */
+const describe = (book: OriginalBookValue) => `${book.title} — ${book.authors}`;
+
+/**
+ * The original title, offering the books already in the database.
+ *
+ * The original book is one entity — a title and its authors — and entering it
+ * field by field is how the same book drifts into near-duplicates, which the
+ * composite key then turns into duplicate *publications*. So a suggestion here
+ * carries the whole book and fills both fields at once, and a term finds a book
+ * by either half of it.
+ *
+ * Free text stands: a book nobody has entered yet is typed, and the field keeps
+ * what it is given.
+ */
+export default forwardRef<HTMLDivElement, DataInputProps>(
+  function OriginalBookDataInput(
+    { rowId, colId, autoValidated: _autoValidated, value, onChange, ...props },
+    ref,
+  ) {
+    const store = usePublicationStore();
+
+    const [isOpen, setIsOpen] = useState(false);
+    const [activeIndex, setActiveIndex] = useState<number | null>(null);
+    const [books, setBooks] = useState<OriginalBookValue[]>([]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const getBooks = useCallback(
+      pDebounce(
+        (search: string) => Publication.autocomplete(search, "originalTitle"),
+        350,
+      ),
+      [],
+    );
+
+    async function handleChange(typed: string) {
+      onChange?.(typed);
+
+      if (!typed) {
+        setIsOpen(false);
+        return;
+      }
+
+      // A lookup that fails offers nothing: the field is usable without
+      // suggestions, and what is being typed is not worth interrupting.
+      const found = await getBooks(typed.toLowerCase()).catch(() => []);
+      setBooks(found);
+      setActiveIndex(0);
+      setIsOpen(found.length > 0);
+    }
+
+    function handleSelect(option: { id: string; label: string }) {
+      const book = books.find((candidate) => describe(candidate) === option.id);
+      if (!book) return;
+
+      // The other half of the book, written straight to its own field — the
+      // point of the suggestion is that the two never disagree.
+      overrideField(store, rowId, "originalAuthors", book.authors);
+      onChange?.(book.title);
+      setIsOpen(false);
+    }
+
+    return (
+      <MenuProvider
+        options={books.map((book) => ({
+          id: describe(book),
+          label: describe(book),
+        }))}
+        isOpen={isOpen}
+        activeIndex={activeIndex}
+        setIsOpen={setIsOpen}
+        setActiveIndex={setActiveIndex}
+        onSelect={handleSelect}
+        bordered={props.bordered}
+      >
+        <TextInput
+          {...props}
+          ref={ref}
+          value={value}
+          onChange={handleChange}
+          aria-autocomplete="list"
+          data-col-id={colId}
+        />
+      </MenuProvider>
+    );
+  },
+) as FC<DataInputProps>;

--- a/frontend/e2e/enter-a-known-original-book.spec.ts
+++ b/frontend/e2e/enter-a-known-original-book.spec.ts
@@ -34,7 +34,7 @@ test("entering a translation of a book already in the database completes it from
   // Typing part of the author finds the book: either half of it will do.
   await originalTitle.fill("Machado");
   const byAuthor = page.getByRole("option", {
-    name: "Dom Casmurro — Machado de Assis",
+    name: "Dom Casmurro Machado de Assis",
   });
   await expect(byAuthor).toBeVisible();
 
@@ -44,7 +44,7 @@ test("entering a translation of a book already in the database completes it from
   // Typing the title narrows to the one book, and picking it fills both halves.
   await originalTitle.fill("Dom Cas");
   await page
-    .getByRole("option", { name: "Dom Casmurro — Machado de Assis" })
+    .getByRole("option", { name: "Dom Casmurro Machado de Assis" })
     .click();
 
   await expect(originalTitle).toHaveValue("Dom Casmurro");

--- a/frontend/e2e/enter-a-known-original-book.spec.ts
+++ b/frontend/e2e/enter-a-known-original-book.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "./fixtures";
+import {
+  commitMulti,
+  draftRow,
+  expectPublicationCount,
+  expectPublicationRow,
+  openPublicationModal,
+  seedCorpus,
+  selectEnumOption,
+  submitWorkspace,
+  CORPUS_SIZE,
+} from "./helpers";
+
+// A second translation of a book the corpus already holds. Its original title
+// and authors must come out exactly as the seeded record spells them — that is
+// what keeps the two publications pointing at one original book.
+const SECOND_TRANSLATION = {
+  title: "Dom Casmurro (Gledson)",
+  year: "1997",
+  authors: "John Gledson",
+  country: "United Kingdom",
+  publisher: "Bloomsbury",
+};
+
+test("entering a translation of a book already in the database completes it from one field", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/admin/publications/new");
+
+  const row = draftRow(page);
+  const originalTitle = row.getByPlaceholder("Original Title", { exact: true });
+
+  // Typing part of the author finds the book: either half of it will do.
+  await originalTitle.fill("Machado");
+  const byAuthor = page.getByRole("option", {
+    name: "Dom Casmurro — Machado de Assis",
+  });
+  await expect(byAuthor).toBeVisible();
+
+  // The corpus holds three works by that author, and each is offered whole.
+  await expect(page.getByRole("option")).toHaveCount(3);
+
+  // Typing the title narrows to the one book, and picking it fills both halves.
+  await originalTitle.fill("Dom Cas");
+  await page
+    .getByRole("option", { name: "Dom Casmurro — Machado de Assis" })
+    .click();
+
+  await expect(originalTitle).toHaveValue("Dom Casmurro");
+  await expect(
+    row.getByText("Machado de Assis", { exact: true }),
+  ).toBeVisible();
+
+  // The rest of the row is this translation's own.
+  await row
+    .getByPlaceholder("Title", { exact: true })
+    .fill(SECOND_TRANSLATION.title);
+  await row
+    .getByPlaceholder("Year", { exact: true })
+    .fill(SECOND_TRANSLATION.year);
+
+  await commitMulti(row, "Translators", SECOND_TRANSLATION.authors);
+  await selectEnumOption(row, "Countries", SECOND_TRANSLATION.country);
+  await commitMulti(row, "Publishers", SECOND_TRANSLATION.publisher);
+
+  await row.getByRole("button", { name: "Add publication" }).click();
+  await submitWorkspace(page, 1);
+
+  // Both translations are in the database, spelling the original the same way.
+  await page.goto("/");
+  await expectPublicationCount(page, CORPUS_SIZE + 1);
+  await expectPublicationRow(page, {
+    ...SECOND_TRANSLATION,
+    originalTitle: "Dom Casmurro",
+    originalAuthors: "Machado de Assis",
+  });
+
+  // And the search agrees they are two translations of one book.
+  const search = page.getByRole("textbox", { name: "Search publications" });
+  await search.fill("Dom Casmurro");
+  await expect(
+    page.getByRole("row").filter({ hasText: "Gledson" }),
+  ).toHaveCount(1);
+  await search.clear();
+
+  const details = await openPublicationModal(page, SECOND_TRANSLATION.title);
+  await expect(
+    details.getByRole("link", { name: "Machado de Assis" }),
+  ).toBeVisible();
+});
+
+test("a book nobody has entered yet is simply typed", async ({ page }) => {
+  await seedCorpus(page);
+  await page.goto("/admin/publications/new");
+
+  const row = draftRow(page);
+  const originalTitle = row.getByPlaceholder("Original Title", { exact: true });
+
+  await originalTitle.fill("Uma Obra Inédita");
+
+  // Nothing to offer, and the field keeps what it was given.
+  await expect(page.getByRole("option")).toHaveCount(0);
+  await expect(originalTitle).toHaveValue("Uma Obra Inédita");
+});

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -39,7 +39,11 @@ export type PublicationInput = {
  * comma always commits the raw typed text, while Enter prefers the highlighted
  * autocomplete option — whose debounced fetch can race the keystrokes and
  * commit a stale suggestion from a previous fill. */
-async function commitMulti(scope: Locator, placeholder: string, value: string) {
+export async function commitMulti(
+  scope: Locator,
+  placeholder: string,
+  value: string,
+) {
   const input = scope.getByPlaceholder(placeholder, { exact: true });
   await input.click();
   await input.pressSequentially(value);
@@ -51,7 +55,7 @@ async function commitMulti(scope: Locator, placeholder: string, value: string) {
  * raw-text commit — the stored value is the option object — so let the async
  * autocomplete settle (it highlights the match) before Enter commits it.
  */
-async function selectEnumOption(
+export async function selectEnumOption(
   scope: Locator,
   placeholder: string,
   name: string,
@@ -68,7 +72,7 @@ async function selectEnumOption(
  * here to stay unambiguous once the grid holds several rows. CSS-based (not
  * getByRole) on purpose: it keeps resolving mid-fill no matter what an open
  * popup's focus manager does to the a11y tree. */
-function draftRow(page: Page) {
+export function draftRow(page: Page) {
   return page
     .locator('[role="row"]')
     .filter({ has: page.locator('button[aria-label="Add publication"]') });

--- a/frontend/modules/original-book.ts
+++ b/frontend/modules/original-book.ts
@@ -1,0 +1,36 @@
+import { request } from "app";
+
+/**
+ * A book in the language it was written in: a title and who wrote it, together.
+ * The pair is what a publication translates, and what the composite key is
+ * built from, so the two travel as a unit rather than as two fields that happen
+ * to sit side by side.
+ */
+type OriginalBook = {
+  title: string;
+  /** The authors as the one comma-separated string the field holds. */
+  authors: string;
+};
+
+interface OriginalBookModule {
+  REMOTE: {
+    search(term: string): Promise<OriginalBook[]>;
+  };
+}
+
+const OriginalBook: OriginalBookModule = {
+  REMOTE: {
+    search(term) {
+      return request(async (http) => {
+        const { data } = await http.get<OriginalBook[]>("/original-books", {
+          params: { search: term },
+        });
+
+        return data;
+      });
+    },
+  },
+};
+
+export { OriginalBook };
+export type { OriginalBook as OriginalBookValue };

--- a/frontend/modules/publication/model.ts
+++ b/frontend/modules/publication/model.ts
@@ -1,6 +1,7 @@
 import { isString } from "lodash";
 import { Author } from "modules/author";
 import { COUNTRIES, Country } from "modules/country";
+import { OriginalBook, type OriginalBookValue } from "modules/original-book";
 import { Publisher } from "modules/publisher";
 
 type Publication = {
@@ -29,7 +30,8 @@ type PublicationError = null | string | Record<PublicationKey, string>;
 type ValidationResult = { publication: Publication; errors: PublicationError };
 type PublicationEntry = ValidationResult & { id: number };
 type PublicationId = NonNullable<Publication["id"]>;
-type PublicationKeyType = "array" | "text" | "enum" | "enumArray" | "number";
+type PublicationKeyType =
+  "array" | "text" | "enum" | "enumArray" | "number" | "book";
 /** Every act the log records, in the order a reader meets them. */
 const HISTORY_ACTIONS = [
   "created",
@@ -106,7 +108,7 @@ const ATTRIBUTE_LABELS: Record<PublicationKey, string> = {
 const ATTRIBUTE_TYPES: Record<PublicationKey, PublicationKeyType> = {
   authors: "array",
   originalAuthors: "array",
-  originalTitle: "text",
+  originalTitle: "book",
   countries: "enumArray",
   publishers: "array",
   title: "text",
@@ -251,6 +253,10 @@ function autocomplete(
   attribute: "originalAuthors",
 ): Promise<Author[]>;
 function autocomplete(value: string, attribute: "authors"): Promise<Author[]>;
+function autocomplete(
+  value: string,
+  attribute: "originalTitle",
+): Promise<OriginalBookValue[]>;
 function autocomplete(value: string, attribute: "publishers"): Promise<[]>;
 function autocomplete(value: string, attribute: string): Promise<[]>;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -261,6 +267,11 @@ function autocomplete(value: string, attribute: string): Promise<any> {
       return Author.REMOTE.search(value);
     case "publishers":
       return Publisher.REMOTE.search(value);
+
+    // The original book is one entity, so it is suggested as one: a term finds
+    // it by its title or by an author, and the suggestion carries both.
+    case "originalTitle":
+      return OriginalBook.REMOTE.search(value);
 
     case "countries": {
       const all = Object.values(COUNTRIES);


### PR DESCRIPTION
A book is a title and who wrote it, and a publication's composite key is built from both. Entering the two apart is how one book drifts into near-duplicates — "Machado de Assis" one day, "M. de Assis" the next — and a drifted book spawns a duplicate publication.

Typing in the original title now offers the books already recorded, found by either half of them, and picking one fills both fields at once. A book nobody has entered yet is still simply typed, and a lookup that fails offers nothing rather than getting in the way.
