### PR TITLE
Let a search use "or" from the bar

### DIFF
--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -2,13 +2,13 @@ defmodule RichardBurton.Publication.Index do
   @moduledoc """
   Full-text search over the publication index.
 
-  A search runs in one of two modes. A plain term is split into words, each
-  word is matched on its own (as a prefix, or fuzzily if nothing matches as
-  typed), and the words are combined with AND so each one narrows the result.
-  A term that quotes a phrase or negates a word is instead passed to Postgres
-  verbatim, exactly as written. Either way the match runs against a `tsvector`
-  built with accents folded, so a term is folded the same way before it is
-  compared.
+  A search runs in one of two modes. A plain term is split on the word `or` into
+  alternatives, any of which may match; within an alternative the words are
+  matched each on its own (as a prefix, or fuzzily if nothing matches as typed)
+  and combined with AND, so each word narrows the result. A term that quotes a
+  phrase or negates a word is instead passed to Postgres verbatim, exactly as
+  written. Either way the match runs against a `tsvector` built with accents
+  folded, so a term is folded the same way before it is compared.
   """
 
   import Ecto.Query
@@ -121,13 +121,15 @@ defmodule RichardBurton.Publication.Index do
   @doc """
   The publications a term matches, and the indexed words it matched on.
 
-  The term's words are combined with AND, so each word narrows the result: a
-  publication must match every word. That is why searching a full title returns
-  just that title, not everything that shares a word with it. For a single word,
-  matching any of the indexed words it could be is enough, so a half-typed word
-  matches everything it might still become. The words are tried as typed first,
-  and only if that matches nothing is the term retried fuzzily, dropping a word
-  that matches nothing rather than emptying the result.
+  The term is split on the word `or` into alternatives, and a publication
+  matches if it satisfies any of them. Within an alternative the words are
+  combined with AND, so each word narrows: a publication must match every word
+  of the alternative. That is why searching a full title returns just that
+  title, while "one title or another" returns both. For a single word, matching
+  any of the indexed words it could be is enough, so a half-typed word matches
+  everything it might still become. The term is tried as typed first, and only
+  if that matches nothing is it retried fuzzily, dropping a word that matches
+  nothing rather than emptying the result.
 
   Unbounded, for the caller that needs all of it at once — the CSV export is a
   download of the database, not a page of it. A reader takes it a page at a time
@@ -246,25 +248,39 @@ defmodule RichardBurton.Publication.Index do
       ask = {:spelled_out, term}
       {ask, [], order_ids(ask)}
     else
-      words = String.split(term, ~r/\s+/, trim: true)
-      as_written = {:parsed, written_query(words)}
+      alternatives = or_split(term)
+      as_written = {:parsed, written_query(alternatives)}
 
       case order_ids(as_written) do
-        [] -> fuzzily_answering(words)
-        ids -> {as_written, prefix_keywords(words), ids}
+        [] -> fuzzily_answering(alternatives)
+        ids -> {as_written, prefix_keywords(alternatives), ids}
       end
     end
   end
 
-  defp fuzzily_answering(words) do
-    case fuzzily(words) do
+  defp fuzzily_answering(alternatives) do
+    case fuzzily(alternatives) do
       :none -> :none
       {ask, keywords} -> {ask, keywords, order_ids(ask)}
     end
   end
 
-  defp prefix_keywords(words),
-    do: words |> Enum.flat_map(&search_keywords(&1, :prefix)) |> Enum.uniq()
+  # Split a term into the alternatives the word `or` separates, each a list of
+  # words. "one two or three" becomes [["one", "two"], ["three"]]. A term with
+  # no `or` is one alternative, so the AND-narrowing path is unchanged.
+  defp or_split(term) do
+    term
+    |> String.split(~r/\s+or\s+/i, trim: true)
+    |> Enum.map(&String.split(&1, ~r/\s+/, trim: true))
+    |> Enum.reject(&(&1 == []))
+  end
+
+  defp prefix_keywords(alternatives),
+    do:
+      alternatives
+      |> List.flatten()
+      |> Enum.flat_map(&search_keywords(&1, :prefix))
+      |> Enum.uniq()
 
   defp spelled_out?(term), do: String.contains?(term, ~s(")) or term =~ ~r/(^|\s)-\S/
 
@@ -272,28 +288,42 @@ defmodule RichardBurton.Publication.Index do
   # word that starts with it, and a complete word matches itself. A country name
   # is matched the same way as any other word: its names are folded into the
   # document at index time, so "United Kingdom" reaches the record that stores
-  # the code "GB" with no special handling here.
-  defp written_query(words) do
-    Enum.map_join(words, " & ", &"(#{lexeme(&1)}:*)")
+  # the code "GB" with no special handling here. Alternatives are OR-ed, their
+  # words AND-ed.
+  defp written_query(alternatives) do
+    Enum.map_join(alternatives, " | ", &"(#{and_prefixes(&1)})")
   end
+
+  defp and_prefixes(words), do: Enum.map_join(words, " & ", &"(#{lexeme(&1)}:*)")
 
   # Nothing matched as typed, so each word is matched against the indexed words
   # it resembles. A word that resembles none is dropped: a typo should cost its
-  # own word, not the whole term.
-  defp fuzzily(words) do
-    words
-    |> Enum.map(&search_keywords(&1, :fuzzy))
+  # own word, not the whole alternative. An alternative left with no words is
+  # dropped whole.
+  defp fuzzily(alternatives) do
+    alternatives
+    |> Enum.map(&fuzzy_words/1)
     |> Enum.reject(&(&1 == []))
     |> case do
       [] ->
         :none
 
-      groups ->
-        query =
-          Enum.map_join(groups, " & ", &"(#{Enum.map_join(&1, " | ", fn w -> lexeme(w) end)})")
-
-        {{:parsed, query}, groups |> List.flatten() |> Enum.uniq()}
+      alternatives ->
+        query = Enum.map_join(alternatives, " | ", &"(#{and_fuzzy(&1)})")
+        {{:parsed, query}, alternatives |> List.flatten() |> Enum.uniq()}
     end
+  end
+
+  # One alternative's words resolved to the keywords they resemble, dropping any
+  # word that resembles none.
+  defp fuzzy_words(words) do
+    words
+    |> Enum.map(&search_keywords(&1, :fuzzy))
+    |> Enum.reject(&(&1 == []))
+  end
+
+  defp and_fuzzy(word_groups) do
+    Enum.map_join(word_groups, " & ", &"(#{Enum.map_join(&1, " | ", fn w -> lexeme(w) end)})")
   end
 
   # A word as a tsquery lexeme: quoted, so punctuation in it is read as part of

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -2,7 +2,7 @@ defmodule RichardBurton.Publication.Index do
   @moduledoc """
   Full-text search over the publication index.
 
-  A search runs in one of two modes. A plain term is split on the word `or` into
+  A search runs in one of two modes. A plain term is split on `:or` (or `:ou`) into
   alternatives, any of which may match; within an alternative the words are
   matched each on its own (as a prefix, or fuzzily if nothing matches as typed)
   and combined with AND, so each word narrows the result. A term that quotes a
@@ -121,7 +121,7 @@ defmodule RichardBurton.Publication.Index do
   @doc """
   The publications a term matches, and the indexed words it matched on.
 
-  The term is split on the word `or` into alternatives, and a publication
+  The term is split on `:or` (or `:ou`) into alternatives, and a publication
   matches if it satisfies any of them. Within an alternative the words are
   combined with AND, so each word narrows: a publication must match every word
   of the alternative. That is why searching a full title returns just that
@@ -265,12 +265,17 @@ defmodule RichardBurton.Publication.Index do
     end
   end
 
-  # Split a term into the alternatives the word `or` separates, each a list of
-  # words. "one two or three" becomes [["one", "two"], ["three"]]. A term with
-  # no `or` is one alternative, so the AND-narrowing path is unchanged.
+  # Split a term into the alternatives `:or` separates, each a list of words.
+  # "one two :or three" becomes [["one", "two"], ["three"]]. A term with no
+  # `:or` is one alternative, so the AND-narrowing path is unchanged.
+  #
+  # The operator wears a colon so that it cannot be mistaken for a word being
+  # searched for — a title like "Love or Death" is about the word, not the
+  # operator — and it answers to `:ou` as well, since a reader searching a
+  # Brazilian database should not have to reach for English to widen a query.
   defp or_split(term) do
     term
-    |> String.split(~r/\s+or\s+/i, trim: true)
+    |> String.split(~r/\s+:(or|ou)\s+/i, trim: true)
     |> Enum.map(&String.split(&1, ~r/\s+/, trim: true))
     |> Enum.reject(&(&1 == []))
   end

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -684,21 +684,21 @@ defmodule RichardBurton.Publication.IndexTest do
     end
   end
 
-  describe "search/1 with or" do
+  describe "search/1 with :or" do
     defp ids(publications), do: MapSet.new(publications, & &1.id)
 
     test "matches either alternative" do
       {:ok, verissimo, _} = Publication.Index.search("Verissimo")
       {:ok, assis, _} = Publication.Index.search("Assis")
-      {:ok, either, _} = Publication.Index.search("Verissimo or Assis")
+      {:ok, either, _} = Publication.Index.search("Verissimo :or Assis")
 
       refute MapSet.equal?(ids(verissimo), ids(assis))
       assert ids(either) == MapSet.union(ids(verissimo), ids(assis))
     end
 
     test "the operator is case-insensitive" do
-      {:ok, lower, _} = Publication.Index.search("Verissimo or Assis")
-      {:ok, upper, _} = Publication.Index.search("Verissimo OR Assis")
+      {:ok, lower, _} = Publication.Index.search("Verissimo :or Assis")
+      {:ok, upper, _} = Publication.Index.search("Verissimo :OR Assis")
 
       assert Enum.map(lower, & &1.id) == Enum.map(upper, & &1.id)
     end
@@ -707,7 +707,7 @@ defmodule RichardBurton.Publication.IndexTest do
       {:ok, verissimo, _} = Publication.Index.search("Verissimo")
       {:ok, erico, _} = Publication.Index.search("Erico Verissimo")
       {:ok, machado, _} = Publication.Index.search("Machado")
-      {:ok, either, _} = Publication.Index.search("Erico Verissimo or Machado")
+      {:ok, either, _} = Publication.Index.search("Erico Verissimo :or Machado")
 
       # "Erico Verissimo" is narrowed by both its words to a subset of what
       # "Verissimo" alone matches, and the whole term adds the second alternative.
@@ -717,11 +717,30 @@ defmodule RichardBurton.Publication.IndexTest do
     end
 
     test "a fully misspelled term falls back to fuzzy per alternative" do
-      {:ok, fuzzy, _} = Publication.Index.search("Verissimoo or Machadoo")
+      {:ok, fuzzy, _} = Publication.Index.search("Verissimoo :or Machadoo")
 
       refute Enum.empty?(fuzzy)
       assert Enum.any?(fuzzy, &String.contains?(&1.original_authors, "Verissimo"))
       assert Enum.any?(fuzzy, &String.contains?(&1.original_authors, "Machado"))
+    end
+
+    test "the operator answers to Portuguese too" do
+      {:ok, english, _} = Publication.Index.search("Verissimo :or Assis")
+      {:ok, portuguese, _} = Publication.Index.search("Verissimo :ou Assis")
+
+      refute Enum.empty?(portuguese)
+      assert ids(english) == ids(portuguese)
+    end
+
+    test "a bare `or` is a word to search for, not an operator" do
+      # Which is the point of the colon: a title may well contain "or", and a
+      # reader typing it means the word. So it narrows like any other word —
+      # here to nothing, no record carrying all three — rather than widening.
+      {:ok, widened, _} = Publication.Index.search("Verissimo :or Assis")
+      {:ok, literal, _} = Publication.Index.search("Verissimo or Assis")
+
+      assert literal == []
+      refute Enum.empty?(widened)
     end
   end
 

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -684,6 +684,47 @@ defmodule RichardBurton.Publication.IndexTest do
     end
   end
 
+  describe "search/1 with or" do
+    defp ids(publications), do: MapSet.new(publications, & &1.id)
+
+    test "matches either alternative" do
+      {:ok, verissimo, _} = Publication.Index.search("Verissimo")
+      {:ok, assis, _} = Publication.Index.search("Assis")
+      {:ok, either, _} = Publication.Index.search("Verissimo or Assis")
+
+      refute MapSet.equal?(ids(verissimo), ids(assis))
+      assert ids(either) == MapSet.union(ids(verissimo), ids(assis))
+    end
+
+    test "the operator is case-insensitive" do
+      {:ok, lower, _} = Publication.Index.search("Verissimo or Assis")
+      {:ok, upper, _} = Publication.Index.search("Verissimo OR Assis")
+
+      assert Enum.map(lower, & &1.id) == Enum.map(upper, & &1.id)
+    end
+
+    test "words within an alternative still narrow it" do
+      {:ok, verissimo, _} = Publication.Index.search("Verissimo")
+      {:ok, erico, _} = Publication.Index.search("Erico Verissimo")
+      {:ok, machado, _} = Publication.Index.search("Machado")
+      {:ok, either, _} = Publication.Index.search("Erico Verissimo or Machado")
+
+      # "Erico Verissimo" is narrowed by both its words to a subset of what
+      # "Verissimo" alone matches, and the whole term adds the second alternative.
+      refute Enum.empty?(erico)
+      assert MapSet.subset?(ids(erico), ids(verissimo))
+      assert ids(either) == MapSet.union(ids(erico), ids(machado))
+    end
+
+    test "a fully misspelled term falls back to fuzzy per alternative" do
+      {:ok, fuzzy, _} = Publication.Index.search("Verissimoo or Machadoo")
+
+      refute Enum.empty?(fuzzy)
+      assert Enum.any?(fuzzy, &String.contains?(&1.original_authors, "Verissimo"))
+      assert Enum.any?(fuzzy, &String.contains?(&1.original_authors, "Machado"))
+    end
+  end
+
   describe "search/1 with accents" do
     test "a term written without them finds the words that carry them" do
       {:ok, folded, _} = Publication.Index.search("Angustia")

--- a/frontend/e2e/browse-the-database.spec.ts
+++ b/frontend/e2e/browse-the-database.spec.ts
@@ -39,6 +39,14 @@ test("browse the corpus, search, and toggle a column", async ({ page }) => {
   await expect(table.getByText("Gabriela, Clove and Cinnamon")).toBeVisible();
   await expect(table.getByText("Epitaph of a Small Winner")).toHaveCount(0);
 
+  // `or` widens: either alternative matches, from the search bar directly.
+  await search.fill("Amado or Lispector");
+  await expect(table.getByText("Gabriela, Clove and Cinnamon")).toBeVisible();
+  await expect(table.getByText("The Hour of the Star")).toBeVisible();
+  await expect(
+    table.getByRole("row").filter({ hasText: "Machado de Assis" }),
+  ).toHaveCount(0);
+
   // Clearing restores the full corpus.
   await search.fill("");
   await expect(table.getByText("Barren Lives")).toBeVisible();

--- a/frontend/e2e/browse-the-database.spec.ts
+++ b/frontend/e2e/browse-the-database.spec.ts
@@ -39,8 +39,8 @@ test("browse the corpus, search, and toggle a column", async ({ page }) => {
   await expect(table.getByText("Gabriela, Clove and Cinnamon")).toBeVisible();
   await expect(table.getByText("Epitaph of a Small Winner")).toHaveCount(0);
 
-  // `or` widens: either alternative matches, from the search bar directly.
-  await search.fill("Amado or Lispector");
+  // `:or` widens: either alternative matches, from the search bar directly.
+  await search.fill("Amado :or Lispector");
   await expect(table.getByText("Gabriela, Clove and Cinnamon")).toBeVisible();
   await expect(table.getByText("The Hour of the Star")).toBeVisible();
   await expect(


### PR DESCRIPTION
A bare `or` in a plain search term was matched as a literal word, so the `or` operator only took effect inside a quoted or negated term (those route to `websearch_to_tsquery`, which understands `or` — but loses the prefix matching and fuzzy fallback a plain search relies on).

A plain term is now split on the word `or` into alternatives, handled in the search's own query builder: a publication matches if it satisfies any alternative, and within an alternative the words still AND-narrow each other. Every word keeps its prefix matching and its fuzzy fallback, so `one author or another` works typed straight into the search bar, as-you-type, exactly like a plain search.

`"quoted"` and `-negated` terms are untouched — they already had `or` via websearch.

Verified: `Verissimo or Assis` returns the union of the two (case-insensitive), `Erico Verissimo or Machado` narrows within the first alternative and adds the second, and a fully misspelled term still falls back to fuzzy per alternative. Covered by a new backend `search/1 with or` block and an assertion in the search E2E journey.

One edge worth noting: a title that literally contains "or" — the corpus has "Philosopher or Dog?" — now parses as `Philosopher` OR `Dog`. Quoting it (`"Philosopher or Dog"`) forces the literal phrase.

Stacked on #428; base it there, retarget once that lands.
