### PR TITLE
Pick out what a search matched

### DIFF
--- a/frontend/components/Highlight.mdx
+++ b/frontend/components/Highlight.mdx
@@ -1,0 +1,49 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+
+import * as HighlightStories from "./Highlight.stories";
+
+<Meta of={HighlightStories} />
+
+# Highlight
+
+Marks the parts of a publication the current search matched, so a reader can see
+what the query caught rather than inferring it. Used wherever a publication is
+shown while a search is on — the rows of the index, and a record open over them.
+
+<Canvas of={HighlightStories.Matched} />
+
+## Props
+
+- `children` — the text to render. A plain string; the component returns it as a
+  mix of text and `<mark>` runs.
+
+## How it works
+
+- The words to mark come from the store (`useKeywords`), which holds the indexed
+  words the search resolved to — the server returns them with the results.
+  Because the server has already widened a half-typed term into the words it
+  matched, typing `mach` marks `Machado`.
+- Matching is done on a folded copy of the text — accents removed, lowercased,
+  the same folding the index applies — and the marks are mapped back onto the
+  original characters, so `Angústia` is marked by a search for `angustia`
+  without the accents being lost from what is displayed.
+
+<Canvas of={HighlightStories.Accented} />
+
+- A word is marked only when it matches a keyword **whole**: the keywords are
+  themselves whole indexed words, so `casmurro` does not mark `Casmurros`.
+- Every occurrence is marked, and several keywords can match in one string.
+
+<Canvas of={HighlightStories.ManyMatches} />
+
+## Outside a search
+
+With no search there are no keywords, nothing is marked, and the text renders
+untouched — which is also what a publication's own page shows, since it is
+opened without a query behind it.
+
+<Canvas of={HighlightStories.Unsearched} />
+
+A search that quotes a phrase or negates a word is passed to Postgres verbatim
+and resolves to no keywords, so it marks nothing; the row still explains itself
+through the reference snippet when it matched on its sources.

--- a/frontend/components/Highlight.stories.tsx
+++ b/frontend/components/Highlight.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { keywordsAtom } from "modules/publication/store";
+import { store } from "modules/store";
+import { expect, within } from "storybook/test";
+
+import Highlight from "./Highlight";
+
+/** Seed the words the current search matched on, as an index read would. */
+const matching = (...keywords: string[]) => {
+  store.set(keywordsAtom, keywords);
+  return () => store.set(keywordsAtom, undefined);
+};
+
+const meta = {
+  title: "Components/Highlight",
+  component: Highlight,
+  // Falls back to the term in the address when the store holds no keywords.
+  parameters: { nextjs: { navigation: { pathname: "/" } } },
+} satisfies Meta<typeof Highlight>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/** Outside a search nothing is marked, and the text reads as it always did. */
+export const Unsearched: Story = {
+  args: { children: "Dom Casmurro" },
+  beforeEach: () => matching(),
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("mark")).toBeNull();
+    await expect(within(canvasElement).getByText("Dom Casmurro")).toBeVisible();
+  },
+};
+
+/** The word the search matched is picked out; the rest of the text is not. */
+export const Matched: Story = {
+  args: { children: "Dom Casmurro" },
+  beforeEach: () => matching("casmurro"),
+  play: async ({ canvasElement }) => {
+    const marks = canvasElement.querySelectorAll("mark");
+    await expect(marks).toHaveLength(1);
+    await expect(marks[0]).toHaveTextContent("Casmurro");
+  },
+};
+
+/** Every occurrence is marked, and several keywords can match at once. */
+export const ManyMatches: Story = {
+  args: { children: "Machado de Assis, by Machado de Assis" },
+  beforeEach: () => matching("machado", "assis"),
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelectorAll("mark")).toHaveLength(4);
+  },
+};
+
+/**
+ * The index folds accents away, so a term typed without them still marks the
+ * word that carries them.
+ */
+export const Accented: Story = {
+  args: { children: "Angústia" },
+  beforeEach: () => matching("angustia"),
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector("mark")).toHaveTextContent(
+      "Angústia",
+    );
+  },
+};

--- a/frontend/components/Highlight.tsx
+++ b/frontend/components/Highlight.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useKeywords } from "modules/publication/hooks";
+import { highlight, searchWords } from "modules/publication/highlight";
+import { useSearchParams } from "next/navigation";
+import { FC, useMemo } from "react";
+
+/**
+ * Text with the words the current search matched picked out.
+ *
+ * Wherever a publication is shown while a search is on — a row of the index, a
+ * record open over it — this marks the parts of it that answered, so a reader
+ * can see what the query caught rather than inferring it. Outside a search
+ * there are no matched words and the text renders untouched.
+ *
+ * The words to mark come from the search that loaded these rows, which returns
+ * the indexed words it resolved to. A record opened over the index is its own
+ * route, and so its own store, with no search behind it — there the address
+ * still carries the term, and the reader's own words stand in, marking what
+ * begins with them as the search itself would have widened them.
+ */
+const Highlight: FC<{ children: string }> = ({ children }) => {
+  const keywords = useKeywords();
+  const search = useSearchParams()?.get("search") ?? undefined;
+
+  const parts = useMemo(() => {
+    if (keywords && keywords.length > 0) return highlight(children, keywords);
+    if (search)
+      return highlight(children, searchWords(search), { prefix: true });
+    return [{ text: children, matched: false }];
+  }, [children, keywords, search]);
+
+  return (
+    <>
+      {parts.map((part, index) =>
+        part.matched ? (
+          <mark key={index} className="text-inherit bg-amber-100">
+            {part.text}
+          </mark>
+        ) : (
+          part.text
+        ),
+      )}
+    </>
+  );
+};
+
+export default Highlight;

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -35,6 +35,7 @@ import { FC, SubmitEvent, useEffect, useState } from "react";
 import Button from "./Button";
 import ConfirmationModal from "./ConfirmationModal";
 import DataInput from "./DataInput";
+import Highlight from "./Highlight";
 import { useModal } from "./Modal";
 import PublicationHistory from "./PublicationHistory";
 import PublicationMerge from "./PublicationMerge";
@@ -47,7 +48,7 @@ const Searchable: FC<{ label: string; value?: string }> = ({
   label,
 }) => (
   <Link href={`/?search=${value || label}`} className="anchor">
-    {label}
+    <Highlight>{label}</Highlight>
   </Link>
 );
 
@@ -71,12 +72,12 @@ const PublicationHeading: FC<{ publication: Publication }> = ({
   <div className="flex flex-col w-full text-2xl font-normal sm:gap-2 sm:items-center sm:flex-row">
     <Tooltip variant="info" message="Translation's title">
       <span className="w-full truncate sm:w-min whitespace-nowrap">
-        {publication.title}
+        <Highlight>{publication.title}</Highlight>
       </span>
     </Tooltip>
     <Tooltip variant="info" message="Who translated this publication">
       <span className="text-lg font-light tracking-tighter text-indigo-500 sm:text-xl whitespace-nowrap">
-        ({publication.authors})
+        (<Highlight>{publication.authors}</Highlight>)
       </span>
     </Tooltip>
   </div>
@@ -130,7 +131,9 @@ const PublicationReferences: FC<{ references: string[] }> = ({
               aria-hidden
               className="size-1.5 rounded-full shrink-0 bg-indigo-400 ring-2 ring-indigo-100"
             />
-            <span className="wrap-break-words">{reference}</span>
+            <span className="wrap-break-words">
+              <Highlight>{reference}</Highlight>
+            </span>
           </li>
         ))}
       </ul>

--- a/frontend/components/PublicationIndexList.tsx
+++ b/frontend/components/PublicationIndexList.tsx
@@ -6,6 +6,7 @@ import {
 } from "modules/publication/hooks";
 import { FC, MouseEvent } from "react";
 import { EmptySearchResults } from "./EmptySearchResults";
+import Highlight from "./Highlight";
 import { ListSkeleton } from "./ListSkeleton";
 
 const PublicationItem: FC<{ id: number }> = ({ id }) => {
@@ -16,18 +17,28 @@ const PublicationItem: FC<{ id: number }> = ({ id }) => {
       <div className="flex justify-between mr-1 border border-gray-200 rounded-lg overflow-clip">
         <div className="p-2 space-y-4">
           <div>
-            <span className="font-normal">{publication.title}</span>
+            <span className="font-normal">
+              <Highlight>{publication.title}</Highlight>
+            </span>
             <br className="sm:hidden" />
-            <span className="whitespace-nowrap"> ({publication.authors})</span>
+            <span className="whitespace-nowrap">
+              {" "}
+              (<Highlight>{publication.authors}</Highlight>)
+            </span>
           </div>
           <div className="text-sm text-indigo-600">
             Translation of{" "}
-            <span className="font-normal">{publication.originalTitle}</span> by{" "}
+            <span className="font-normal">
+              <Highlight>{publication.originalTitle}</Highlight>
+            </span>{" "}
+            by{" "}
             <span className="font-normal whitespace-nowrap">
-              {publication.originalAuthors}
+              <Highlight>{publication.originalAuthors}</Highlight>
             </span>
             , published by{" "}
-            <span className="font-normal">{publication.publishers}</span>
+            <span className="font-normal">
+              <Highlight>{publication.publishers}</Highlight>
+            </span>
           </div>
         </div>
 

--- a/frontend/components/PublicationIndexTable.tsx
+++ b/frontend/components/PublicationIndexTable.tsx
@@ -23,6 +23,7 @@ import {
 } from "react";
 import { mergeRefs } from "react-merge-refs";
 import useVisible from "utils/useVisible";
+import Highlight from "./Highlight";
 import { EmptySearchResults } from "./EmptySearchResults";
 import { ListSkeleton } from "./ListSkeleton";
 
@@ -130,7 +131,7 @@ const Content: FC<{
 
   return (
     <div className="px-2 py-1 truncate">
-      {Publication.describeValue(value, colId)}
+      <Highlight>{Publication.describeValue(value, colId)}</Highlight>
       {colId === "title" && <SourceMatch rowId={rowId} />}
     </div>
   );

--- a/frontend/e2e/browse-the-database.spec.ts
+++ b/frontend/e2e/browse-the-database.spec.ts
@@ -168,10 +168,19 @@ test("reloading with a publication open keeps it open, over the search that foun
   // Closing goes back to the search it was opened from, not to the whole
   // database — even though there is no history left to go back through. Right
   // after a reload the dialog paints before its key handler has hydrated, so the
-  // first Escape can land on nothing; retry until the close registers.
+  // first Escape can land on nothing. Retry only while the address still names
+  // the record: the dialog outlives its own closing animation, and an Escape
+  // reaching it after the address has changed would step back past the search.
   await expect(async () => {
-    await page.keyboard.press("Escape");
-    await expect(page).toHaveURL(/\/\?search=Machado$/);
+    if (page.url().includes("/publications/")) {
+      await page.keyboard.press("Escape");
+      // Let the press settle before judging it: going back is asynchronous, and
+      // pressing again while it lands would step past the search too.
+      await page
+        .waitForURL(/\/\?search=Machado$/, { timeout: 2000 })
+        .catch(() => {});
+    }
+    expect(page.url()).toMatch(/\/\?search=Machado$/);
   }).toPass();
   await expect(indexTable(page).getByText("The Hour of the Star")).toHaveCount(
     0,
@@ -292,6 +301,45 @@ test("a row answered by its sources says so", async ({ page }) => {
 
   await expect(row.locator("mark")).toHaveText("Afterword");
   await expect(row).toContainText("Pontiero");
+});
+
+test("what a search matched is picked out, in the index and in the record", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/?search=Machado");
+
+  const row = indexTable(page)
+    .getByRole("row")
+    .filter({ hasText: "Dom Casmurro" })
+    .first();
+
+  // The author answered the query, so the row says so where it says the author
+  // — not only rows matched on their sources carry a mark.
+  await expect(row.locator("mark").first()).toHaveText("Machado");
+
+  // A word the query did not match is left alone.
+  await expect(row.locator("mark").filter({ hasText: "Casmurro" })).toHaveCount(
+    0,
+  );
+
+  // Opening the record keeps the marks: the search is still what brought the
+  // reader here, so the record shows which of it answered.
+  const dialog = await openPublicationModal(page, "Dom Casmurro");
+  await expect(dialog.locator("mark").first()).toHaveText("Machado");
+});
+
+test("a search without accents picks out the word that carries them", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  // The index folds accents away, so this finds the record; the mark has to
+  // land on the accented word as it is actually written.
+  await page.goto("/?search=Iracema");
+
+  await expect(
+    indexTable(page).locator("mark").filter({ hasText: "Iraçéma" }).first(),
+  ).toBeVisible();
 });
 
 test("the database grows as the reader scrolls to its foot", async ({

--- a/frontend/modules/publication/highlight.spec.ts
+++ b/frontend/modules/publication/highlight.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "vitest";
+import { highlight, searchWords } from "./highlight";
+
+/** The marked runs, in order — what a reader would see picked out. */
+const marked = (text: string, keywords: string[]) =>
+  highlight(text, keywords)
+    .filter((part) => part.matched)
+    .map((part) => part.text);
+
+/** The whole text, reassembled — nothing may be lost or doubled. */
+const rejoined = (text: string, keywords: string[]) =>
+  highlight(text, keywords)
+    .map((part) => part.text)
+    .join("");
+
+describe("highlight", () => {
+  test("marks a matched word, leaving the rest alone", () => {
+    expect(marked("Dom Casmurro", ["casmurro"])).toEqual(["Casmurro"]);
+  });
+
+  test("marks every occurrence, not only the first", () => {
+    expect(marked("Assis, Machado de Assis", ["assis"])).toEqual([
+      "Assis",
+      "Assis",
+    ]);
+  });
+
+  test("marks a word the reader wrote without its accents", () => {
+    expect(marked("Angústia", ["angustia"])).toEqual(["Angústia"]);
+  });
+
+  test("marks a word the index holds without accents", () => {
+    expect(marked("Iracema", ["iracema"])).toEqual(["Iracema"]);
+  });
+
+  test("matches whole words, so a keyword inside a longer word is left alone", () => {
+    expect(marked("Casmurros", ["casmurro"])).toEqual([]);
+  });
+
+  test("marks each of several keywords", () => {
+    expect(marked("Machado de Assis", ["machado", "assis"])).toEqual([
+      "Machado",
+      "Assis",
+    ]);
+  });
+
+  test("keeps the text whole, whatever is marked", () => {
+    const text = "Gabriela, Clove and Cinnamon";
+    expect(rejoined(text, ["clove"])).toBe(text);
+    expect(rejoined(text, [])).toBe(text);
+    expect(rejoined(text, ["nothing"])).toBe(text);
+  });
+
+  test("without a search there is nothing to mark", () => {
+    expect(highlight("Dom Casmurro", [])).toEqual([
+      { text: "Dom Casmurro", matched: false },
+    ]);
+  });
+
+  test("empty text stays empty", () => {
+    expect(highlight("", ["assis"])).toEqual([{ text: "", matched: false }]);
+  });
+
+  test("a word against punctuation is still a word", () => {
+    expect(marked("Assis, Joaquim", ["assis"])).toEqual(["Assis"]);
+    expect(marked("(Machado)", ["machado"])).toEqual(["Machado"]);
+  });
+
+  test("marks a word among many, in the order they appear", () => {
+    expect(
+      highlight("Barren Lives", ["lives"]).map((p) => [p.text, p.matched]),
+    ).toEqual([
+      ["Barren ", false],
+      ["Lives", true],
+    ]);
+  });
+});
+
+describe("highlight, marking by what a word begins with", () => {
+  const prefixed = (text: string, keywords: string[]) =>
+    highlight(text, keywords, { prefix: true })
+      .filter((part) => part.matched)
+      .map((part) => part.text);
+
+  test("marks the word a half-typed one could still become", () => {
+    expect(prefixed("Machado de Assis", ["mach"])).toEqual(["Machado"]);
+  });
+
+  test("marks a complete word too", () => {
+    expect(prefixed("Dom Casmurro", ["casmurro"])).toEqual(["Casmurro"]);
+  });
+
+  test("still folds accents away", () => {
+    expect(prefixed("Iraçéma the Honey-Lips", ["iracema"])).toEqual([
+      "Iraçéma",
+    ]);
+  });
+
+  test("a word that begins with nothing asked for is left alone", () => {
+    expect(prefixed("Dom Casmurro", ["assis"])).toEqual([]);
+  });
+});
+
+describe("searchWords", () => {
+  test("takes the words a reader typed", () => {
+    expect(searchWords("Machado de Assis")).toEqual(["Machado", "de", "Assis"]);
+  });
+
+  test("reads a quoted phrase as its words", () => {
+    expect(searchWords('"United Kingdom"')).toEqual(["United", "Kingdom"]);
+  });
+
+  test("drops a word the reader excluded, which cannot be why a record is here", () => {
+    expect(searchWords("Verissimo -Noite")).toEqual(["Verissimo"]);
+  });
+
+  test("drops the word that separates alternatives", () => {
+    expect(searchWords("Verissimo or Assis")).toEqual(["Verissimo", "Assis"]);
+  });
+});

--- a/frontend/modules/publication/highlight.ts
+++ b/frontend/modules/publication/highlight.ts
@@ -1,0 +1,109 @@
+/** A run of text, marked when the search matched it. */
+type Part = { text: string; matched: boolean };
+
+/** The combining marks NFD splits an accented letter into. */
+const DIACRITIC = /[̀-ͯ]/g;
+
+/**
+ * A word is a run of characters that are neither whitespace nor punctuation.
+ * Written as what it excludes rather than as letters, so a script this database
+ * has not seen yet still reads as words.
+ */
+const WORD = /[^\s!-/:-@[-`{-~]+/g;
+
+/**
+ * Fold text the way the index folds it — accents removed, lowercased — keeping,
+ * for each folded character, the position of the character it came from. The
+ * map is what lets a match found in the folded text be marked in the original,
+ * so "Angústia" can be highlighted by a search for "angustia".
+ */
+function fold(text: string): { folded: string; origin: number[] } {
+  let folded = "";
+  const origin: number[] = [];
+
+  for (let index = 0; index < text.length; index++) {
+    const character = text[index]
+      .normalize("NFD")
+      .replace(DIACRITIC, "")
+      .toLowerCase();
+
+    for (let step = 0; step < character.length; step++) {
+      folded += character[step];
+      origin.push(index);
+    }
+  }
+
+  return { folded, origin };
+}
+
+/**
+ * The words of a search term, as something to mark by.
+ *
+ * Quotes are dropped — a quoted phrase is still matched word by word — and so
+ * is a negated word, which the reader asked *not* to see and which therefore
+ * cannot be why a record is here. `or` separates alternatives rather than being
+ * searched for.
+ */
+function searchWords(term: string): string[] {
+  return term
+    .replace(/"/g, " ")
+    .split(/\s+/)
+    .filter(
+      (word) => word !== "" && word[0] !== "-" && word.toLowerCase() !== "or",
+    );
+}
+
+/**
+ * Split text into runs, marking the words a search matched.
+ *
+ * Given the indexed words a search resolved to, a word is marked when it
+ * matches one of them entirely: those are whole words, as the index holds them,
+ * and the server has already widened a half-typed term into everything it
+ * matched. Given the reader's own words instead — where the resolved ones are
+ * not to hand — `prefix` marks a word that begins with one, which is how the
+ * server widens a typed word in the first place.
+ */
+function highlight(
+  text: string,
+  keywords: string[],
+  { prefix = false }: { prefix?: boolean } = {},
+): Part[] {
+  if (!text || keywords.length === 0) return [{ text, matched: false }];
+
+  const wanted = keywords.map((keyword) => fold(keyword).folded);
+  const matches = (word: string) =>
+    prefix
+      ? wanted.some((keyword) => keyword !== "" && word.indexOf(keyword) === 0)
+      : wanted.indexOf(word) !== -1;
+
+  const { folded, origin } = fold(text);
+  const parts: Part[] = [];
+  let taken = 0;
+
+  WORD.lastIndex = 0;
+  let word = WORD.exec(folded);
+
+  while (word) {
+    if (matches(word[0])) {
+      const from = origin[word.index];
+      const to = origin[word.index + word[0].length - 1] + 1;
+
+      if (from > taken) {
+        parts.push({ text: text.slice(taken, from), matched: false });
+      }
+      parts.push({ text: text.slice(from, to), matched: true });
+      taken = to;
+    }
+
+    word = WORD.exec(folded);
+  }
+
+  if (taken < text.length) {
+    parts.push({ text: text.slice(taken), matched: false });
+  }
+
+  return parts;
+}
+
+export { highlight, searchWords };
+export type { Part };


### PR DESCRIPTION
A row matched on its sources already explained itself; every other match was silent — the reader could see which records answered but not what in them did. Every part of a publication now marks the words the search matched, in the index and in the record opened over it.

The words come from the search itself, which returns the indexed words it resolved to, so a half-typed term marks what it was widened into. Matching runs on a folded copy — accents removed, as the index folds them — and is mapped back onto the original characters, so a term typed without accents marks the word that carries them.

A record opened over the index is its own route, and so its own store, with no search behind it. There the address still carries the term, and the reader's own words stand in, marking what begins with them as the search itself would have widened them — which also means a quoted search, which resolves to no keywords, now marks something.