### PR TITLE
Stop a bulk-insert test depending on row order

### DIFF
--- a/backend/test/richard_burton/publication_test.exs
+++ b/backend/test/richard_burton/publication_test.exs
@@ -227,7 +227,12 @@ defmodule RichardBurton.PublicationTest do
           Map.put(@valid_attrs, "year", 1890)
         ])
 
-      assert Publication.preload(publications) == Publication.all()
+      # `Publication.all/0` asks for no order, so the database is free to return
+      # the rows in any: what this asserts is which publications now exist, not
+      # the order they came back in.
+      by_id = &Enum.sort_by(&1, fn publication -> publication.id end)
+
+      assert by_id.(Publication.preload(publications)) == by_id.(Publication.all())
     end
 
     test "when invalid publications are provided, rolls back and returns the first error" do


### PR DESCRIPTION
The bulk-insert test compared what it inserted against every publication there is, as lists. Nothing asks the database for an order there, so it is free to return the rows in any — and roughly one run in a dozen it chose one the insertion order did not match, failing a test about which records exist rather than about their order.

Caught by running the suite in a loop (seed 778792); compares by id now, and 25 consecutive runs are clean.