### PR TITLE
Search a field by name, and a year by span

### DIFF
--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -240,8 +240,8 @@ defmodule RichardBurton.Publication.Index do
     |> Enum.reduce(fn predicate, acc -> dynamic(^acc or ^predicate) end)
   end
 
-  defp alternative_predicate(%{query: query, filters: filters}) do
-    [words_predicate(query) | Enum.map(filters, &filter_predicate/1)]
+  defp alternative_predicate(%{query: query, filters: filters, mode: mode}) do
+    [words_predicate(query) | Enum.map(filters, &filter_predicate(&1, mode))]
     |> Enum.reject(&is_nil/1)
     |> case do
       # Only operators nothing could be made of: the alternative asks nothing,
@@ -259,15 +259,20 @@ defmodule RichardBurton.Publication.Index do
   # An operator asks of one field rather than of the whole document, so it is
   # matched against that field's own text. A quoted value is a phrase, taken in
   # order; anything else matches from the start of a word, as free text does.
-  defp filter_predicate(%{field: :year, value: value, negated: negated}) do
+  defp filter_predicate(%{field: :year, value: value, negated: negated}, _mode) do
     case Term.span(value) do
       :none -> nil
       {from, to} -> negate(year_predicate(from, to), negated)
     end
   end
 
-  defp filter_predicate(%{field: field, value: value, exact: exact, negated: negated}) do
-    negate(text_predicate(field, value, exact), negated)
+  defp filter_predicate(%{field: field, value: value, exact: exact, negated: negated}, mode) do
+    case value_query(value, exact, mode) do
+      # Nothing in the index resembles what was asked of this field, so nothing
+      # can satisfy it — the same answer the free words give.
+      :none -> negate(dynamic(false), negated)
+      query -> negate(text_predicate(field, query), negated)
+    end
   end
 
   defp negate(predicate, false), do: predicate
@@ -279,34 +284,46 @@ defmodule RichardBurton.Publication.Index do
 
   # References are a list, so they are matched as the text of the whole list —
   # the same thing the search document folds them in as.
-  defp text_predicate(:references, value, exact) do
+  defp text_predicate(:references, query) do
     dynamic(
       [p],
-      fragment(
-        "to_tsvector('rb_search', array_to_string(?, ' ')) @@ ?",
-        p.references,
-        ^value_query(value, exact)
-      )
+      fragment("to_tsvector('rb_search', array_to_string(?, ' ')) @@ ?", p.references, ^query)
     )
   end
 
-  defp text_predicate(field, value, exact) do
+  defp text_predicate(field, query) do
     dynamic(
       [p],
-      fragment(
-        "to_tsvector('rb_search', coalesce(?::text, '')) @@ ?",
-        field(p, ^field),
-        ^value_query(value, exact)
-      )
+      fragment("to_tsvector('rb_search', coalesce(?::text, '')) @@ ?", field(p, ^field), ^query)
     )
   end
 
-  defp value_query(value, true),
+  # A quoted value is a phrase, whatever the mode: it was asked for as written.
+  defp value_query(value, true, _mode),
     do: dynamic(fragment("phraseto_tsquery('rb_search', ?)", ^value))
 
-  defp value_query(value, false) do
+  defp value_query(value, false, :prefix) do
     query = value |> String.split(~r/\s+/, trim: true) |> and_prefixes()
     dynamic(fragment("to_tsquery('rb_search', ?)", ^query))
+  end
+
+  # An operator's value is forgiven a misspelling exactly as a free word is:
+  # each of its words stands for the indexed words it resembles.
+  defp value_query(value, false, :fuzzy) do
+    value
+    |> String.split(~r/\s+/, trim: true)
+    |> Enum.map(&search_keywords(&1, :fuzzy))
+    |> case do
+      [] ->
+        :none
+
+      groups ->
+        if Enum.any?(groups, &(&1 == [])) do
+          :none
+        else
+          dynamic(fragment("to_tsquery('rb_search', ?)", ^and_fuzzy(groups)))
+        end
+    end
   end
 
   defp ranking({:spelled_out, term}),
@@ -379,7 +396,11 @@ defmodule RichardBurton.Publication.Index do
   defp asked(alternatives, mode) do
     {:alternatives,
      Enum.map(alternatives, fn alternative ->
-       %{query: words_query(alternative.words, mode), filters: alternative.filters}
+       %{
+         query: words_query(alternative.words, mode),
+         filters: alternative.filters,
+         mode: mode
+       }
      end)}
   end
 

--- a/backend/lib/richard_burton/publication_index.ex
+++ b/backend/lib/richard_burton/publication_index.ex
@@ -2,13 +2,25 @@ defmodule RichardBurton.Publication.Index do
   @moduledoc """
   Full-text search over the publication index.
 
-  A search runs in one of two modes. A plain term is split on `:or` (or `:ou`) into
-  alternatives, any of which may match; within an alternative the words are
-  matched each on its own (as a prefix, or fuzzily if nothing matches as typed)
-  and combined with AND, so each word narrows the result. A term that quotes a
-  phrase or negates a word is instead passed to Postgres verbatim, exactly as
-  written. Either way the match runs against a `tsvector` built with accents
-  folded, so a term is folded the same way before it is compared.
+  A term is read as the alternatives `:or` (or `:ou`) separates, any of which
+  may match. An alternative is free words — matched each on its own, as a
+  prefix or fuzzily if nothing matches as typed, and combined with AND so each
+  one narrows — together with the operators that name a single field:
+
+      title:casmurro            the title alone
+      autor:machado             the writer, in Portuguese
+      year:1950-1960            a span of years
+      -country:US               everything but
+      title:"dom casmurro"      the phrase, in that order
+
+  An alternative is satisfied by its words and its operators together. A term
+  with no operator that quotes a phrase or negates a word is passed to Postgres
+  verbatim instead, exactly as written.
+
+  Either way the match runs against a `tsvector` built with accents folded, so a
+  term is folded the same way before it is compared. See
+  `RichardBurton.Publication.Index.Term` for the operators and the words that
+  name them.
   """
 
   import Ecto.Query
@@ -16,6 +28,7 @@ defmodule RichardBurton.Publication.Index do
   alias RichardBurton.FlatPublication
   alias RichardBurton.Publication.Index.SearchDocument
   alias RichardBurton.Publication.Index.SearchKeyword
+  alias RichardBurton.Publication.Index.Term
   alias RichardBurton.Repo
 
   # The response header carrying the index's total publication count.
@@ -217,17 +230,102 @@ defmodule RichardBurton.Publication.Index do
     )
   end
 
-  defp matches({:parsed, query}),
-    do: dynamic(fragment("document @@ to_tsquery('rb_search', ?)", ^query))
-
   defp matches({:spelled_out, term}),
     do: dynamic(fragment("document @@ websearch_to_tsquery('rb_search', ?)", ^term))
 
-  defp ranking({:parsed, query}),
-    do: dynamic(fragment("ts_rank_cd(document, to_tsquery('rb_search', ?), 4)", ^query))
+  # Any alternative will do, and each is its words and its operators together.
+  defp matches({:alternatives, alternatives}) do
+    alternatives
+    |> Enum.map(&alternative_predicate/1)
+    |> Enum.reduce(fn predicate, acc -> dynamic(^acc or ^predicate) end)
+  end
+
+  defp alternative_predicate(%{query: query, filters: filters}) do
+    [words_predicate(query) | Enum.map(filters, &filter_predicate/1)]
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      # Only operators nothing could be made of: the alternative asks nothing,
+      # rather than silently asking for everything.
+      [] -> dynamic(false)
+      predicates -> Enum.reduce(predicates, fn predicate, acc -> dynamic(^acc and ^predicate) end)
+    end
+  end
+
+  defp words_predicate(nil), do: nil
+
+  defp words_predicate(query),
+    do: dynamic(fragment("document @@ to_tsquery('rb_search', ?)", ^query))
+
+  # An operator asks of one field rather than of the whole document, so it is
+  # matched against that field's own text. A quoted value is a phrase, taken in
+  # order; anything else matches from the start of a word, as free text does.
+  defp filter_predicate(%{field: :year, value: value, negated: negated}) do
+    case Term.span(value) do
+      :none -> nil
+      {from, to} -> negate(year_predicate(from, to), negated)
+    end
+  end
+
+  defp filter_predicate(%{field: field, value: value, exact: exact, negated: negated}) do
+    negate(text_predicate(field, value, exact), negated)
+  end
+
+  defp negate(predicate, false), do: predicate
+  defp negate(predicate, true), do: dynamic(not (^predicate))
+
+  defp year_predicate(nil, to), do: dynamic([p], p.year <= ^to)
+  defp year_predicate(from, nil), do: dynamic([p], p.year >= ^from)
+  defp year_predicate(from, to), do: dynamic([p], p.year >= ^from and p.year <= ^to)
+
+  # References are a list, so they are matched as the text of the whole list —
+  # the same thing the search document folds them in as.
+  defp text_predicate(:references, value, exact) do
+    dynamic(
+      [p],
+      fragment(
+        "to_tsvector('rb_search', array_to_string(?, ' ')) @@ ?",
+        p.references,
+        ^value_query(value, exact)
+      )
+    )
+  end
+
+  defp text_predicate(field, value, exact) do
+    dynamic(
+      [p],
+      fragment(
+        "to_tsvector('rb_search', coalesce(?::text, '')) @@ ?",
+        field(p, ^field),
+        ^value_query(value, exact)
+      )
+    )
+  end
+
+  defp value_query(value, true),
+    do: dynamic(fragment("phraseto_tsquery('rb_search', ?)", ^value))
+
+  defp value_query(value, false) do
+    query = value |> String.split(~r/\s+/, trim: true) |> and_prefixes()
+    dynamic(fragment("to_tsquery('rb_search', ?)", ^query))
+  end
 
   defp ranking({:spelled_out, term}),
     do: dynamic(fragment("ts_rank_cd(document, websearch_to_tsquery('rb_search', ?), 4)", ^term))
+
+  # Rank on the words asked for, whichever alternative they came from; an
+  # alternative made only of operators has nothing to rank by and adds nothing.
+  defp ranking({:alternatives, alternatives}) do
+    alternatives
+    |> Enum.map(& &1.query)
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      [] -> dynamic(0.0)
+      queries -> ranking_by(Enum.map_join(queries, " | ", &"(#{&1})"))
+    end
+  end
+
+  defp ranking_by(query),
+    do: dynamic(fragment("ts_rank_cd(document, to_tsquery('rb_search', ?), 4)", ^query))
 
   # The ids a search matches, in reading order — the ordering the reader pages
   # through by id.
@@ -244,19 +342,29 @@ defmodule RichardBurton.Publication.Index do
   # it wants, so it is passed to Postgres as written and never widened: no prefix
   # matching, and no fuzzy pass that could add back a word it just excluded.
   defp answering(term) do
-    if spelled_out?(term) do
-      ask = {:spelled_out, term}
-      {ask, [], order_ids(ask)}
-    else
-      alternatives = or_split(term)
-      as_written = {:parsed, written_query(alternatives)}
+    alternatives = Term.parse(term)
 
-      case order_ids(as_written) do
-        [] -> fuzzily_answering(alternatives)
-        ids -> {as_written, prefix_keywords(alternatives), ids}
-      end
+    cond do
+      alternatives == [] ->
+        :none
+
+      # A term that only quotes or excludes, with no operator in it, is still
+      # handed to Postgres as written — the path that has always served it.
+      plain?(alternatives) and spelled_out?(term) ->
+        ask = {:spelled_out, term}
+        {ask, [], order_ids(ask)}
+
+      true ->
+        as_written = asked(alternatives, :prefix)
+
+        case order_ids(as_written) do
+          [] -> fuzzily_answering(alternatives)
+          ids -> {as_written, prefix_keywords(alternatives), ids}
+        end
     end
   end
+
+  defp plain?(alternatives), do: Enum.all?(alternatives, &(&1.filters == []))
 
   defp fuzzily_answering(alternatives) do
     case fuzzily(alternatives) do
@@ -265,39 +373,34 @@ defmodule RichardBurton.Publication.Index do
     end
   end
 
-  # Split a term into the alternatives `:or` separates, each a list of words.
-  # "one two :or three" becomes [["one", "two"], ["three"]]. A term with no
-  # `:or` is one alternative, so the AND-narrowing path is unchanged.
-  #
-  # The operator wears a colon so that it cannot be mistaken for a word being
-  # searched for — a title like "Love or Death" is about the word, not the
-  # operator — and it answers to `:ou` as well, since a reader searching a
-  # Brazilian database should not have to reach for English to widen a query.
-  defp or_split(term) do
-    term
-    |> String.split(~r/\s+:(or|ou)\s+/i, trim: true)
-    |> Enum.map(&String.split(&1, ~r/\s+/, trim: true))
-    |> Enum.reject(&(&1 == []))
+  # What the search asks of the database: for each alternative, the words to
+  # look for anywhere in the record and the operators that narrow it. An
+  # alternative is satisfied by both together, and any alternative will do.
+  defp asked(alternatives, mode) do
+    {:alternatives,
+     Enum.map(alternatives, fn alternative ->
+       %{query: words_query(alternative.words, mode), filters: alternative.filters}
+     end)}
+  end
+
+  defp words_query([], _mode), do: nil
+  defp words_query(words, :prefix), do: and_prefixes(words)
+
+  defp words_query(words, :fuzzy) do
+    case fuzzy_words(words) do
+      [] -> nil
+      groups -> and_fuzzy(groups)
+    end
   end
 
   defp prefix_keywords(alternatives),
     do:
       alternatives
-      |> List.flatten()
+      |> Enum.flat_map(& &1.words)
       |> Enum.flat_map(&search_keywords(&1, :prefix))
       |> Enum.uniq()
 
   defp spelled_out?(term), do: String.contains?(term, ~s(")) or term =~ ~r/(^|\s)-\S/
-
-  # `:*` makes each word a prefix, so a word still being typed matches every
-  # word that starts with it, and a complete word matches itself. A country name
-  # is matched the same way as any other word: its names are folded into the
-  # document at index time, so "United Kingdom" reaches the record that stores
-  # the code "GB" with no special handling here. Alternatives are OR-ed, their
-  # words AND-ed.
-  defp written_query(alternatives) do
-    Enum.map_join(alternatives, " | ", &"(#{and_prefixes(&1)})")
-  end
 
   defp and_prefixes(words), do: Enum.map_join(words, " & ", &"(#{lexeme(&1)}:*)")
 
@@ -306,17 +409,22 @@ defmodule RichardBurton.Publication.Index do
   # own word, not the whole alternative. An alternative left with no words is
   # dropped whole.
   defp fuzzily(alternatives) do
-    alternatives
-    |> Enum.map(&fuzzy_words/1)
-    |> Enum.reject(&(&1 == []))
-    |> case do
-      [] ->
-        :none
+    {:alternatives, asked} = ask = asked(alternatives, :fuzzy)
 
-      alternatives ->
-        query = Enum.map_join(alternatives, " | ", &"(#{and_fuzzy(&1)})")
-        {{:parsed, query}, alternatives |> List.flatten() |> Enum.uniq()}
+    # Nothing resembled anything and no operator narrowed anything: the term
+    # names nothing this database holds.
+    if Enum.all?(asked, &(&1.query == nil and &1.filters == [])) do
+      :none
+    else
+      {ask, fuzzy_keywords(alternatives)}
     end
+  end
+
+  defp fuzzy_keywords(alternatives) do
+    alternatives
+    |> Enum.flat_map(& &1.words)
+    |> Enum.flat_map(&search_keywords(&1, :fuzzy))
+    |> Enum.uniq()
   end
 
   # One alternative's words resolved to the keywords they resemble, dropping any

--- a/backend/lib/richard_burton/publication_index/term.ex
+++ b/backend/lib/richard_burton/publication_index/term.ex
@@ -7,7 +7,9 @@ defmodule RichardBurton.Publication.Index.Term do
   that name a single field. `title:casmurro` asks of the title alone;
   `year:1950-1960` asks for a span of years; a leading `-` excludes rather than
   requires; `title:"dom casmurro"` asks for those words in that order; and
-  `title:(dom casmurro)` asks for both of them, in any.
+  `title:(dom casmurro)` asks for both of them, in any. An operator's value is
+  matched as a free word is — from the start of a word, and fuzzily when
+  nothing matches as typed — except when quoted, which asks for it as written.
 
   Operators answer to three vocabularies — the labels the interface uses, the
   names the database uses, and Portuguese — because the reader of a database of

--- a/backend/lib/richard_burton/publication_index/term.ex
+++ b/backend/lib/richard_burton/publication_index/term.ex
@@ -1,0 +1,166 @@
+defmodule RichardBurton.Publication.Index.Term do
+  @moduledoc """
+  What a reader typed, read as a question.
+
+  A term is free text — words to look for anywhere in a publication — with two
+  things picked out of it: the alternatives `:or` separates, and the operators
+  that name a single field. `title:casmurro` asks of the title alone;
+  `year:1950-1960` asks for a span of years; a leading `-` excludes rather than
+  requires; and a quoted value is taken as written rather than as the start of a
+  word.
+
+  Operators answer to three vocabularies — the labels the interface uses, the
+  names the database uses, and Portuguese — because the reader of a database of
+  Brazilian literature should not have to know which language it was built in.
+  A prefix this does not recognise is not an operator at all: `foo:bar` is
+  searched for as the words it looks like, which is friendlier than refusing a
+  query over a colon someone typed in a title.
+  """
+
+  @type filter :: %{field: atom, value: String.t(), exact: boolean, negated: boolean}
+  @type alternative :: %{words: [String.t()], filters: [filter]}
+
+  # Every name an operator answers to. Reader labels first, then the schema's
+  # own, then Portuguese. `author` is deliberately absent: this database calls
+  # the writer of the book the original author and the person who rendered it
+  # the translator, and a bare "author" would have to guess between them.
+  @fields %{
+    "title" => :title,
+    "titulo" => :title,
+    "título" => :title,
+    "original" => :original_title,
+    "original_title" => :original_title,
+    "original-title" => :original_title,
+    "titulo_original" => :original_title,
+    "titulo-original" => :original_title,
+    "translator" => :authors,
+    "translators" => :authors,
+    "authors" => :authors,
+    "tradutor" => :authors,
+    "tradutores" => :authors,
+    "original_author" => :original_authors,
+    "original-author" => :original_authors,
+    "original_authors" => :original_authors,
+    "autor" => :original_authors,
+    "autores" => :original_authors,
+    "country" => :countries,
+    "countries" => :countries,
+    "pais" => :countries,
+    "país" => :countries,
+    "paises" => :countries,
+    "países" => :countries,
+    "publisher" => :publishers,
+    "publishers" => :publishers,
+    "editora" => :publishers,
+    "editoras" => :publishers,
+    "year" => :year,
+    "ano" => :year,
+    "source" => :references,
+    "sources" => :references,
+    "references" => :references,
+    "fonte" => :references,
+    "fontes" => :references
+  }
+
+  # A token runs until a space, except that a quoted stretch is part of it and
+  # may hold spaces — so `title:"dom casmurro"` is one token, not two.
+  @token ~r/(?:[^\s"]+|"[^"]*")+/
+  @operator ~r/^(?<negated>-?)(?<field>[^\s:"]+):(?<value>.*)$/s
+  @alternator ~r/^:(or|ou)$/i
+
+  @doc "The fields an operator can name, against every word that names them."
+  def fields, do: @fields
+
+  @doc """
+  Read a term as the alternatives it offers, each a set of words to look for and
+  the filters that narrow them. A term with no operators is one alternative of
+  words, which is what the search has always been.
+  """
+  @spec parse(String.t()) :: [alternative]
+  def parse(term) when is_binary(term) do
+    @token
+    |> Regex.scan(term)
+    |> Enum.map(&hd/1)
+    |> Enum.chunk_by(&(&1 =~ @alternator))
+    |> Enum.reject(&(hd(&1) =~ @alternator))
+    |> Enum.map(&read_alternative/1)
+    |> Enum.reject(&(&1.words == [] and &1.filters == []))
+  end
+
+  defp read_alternative(tokens) do
+    {filters, words} = Enum.split_with(tokens, &operator?/1)
+
+    %{
+      words: Enum.map(words, &unquoted/1),
+      filters: Enum.map(filters, &read_filter/1)
+    }
+  end
+
+  defp operator?(token) do
+    case Regex.named_captures(@operator, token) do
+      nil -> false
+      %{"field" => field, "value" => value} -> known?(field) and value != ""
+    end
+  end
+
+  defp read_filter(token) do
+    %{"negated" => negated, "field" => field, "value" => value} =
+      Regex.named_captures(@operator, token)
+
+    %{
+      field: Map.fetch!(@fields, String.downcase(field)),
+      value: unquoted(value),
+      exact: quoted?(value),
+      negated: negated == "-"
+    }
+  end
+
+  defp known?(field), do: Map.has_key?(@fields, String.downcase(field))
+
+  defp quoted?(value), do: String.starts_with?(value, ~s(")) and String.ends_with?(value, ~s("))
+
+  defp unquoted(value) do
+    if quoted?(value) and String.length(value) >= 2,
+      do: String.slice(value, 1..-2//1),
+      else: value
+  end
+
+  @doc """
+  A year operator's value as the span it names: `1950` is that year alone,
+  `1950-1960` the years between, and an open end (`1950-`, `-1960`) everything
+  from or up to it. Anything else is not a span, and the operator is ignored
+  rather than answered wrongly.
+  """
+  @spec span(String.t()) :: {integer | nil, integer | nil} | :none
+  def span(value) do
+    case String.split(value, "-", parts: 2) do
+      [year] -> single(year)
+      [from, to] -> range(from, to)
+    end
+  end
+
+  defp single(year) do
+    case Integer.parse(String.trim(year)) do
+      {year, ""} -> {year, year}
+      _ -> :none
+    end
+  end
+
+  defp range(from, to) do
+    case {edge(from), edge(to)} do
+      {:invalid, _} -> :none
+      {_, :invalid} -> :none
+      {nil, nil} -> :none
+      {from, to} -> {from, to}
+    end
+  end
+
+  defp edge(""), do: nil
+
+  defp edge(value) do
+    case Integer.parse(String.trim(value)) do
+      {year, ""} -> year
+      _ -> :invalid
+    end
+  end
+end

--- a/backend/lib/richard_burton/publication_index/term.ex
+++ b/backend/lib/richard_burton/publication_index/term.ex
@@ -20,51 +20,40 @@ defmodule RichardBurton.Publication.Index.Term do
   @type filter :: %{field: atom, value: String.t(), exact: boolean, negated: boolean}
   @type alternative :: %{words: [String.t()], filters: [filter]}
 
-  # Every name an operator answers to: the labels the interface shows, the names
-  # the database uses, and Portuguese.
+  # Every name an operator answers to, in English and in Portuguese.
   #
-  # `author` names the writer of the book, and so does `authors` — even though
-  # the column called `authors` holds the translators. That is the database's
-  # word for them, and it has no business reaching the person typing: a reader
-  # asking for an author means whoever wrote the thing, and asks for the person
-  # who rendered it by name, as `translator`.
+  # Each is singular, because asking for more than one of something is asking
+  # the same operator twice — `author:machado author:assis` wants both — and a
+  # plural spelling would only be a second way to say the same thing.
+  #
+  # `author` names whoever wrote the book, though the column holding the
+  # translators is the one called `authors`. That is the database's word for
+  # them, and it has no business reaching the person typing: the one who
+  # rendered a book is asked for as `translator`.
   @fields %{
     "title" => :title,
     "titulo" => :title,
     "título" => :title,
     "original" => :original_title,
-    "original_title" => :original_title,
     "original-title" => :original_title,
-    "titulo_original" => :original_title,
+    "original_title" => :original_title,
     "titulo-original" => :original_title,
+    "titulo_original" => :original_title,
     "translator" => :authors,
-    "translators" => :authors,
     "tradutor" => :authors,
-    "tradutores" => :authors,
     "author" => :original_authors,
-    "authors" => :original_authors,
-    "original_author" => :original_authors,
-    "original-author" => :original_authors,
-    "original_authors" => :original_authors,
     "autor" => :original_authors,
-    "autores" => :original_authors,
+    "original-author" => :original_authors,
+    "original_author" => :original_authors,
     "country" => :countries,
-    "countries" => :countries,
     "pais" => :countries,
     "país" => :countries,
-    "paises" => :countries,
-    "países" => :countries,
     "publisher" => :publishers,
-    "publishers" => :publishers,
     "editora" => :publishers,
-    "editoras" => :publishers,
     "year" => :year,
     "ano" => :year,
     "source" => :references,
-    "sources" => :references,
-    "references" => :references,
-    "fonte" => :references,
-    "fontes" => :references
+    "fonte" => :references
   }
 
   # A token runs until a space, except that a quoted or bracketed stretch is

--- a/backend/lib/richard_burton/publication_index/term.ex
+++ b/backend/lib/richard_burton/publication_index/term.ex
@@ -6,8 +6,8 @@ defmodule RichardBurton.Publication.Index.Term do
   things picked out of it: the alternatives `:or` separates, and the operators
   that name a single field. `title:casmurro` asks of the title alone;
   `year:1950-1960` asks for a span of years; a leading `-` excludes rather than
-  requires; and a quoted value is taken as written rather than as the start of a
-  word.
+  requires; `title:"dom casmurro"` asks for those words in that order; and
+  `title:(dom casmurro)` asks for both of them, in any.
 
   Operators answer to three vocabularies — the labels the interface uses, the
   names the database uses, and Portuguese — because the reader of a database of
@@ -20,10 +20,14 @@ defmodule RichardBurton.Publication.Index.Term do
   @type filter :: %{field: atom, value: String.t(), exact: boolean, negated: boolean}
   @type alternative :: %{words: [String.t()], filters: [filter]}
 
-  # Every name an operator answers to. Reader labels first, then the schema's
-  # own, then Portuguese. `author` is deliberately absent: this database calls
-  # the writer of the book the original author and the person who rendered it
-  # the translator, and a bare "author" would have to guess between them.
+  # Every name an operator answers to: the labels the interface shows, the names
+  # the database uses, and Portuguese.
+  #
+  # `author` names the writer of the book, and so does `authors` — even though
+  # the column called `authors` holds the translators. That is the database's
+  # word for them, and it has no business reaching the person typing: a reader
+  # asking for an author means whoever wrote the thing, and asks for the person
+  # who rendered it by name, as `translator`.
   @fields %{
     "title" => :title,
     "titulo" => :title,
@@ -35,9 +39,10 @@ defmodule RichardBurton.Publication.Index.Term do
     "titulo-original" => :original_title,
     "translator" => :authors,
     "translators" => :authors,
-    "authors" => :authors,
     "tradutor" => :authors,
     "tradutores" => :authors,
+    "author" => :original_authors,
+    "authors" => :original_authors,
     "original_author" => :original_authors,
     "original-author" => :original_authors,
     "original_authors" => :original_authors,
@@ -62,9 +67,10 @@ defmodule RichardBurton.Publication.Index.Term do
     "fontes" => :references
   }
 
-  # A token runs until a space, except that a quoted stretch is part of it and
-  # may hold spaces — so `title:"dom casmurro"` is one token, not two.
-  @token ~r/(?:[^\s"]+|"[^"]*")+/
+  # A token runs until a space, except that a quoted or bracketed stretch is
+  # part of it and may hold spaces — so `title:"dom casmurro"` and
+  # `title:(dom casmurro)` are each one token, not two.
+  @token ~r/(?:[^\s"()]+|"[^"]*"|\([^)]*\))+/
   @operator ~r/^(?<negated>-?)(?<field>[^\s:"]+):(?<value>.*)$/s
   @alternator ~r/^:(or|ou)$/i
 
@@ -117,10 +123,19 @@ defmodule RichardBurton.Publication.Index.Term do
 
   defp known?(field), do: Map.has_key?(@fields, String.downcase(field))
 
-  defp quoted?(value), do: String.starts_with?(value, ~s(")) and String.ends_with?(value, ~s("))
+  defp quoted?(value), do: wrapped?(value, ~s("), ~s("))
+
+  # Several words asked of one field, in any order: `title:(dom casmurro)`.
+  # Quoting would ask for them in that order, which is a different question.
+  defp grouped?(value), do: wrapped?(value, "(", ")")
+
+  defp wrapped?(value, opening, closing),
+    do:
+      String.length(value) >= 2 and String.starts_with?(value, opening) and
+        String.ends_with?(value, closing)
 
   defp unquoted(value) do
-    if quoted?(value) and String.length(value) >= 2,
+    if quoted?(value) or grouped?(value),
       do: String.slice(value, 1..-2//1),
       else: value
   end

--- a/backend/test/richard_burton/publication_index_term_test.exs
+++ b/backend/test/richard_burton/publication_index_term_test.exs
@@ -68,17 +68,11 @@ defmodule RichardBurton.Publication.Index.TermTest do
       end
     end
 
-    test "answers to the names the database uses" do
-      for {name, field} <- [
-            {"original_title", :original_title},
-            {"original_authors", :original_authors},
-            {"countries", :countries},
-            {"publishers", :publishers},
-            {"references", :references}
-          ] do
-        assert [%{filters: [%{field: ^field}]}] = Term.parse("#{name}:x"),
-               "expected #{name}: to name #{field}"
-      end
+    test "asking for more than one is asking twice, not a plural name" do
+      # `author:machado author:assis` wants both; a plural spelling would only
+      # be a second way to say the same thing.
+      assert [%{words: ["authors:machado"], filters: []}] = Term.parse("authors:machado")
+      assert [%{filters: [_, _]}] = Term.parse("author:machado author:assis")
     end
 
     test "answers in Portuguese" do
@@ -107,7 +101,7 @@ defmodule RichardBurton.Publication.Index.TermTest do
       # The column named `authors` holds the translators; that is the database's
       # word, and a reader asking for an author means the writer.
       assert [%{filters: [%{field: :original_authors}]}] = Term.parse("author:machado")
-      assert [%{filters: [%{field: :original_authors}]}] = Term.parse("authors:machado")
+      assert [%{filters: [%{field: :original_authors}]}] = Term.parse("autor:machado")
       assert [%{filters: [%{field: :authors}]}] = Term.parse("translator:caldwell")
     end
 

--- a/backend/test/richard_burton/publication_index_term_test.exs
+++ b/backend/test/richard_burton/publication_index_term_test.exs
@@ -71,7 +71,6 @@ defmodule RichardBurton.Publication.Index.TermTest do
     test "answers to the names the database uses" do
       for {name, field} <- [
             {"original_title", :original_title},
-            {"authors", :authors},
             {"original_authors", :original_authors},
             {"countries", :countries},
             {"publishers", :publishers},
@@ -102,6 +101,19 @@ defmodule RichardBurton.Publication.Index.TermTest do
     test "the name is read whatever its case" do
       assert [%{filters: [%{field: :title}]}] = Term.parse("Title:casmurro")
       assert [%{filters: [%{field: :title}]}] = Term.parse("TÍTULO:casmurro")
+    end
+
+    test "an author is whoever wrote the book, whatever the column is called" do
+      # The column named `authors` holds the translators; that is the database's
+      # word, and a reader asking for an author means the writer.
+      assert [%{filters: [%{field: :original_authors}]}] = Term.parse("author:machado")
+      assert [%{filters: [%{field: :original_authors}]}] = Term.parse("authors:machado")
+      assert [%{filters: [%{field: :authors}]}] = Term.parse("translator:caldwell")
+    end
+
+    test "a bracketed value asks for several words of one field, in any order" do
+      assert [%{filters: [filter]}] = Term.parse("title:(dom casmurro)")
+      assert %{field: :title, value: "dom casmurro", exact: false} = filter
     end
 
     test "a prefix it does not know is not an operator" do

--- a/backend/test/richard_burton/publication_index_term_test.exs
+++ b/backend/test/richard_burton/publication_index_term_test.exs
@@ -1,0 +1,140 @@
+defmodule RichardBurton.Publication.Index.TermTest do
+  @moduledoc """
+  Tests for reading a search term as the question it asks.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias RichardBurton.Publication.Index.Term
+
+  describe "parse/1 without operators" do
+    test "a plain term is one alternative of words" do
+      assert [%{words: ["machado", "assis"], filters: []}] = Term.parse("machado assis")
+    end
+
+    test "`:or` cuts the term into alternatives" do
+      assert [%{words: ["machado"]}, %{words: ["assis"]}] = Term.parse("machado :or assis")
+    end
+
+    test "an empty term asks nothing" do
+      assert Term.parse("") == []
+      assert Term.parse("   ") == []
+    end
+  end
+
+  describe "parse/1 with a field operator" do
+    test "names the field, and keeps the rest as words" do
+      assert [%{words: ["1953"], filters: [filter]}] = Term.parse("title:casmurro 1953")
+
+      assert %{field: :title, value: "casmurro", exact: false, negated: false} = filter
+    end
+
+    test "a quoted value is taken as written" do
+      assert [%{filters: [%{value: "dom casmurro", exact: true}]}] =
+               Term.parse(~s(title:"dom casmurro"))
+    end
+
+    test "a leading minus excludes" do
+      assert [%{filters: [%{field: :countries, value: "GB", negated: true}]}] =
+               Term.parse("-country:GB")
+    end
+
+    test "several operators narrow together" do
+      assert [%{filters: filters}] = Term.parse("title:casmurro year:1953")
+      assert Enum.map(filters, & &1.field) == [:title, :year]
+    end
+
+    test "operators live inside their own alternative" do
+      assert [first, second] = Term.parse("title:casmurro :or title:iracema")
+      assert [%{value: "casmurro"}] = first.filters
+      assert [%{value: "iracema"}] = second.filters
+    end
+  end
+
+  describe "parse/1 vocabulary" do
+    test "answers to the labels the interface uses" do
+      for {name, field} <- [
+            {"title", :title},
+            {"original", :original_title},
+            {"translator", :authors},
+            {"original-author", :original_authors},
+            {"country", :countries},
+            {"publisher", :publishers},
+            {"year", :year},
+            {"source", :references}
+          ] do
+        assert [%{filters: [%{field: ^field}]}] = Term.parse("#{name}:x"),
+               "expected #{name}: to name #{field}"
+      end
+    end
+
+    test "answers to the names the database uses" do
+      for {name, field} <- [
+            {"original_title", :original_title},
+            {"authors", :authors},
+            {"original_authors", :original_authors},
+            {"countries", :countries},
+            {"publishers", :publishers},
+            {"references", :references}
+          ] do
+        assert [%{filters: [%{field: ^field}]}] = Term.parse("#{name}:x"),
+               "expected #{name}: to name #{field}"
+      end
+    end
+
+    test "answers in Portuguese" do
+      for {name, field} <- [
+            {"titulo", :title},
+            {"título", :title},
+            {"tradutor", :authors},
+            {"autor", :original_authors},
+            {"pais", :countries},
+            {"país", :countries},
+            {"editora", :publishers},
+            {"ano", :year},
+            {"fonte", :references}
+          ] do
+        assert [%{filters: [%{field: ^field}]}] = Term.parse("#{name}:x"),
+               "expected #{name}: to name #{field}"
+      end
+    end
+
+    test "the name is read whatever its case" do
+      assert [%{filters: [%{field: :title}]}] = Term.parse("Title:casmurro")
+      assert [%{filters: [%{field: :title}]}] = Term.parse("TÍTULO:casmurro")
+    end
+
+    test "a prefix it does not know is not an operator" do
+      # A colon in a title is a colon in a title, not a failed query.
+      assert [%{words: ["manuel:", "de", "moraes"], filters: []}] =
+               Term.parse("manuel: de moraes")
+
+      assert [%{words: ["foo:bar"], filters: []}] = Term.parse("foo:bar")
+    end
+
+    test "a name with nothing after it is not an operator" do
+      assert [%{words: ["title:"], filters: []}] = Term.parse("title:")
+    end
+  end
+
+  describe "span/1" do
+    test "a single year is that year" do
+      assert Term.span("1953") == {1953, 1953}
+    end
+
+    test "two years are the span between them" do
+      assert Term.span("1950-1960") == {1950, 1960}
+    end
+
+    test "an open end runs from, or up to" do
+      assert Term.span("1950-") == {1950, nil}
+      assert Term.span("-1960") == {nil, 1960}
+    end
+
+    test "what is not a span is no span at all" do
+      assert Term.span("recent") == :none
+      assert Term.span("195x-1960") == :none
+      assert Term.span("-") == :none
+    end
+  end
+end

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -812,6 +812,27 @@ defmodule RichardBurton.Publication.IndexTest do
       assert found(~s(title:"wind and the time")) == []
     end
 
+    test "several words can be asked of one field, in any order" do
+      grouped = found("title:(time wind)")
+
+      refute Enum.empty?(grouped)
+      assert Enum.all?(grouped, &(&1.title == "Time and the Wind"))
+      # Order does not matter, unlike a quoted phrase.
+      assert Enum.map(found("title:(wind time)"), & &1.id) == Enum.map(grouped, & &1.id)
+      assert found(~s(title:"wind time")) == []
+    end
+
+    test "an author is the writer, and a translator the one who rendered it" do
+      writers = found("author:verissimo")
+      renderers = found("translator:barrett")
+
+      refute Enum.empty?(writers)
+      assert Enum.all?(writers, &(String.downcase(&1.original_authors) =~ "verissimo"))
+
+      refute Enum.empty?(renderers)
+      assert Enum.all?(renderers, &(String.downcase(&1.authors) =~ "barrett"))
+    end
+
     test "operators narrow the free words beside them" do
       loose = found("night")
       narrowed = found("night country:US")

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -858,6 +858,17 @@ defmodule RichardBurton.Publication.IndexTest do
       assert Enum.all?(results, &(&1.year == 1956))
     end
 
+    test "a misspelled value is forgiven, as a free word is" do
+      assert Enum.all?(found("title:nigth"), &(&1.title == "Night"))
+      refute Enum.empty?(found("title:nigth"))
+
+      # Inside a bracketed value too, word by word.
+      refute Enum.empty?(found("title:(nigth)"))
+
+      # And what resembles nothing still answers nothing.
+      assert found("title:zzzzqqqx") == []
+    end
+
     test "a half-typed value still finds the word it could become" do
       assert Enum.all?(found("translator:barr"), &(String.downcase(&1.authors) =~ "barr"))
       refute Enum.empty?(found("translator:barr"))

--- a/backend/test/richard_burton/publication_index_test.exs
+++ b/backend/test/richard_burton/publication_index_test.exs
@@ -744,6 +744,113 @@ defmodule RichardBurton.Publication.IndexTest do
     end
   end
 
+  describe "search/1 with field operators" do
+    defp found(term) do
+      {:ok, publications, _} = Publication.Index.search(term)
+      publications
+    end
+
+    test "a field operator asks of that field alone" do
+      results = found("title:night")
+
+      refute Enum.empty?(results)
+      assert Enum.all?(results, &(String.downcase(&1.title) =~ "night"))
+    end
+
+    test "the same word asked of another field answers differently" do
+      by_title = found("title:noite")
+      by_original = found("original:noite")
+
+      assert Enum.empty?(by_title)
+      refute Enum.empty?(by_original)
+      assert Enum.all?(by_original, &(String.downcase(&1.original_title) =~ "noite"))
+    end
+
+    test "a translator and an original author are told apart" do
+      translators = found("translator:barrett")
+      authors = found("autor:verissimo")
+
+      refute Enum.empty?(translators)
+      assert Enum.all?(translators, &(String.downcase(&1.authors) =~ "barrett"))
+
+      refute Enum.empty?(authors)
+      assert Enum.all?(authors, &(String.downcase(&1.original_authors) =~ "verissimo"))
+    end
+
+    test "a publisher and a country can be asked for" do
+      assert Enum.all?(
+               found("publisher:macmillan"),
+               &(String.downcase(&1.publishers) =~ "macmillan")
+             )
+
+      assert Enum.all?(found("country:GB"), &(&1.countries =~ "GB"))
+      refute Enum.empty?(found("editora:macmillan"))
+      refute Enum.empty?(found("pais:GB"))
+    end
+
+    test "a year is a year, and a span is a span" do
+      assert Enum.all?(found("year:1956"), &(&1.year == 1956))
+      assert Enum.all?(found("year:1950-1960"), &(&1.year >= 1950 and &1.year <= 1960))
+      assert Enum.all?(found("ano:2000-"), &(&1.year >= 2000))
+      assert Enum.all?(found("year:-1950"), &(&1.year <= 1950))
+
+      refute Enum.empty?(found("year:1950-1960"))
+    end
+
+    test "a minus excludes what it names" do
+      all = found("translator:barrett")
+      without = found("translator:barrett -country:US")
+
+      refute Enum.empty?(without)
+      assert length(without) < length(all)
+      refute Enum.any?(without, &(&1.countries =~ "US"))
+    end
+
+    test "a quoted value is a phrase, not a set of words" do
+      assert Enum.all?(found(~s(title:"time and the wind")), &(&1.title == "Time and the Wind"))
+      # The same words in another order are not that phrase.
+      assert found(~s(title:"wind and the time")) == []
+    end
+
+    test "operators narrow the free words beside them" do
+      loose = found("night")
+      narrowed = found("night country:US")
+
+      refute Enum.empty?(narrowed)
+      assert length(narrowed) < length(loose)
+      assert Enum.all?(narrowed, &(&1.countries =~ "US"))
+    end
+
+    test "operators belong to their own alternative" do
+      either = found("country:BR :or country:CA")
+
+      refute Enum.empty?(either)
+      assert Enum.all?(either, &(&1.countries =~ "BR" or &1.countries =~ "CA"))
+      assert Enum.any?(either, &(&1.countries =~ "BR"))
+      assert Enum.any?(either, &(&1.countries =~ "CA"))
+    end
+
+    test "an operator alone answers without any words to look for" do
+      results = found("year:1956")
+
+      refute Enum.empty?(results)
+      assert Enum.all?(results, &(&1.year == 1956))
+    end
+
+    test "a half-typed value still finds the word it could become" do
+      assert Enum.all?(found("translator:barr"), &(String.downcase(&1.authors) =~ "barr"))
+      refute Enum.empty?(found("translator:barr"))
+    end
+
+    test "a prefix that names no field is not an operator" do
+      # A colon someone typed is not a failed query: the term is looked for as
+      # text, and answers as any text does — including the fuzzy ladder, which
+      # is why a word buried in it can still find something.
+      assert found("nosuchfield:zzzzqqqqx") == []
+      refute Enum.empty?(found("nosuchfield:barrett"))
+    end
+  end
+
   describe "search/1 with accents" do
     test "a term written without them finds the words that carry them" do
       {:ok, folded, _} = Publication.Index.search("Angustia")

--- a/frontend/app/Home.tsx
+++ b/frontend/app/Home.tsx
@@ -11,6 +11,7 @@ import { PublicationIndexList } from "components/PublicationIndexList";
 import { PublicationIndexTable } from "components/PublicationIndexTable";
 import PublicationScroll from "components/PublicationScroll";
 import PublicationSearch from "components/PublicationSearch";
+import { SearchHelpModal } from "components/SearchHelpModal";
 import SignInButton from "components/SignInButton";
 import type { PublicationIndex } from "app/publications/read";
 import { usePublicationIndexCount } from "modules/publication/hooks";
@@ -114,6 +115,7 @@ function Database({ index }: Props) {
 
           <ContactModal />
           <LearnMoreModal />
+          <SearchHelpModal />
         </div>
       }
     />

--- a/frontend/components/Modal.tsx
+++ b/frontend/components/Modal.tsx
@@ -124,6 +124,9 @@ const Modal: FC<Props> = ({ children, isOpen, onClose, label = "Dialog" }) => {
                   role="dialog"
                   aria-modal="true"
                   aria-label={label}
+                  // The dialog scrolls when its content outgrows it, and a
+                  // region that scrolls has to be reachable by keyboard.
+                  tabIndex={0}
                   className={`
                   mb-5 sm:rounded-lg bg-white text-gray-900 shadow-lg scrollbar-thin scrollbar-thumb-indigo-600
                   overflow-y-auto overflow-x-clip

--- a/frontend/components/PublicationSearch.tsx
+++ b/frontend/components/PublicationSearch.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { ChangeEventHandler, FC, useRef, useState, useTransition } from "react";
 import useDebounce from "utils/useDebounce";
+import { useURLQueryModal } from "./Modal";
+import { SEARCH_HELP_MODAL_KEY } from "./SearchHelpModal";
 
 /** Long enough that a typist does not query on every letter. */
 const SEARCH_DELAY_MS = 350;
@@ -44,6 +46,9 @@ const PublicationSearch: FC = () => {
 
   const isLoading = search !== searchUrlParam || isNavigating;
 
+  // Opened through the address, so the modal keeps whatever is being searched.
+  const { open: openHelp } = useURLQueryModal(SEARCH_HELP_MODAL_KEY);
+
   const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
     setSearch(e.target.value);
     navigate(e.target.value);
@@ -58,35 +63,44 @@ const PublicationSearch: FC = () => {
         value={search}
         onChange={handleChange}
       />
-      <div aria-live="polite" className="h-4 px-3 space-x-1 text-xs truncate">
-        {isLoading ? (
-          <span>
-            Searching the collection
-            <span aria-hidden className="tracking-widest">
-              <span className="animate-pulse">.</span>
-              <span className="animate-pulse [animation-delay:150ms]">.</span>
-              <span className="animate-pulse [animation-delay:300ms]">.</span>
+      <div className="flex gap-3 items-baseline px-3 h-4 text-xs">
+        <div aria-live="polite" className="space-x-1 truncate grow">
+          {isLoading ? (
+            <span>
+              Searching the collection
+              <span aria-hidden className="tracking-widest">
+                <span className="animate-pulse">.</span>
+                <span className="animate-pulse [animation-delay:150ms]">.</span>
+                <span className="animate-pulse [animation-delay:300ms]">.</span>
+              </span>
             </span>
-          </span>
-        ) : (
-          keywords &&
-          keywords.length > 0 && (
-            <>
-              <span>Showing results for</span>
-              {keywords.map((keyword, index) => (
-                <span key={`search-keyword-${keyword}`}>
-                  <Link
-                    href={`?search=${keyword}`}
-                    className="text-indigo-600 underline hover:bg-indigo-300"
-                  >
-                    {keyword}
-                  </Link>
-                  {index < keywords.length - 1 ? "," : "."}
-                </span>
-              ))}
-            </>
-          )
-        )}
+          ) : (
+            keywords &&
+            keywords.length > 0 && (
+              <>
+                <span>Showing results for</span>
+                {keywords.map((keyword, index) => (
+                  <span key={`search-keyword-${keyword}`}>
+                    <Link
+                      href={`?search=${keyword}`}
+                      className="text-indigo-600 underline hover:bg-indigo-300"
+                    >
+                      {keyword}
+                    </Link>
+                    {index < keywords.length - 1 ? "," : "."}
+                  </span>
+                ))}
+              </>
+            )
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => openHelp()}
+          className="text-gray-600 whitespace-nowrap rounded underline shrink-0 hover:text-indigo-600 focus-ring"
+        >
+          How to search
+        </button>
       </div>
     </section>
   );

--- a/frontend/components/SearchHelpModal.mdx
+++ b/frontend/components/SearchHelpModal.mdx
@@ -1,0 +1,54 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks";
+
+import * as SearchHelpStories from "./SearchHelpModal.stories";
+
+<Meta of={SearchHelpStories} />
+
+# Search help
+
+What the search can do, written for the person searching. The search does a
+good deal that a text box cannot advertise — it forgives accents and
+misspellings, it narrows on every word, and it takes operators — and none of
+that is worth anything to a reader who never finds out. This is where they find
+out.
+
+<Canvas of={SearchHelpStories.Open} />
+
+## What it covers
+
+- **Spelling and accents** — accents may be omitted or included, minor
+  misspellings are tolerated, and an incomplete word matches what it could
+  become. These come first because they are the tolerances a reader is most
+  likely to give up without.
+- **Searching a single field** — `title:`, `author:` (the author of the
+  original work), `translator:`, `publisher:`, `country:`, `original:` and
+  `source:`, and `year:` for a single year or a range.
+- **Refining a search** — quotation marks for words in the order given,
+  parentheses for words of one field in any order, a leading minus to exclude,
+  and a repeated operator to require both.
+- **Broadening a search** — `:or`, the one operator that widens rather than
+  narrows.
+
+## In Portuguese
+
+Every operator answers in Portuguese, and the help says so rather than leaving
+it to be discovered — this is a database of Brazilian literature, and its
+readers should not have to reach for English to ask it something.
+
+<Canvas of={SearchHelpStories.InPortuguese} />
+
+## How it opens
+
+Through the address (`?search-help`), like the platform's other modals, and
+from a quiet link beside the search box. Opening it keeps whatever is being
+searched, so a reader can read how to narrow a query and return to the query
+they were narrowing.
+
+<Canvas of={SearchHelpStories.Closed} />
+
+## What it deliberately does not say
+
+Nothing here is about how the search works underneath — no mention of indexes,
+ranking or prefixes as machinery. Every line is a thing a reader might want and
+the shortest way to ask for it. When an operator changes, this is the copy that
+has to change with it.

--- a/frontend/components/SearchHelpModal.stories.tsx
+++ b/frontend/components/SearchHelpModal.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect, screen } from "storybook/test";
+
+import { SearchHelpModal } from "./SearchHelpModal";
+
+const meta = {
+  title: "Components/Search Help",
+  component: SearchHelpModal,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof SearchHelpModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * What the search can do, said in the reader's terms. Opened from the address,
+ * so the search being explained is still there behind it.
+ */
+export const Open: Story = {
+  parameters: {
+    nextjs: { navigation: { pathname: "/", query: { "search-help": "true" } } },
+  },
+  play: async () => {
+    const dialog = await screen.findByRole("dialog", { name: "How to search" });
+
+    await expect(dialog).toBeVisible();
+    // The tolerances a reader could not guess from a text box.
+    await expect(dialog).toHaveTextContent("Accents may be omitted");
+    await expect(dialog).toHaveTextContent("misspellings are tolerated");
+    // And the operators, with an example of each shape.
+    await expect(dialog).toHaveTextContent("title:iracema");
+    await expect(dialog).toHaveTextContent("year:1950-1960");
+    await expect(dialog).toHaveTextContent("-country:US");
+    await expect(dialog).toHaveTextContent(":or");
+  },
+};
+
+/** Portuguese is not a footnote: every operator answers in it. */
+export const InPortuguese: Story = {
+  parameters: {
+    nextjs: { navigation: { pathname: "/", query: { "search-help": "true" } } },
+  },
+  play: async () => {
+    const dialog = await screen.findByRole("dialog", { name: "How to search" });
+
+    await expect(dialog).toHaveTextContent("autor:");
+    await expect(dialog).toHaveTextContent("tradutor:");
+    await expect(dialog).toHaveTextContent(":ou");
+  },
+};
+
+/** Closed, it is nothing at all — the address says whether it is open. */
+export const Closed: Story = {
+  parameters: { nextjs: { navigation: { pathname: "/" } } },
+  play: async () => {
+    await expect(screen.queryByRole("dialog")).toBeNull();
+  },
+};

--- a/frontend/components/SearchHelpModal.tsx
+++ b/frontend/components/SearchHelpModal.tsx
@@ -78,7 +78,8 @@ const SearchHelp: FC = () => (
           Accents may be omitted or included; this returns <em>Angústia</em>.
         </Row>
         <Row type="casmuro">
-          Minor misspellings are tolerated when no exact match is found.
+          Minor misspellings are tolerated when no exact match is found, here
+          and within an operator alike.
         </Row>
         <Row type="mach">
           An incomplete word matches any word beginning with it, such as{" "}
@@ -112,7 +113,8 @@ const SearchHelp: FC = () => (
           Quotation marks match the words in the order given.
         </Row>
         <Row type="title:(dom casmurro)">
-          Parentheses match all the words, in any order.
+          Parentheses match all the words, in any order — and, like any other
+          word, allowing for a misspelling.
         </Row>
         <Row type="-country:US">
           A leading minus sign excludes matching records.

--- a/frontend/components/SearchHelpModal.tsx
+++ b/frontend/components/SearchHelpModal.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { FC, ReactNode } from "react";
+import { Modal, useURLQueryModal } from "./Modal";
+
+const SEARCH_HELP_MODAL_KEY = "search-help";
+
+/** One example, against what it returns. */
+const Row: FC<{ type: string; children: ReactNode }> = ({ type, children }) => (
+  <tr className="border-b border-gray-100 last:border-0">
+    <td className="py-1.5 pr-4 align-top">
+      <code className="px-1.5 py-0.5 font-mono text-xs text-indigo-800 whitespace-nowrap bg-indigo-50 rounded">
+        {type}
+      </code>
+    </td>
+    <td className="py-1.5 text-sm text-gray-600 align-top">{children}</td>
+  </tr>
+);
+
+/** A named run of rows: the tables read as one, grouped by what is being asked. */
+const Group: FC<{ title: string; children: ReactNode }> = ({
+  title,
+  children,
+}) => (
+  <tbody>
+    <tr>
+      <th
+        colSpan={2}
+        scope="colgroup"
+        className="pt-5 pb-1 text-xs font-medium tracking-wide text-left text-gray-500 uppercase"
+      >
+        {title}
+      </th>
+    </tr>
+    {children}
+  </tbody>
+);
+
+/**
+ * How to search, for the person searching.
+ *
+ * The search does a good deal that is not obvious from a text box — it forgives
+ * accents and misspellings, it narrows on every word, and it takes operators —
+ * and none of that is worth anything to a reader who cannot discover it. This
+ * states what to enter and what it returns: nothing here describes how the
+ * search works underneath, and every line is something a reader could want.
+ */
+const SearchHelp: FC = () => (
+  <div className="p-8 space-y-6 w-full">
+    <header className="space-y-1">
+      <h2 className="text-2xl font-normal">How to search</h2>
+      <p className="text-sm text-gray-600">
+        Enter any details of a publication — a title, a name, a year. Each
+        additional word narrows the results, so a record must match all of them.
+      </p>
+    </header>
+
+    <table className="w-full border-collapse">
+      <thead>
+        <tr className="border-b border-gray-300">
+          <th
+            scope="col"
+            className="py-1 pr-4 w-1/3 text-xs font-medium text-left text-gray-500"
+          >
+            Example
+          </th>
+          <th
+            scope="col"
+            className="py-1 text-xs font-medium text-left text-gray-500"
+          >
+            What it returns
+          </th>
+        </tr>
+      </thead>
+
+      <Group title="Spelling and accents">
+        <Row type="angustia">
+          Accents may be omitted or included; this returns <em>Angústia</em>.
+        </Row>
+        <Row type="casmuro">
+          Minor misspellings are tolerated when no exact match is found.
+        </Row>
+        <Row type="mach">
+          An incomplete word matches any word beginning with it, such as{" "}
+          <em>Machado</em>.
+        </Row>
+      </Group>
+
+      <Group title="Searching a single field">
+        <Row type="title:iracema">
+          Restricts the search to the title, excluding matches elsewhere in the
+          record.
+        </Row>
+        <Row type="author:machado">The author of the original work.</Row>
+        <Row type="translator:caldwell">The person who translated it.</Row>
+        <Row type="publisher:knopf">
+          Also <code className="font-mono text-xs">country:</code>,{" "}
+          <code className="font-mono text-xs">original:</code> for the original
+          title, and <code className="font-mono text-xs">source:</code> for the
+          sources a record cites.
+        </Row>
+        <Row type="year:1962">A single year.</Row>
+        <Row type="year:1950-1960">
+          A range. <code className="font-mono text-xs">year:2000-</code> runs
+          from that year onwards, and{" "}
+          <code className="font-mono text-xs">year:-1900</code> up to it.
+        </Row>
+      </Group>
+
+      <Group title="Refining a search">
+        <Row type={'title:"dom casmurro"'}>
+          Quotation marks match the words in the order given.
+        </Row>
+        <Row type="title:(dom casmurro)">
+          Parentheses match all the words, in any order.
+        </Row>
+        <Row type="-country:US">
+          A leading minus sign excludes matching records.
+        </Row>
+        <Row type="author:machado author:assis">
+          Repeating an operator requires both conditions to hold.
+        </Row>
+      </Group>
+
+      <Group title="Broadening a search">
+        <Row type="amado :or lispector">
+          Returns records matching either side, rather than both.
+        </Row>
+      </Group>
+
+      <Group title="Operators in Portuguese">
+        <Row type="titulo: autor: tradutor:">
+          The same as <code className="font-mono text-xs">title:</code>,{" "}
+          <code className="font-mono text-xs">author:</code> and{" "}
+          <code className="font-mono text-xs">translator:</code>.
+        </Row>
+        <Row type="editora: pais: ano: fonte:">
+          The same as <code className="font-mono text-xs">publisher:</code>,{" "}
+          <code className="font-mono text-xs">country:</code>,{" "}
+          <code className="font-mono text-xs">year:</code> and{" "}
+          <code className="font-mono text-xs">source:</code>.
+        </Row>
+        <Row type=":ou">
+          The same as <code className="font-mono text-xs">:or</code>.
+        </Row>
+      </Group>
+    </table>
+  </div>
+);
+
+const SearchHelpModal: FC = () => {
+  const { isOpen, close } = useURLQueryModal(SEARCH_HELP_MODAL_KEY);
+
+  return (
+    <Modal isOpen={isOpen} onClose={close} label="How to search">
+      <SearchHelp />
+    </Modal>
+  );
+};
+
+export { SEARCH_HELP_MODAL_KEY, SearchHelpModal };

--- a/frontend/e2e/browse-the-database.spec.ts
+++ b/frontend/e2e/browse-the-database.spec.ts
@@ -178,6 +178,49 @@ test("reloading with a publication open keeps it open, over the search that foun
   );
 });
 
+test("a reader narrows a search with operators, in either language", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/");
+
+  const rows = indexTable(page).getByRole("row");
+  const search = page.getByRole("textbox", { name: "Search publications" });
+
+  // The name is the author's, not any title's — so asking it of the title
+  // finds nothing while asking it of the author finds their three works.
+  await search.fill("title:Machado");
+  await expect(
+    page.getByText("No results found, try another query.").first(),
+  ).toBeVisible();
+
+  await search.fill("autor:Machado");
+  await expect(rows.filter({ hasText: "Machado de Assis" })).toHaveCount(3);
+
+  // A span of years, and the same question in English and Portuguese.
+  await search.fill("year:1952-1954");
+  await expect(rows.filter({ hasText: "Machado de Assis" })).toHaveCount(3);
+  await expect(rows.filter({ hasText: "Barren Lives" })).toHaveCount(0);
+
+  await search.fill("ano:1952-1954");
+  await expect(rows.filter({ hasText: "Machado de Assis" })).toHaveCount(3);
+
+  // An operator narrows the words beside it, and a minus excludes.
+  await search.fill("Machado -title:Casmurro");
+  await expect(rows.filter({ hasText: "Dom Casmurro" })).toHaveCount(0);
+  await expect(
+    rows.filter({ hasText: "Epitaph of a Small Winner" }),
+  ).toHaveCount(1);
+
+  // Operators belong to their own alternative.
+  await search.fill("country:GB :or editora:Knopf");
+  await expect(rows.filter({ hasText: "The Hour of the Star" })).toHaveCount(1);
+  await expect(
+    rows.filter({ hasText: "Gabriela, Clove and Cinnamon" }),
+  ).toHaveCount(1);
+  await expect(rows.filter({ hasText: "Barren Lives" })).toHaveCount(0);
+});
+
 test("a large index virtualizes: far rows render as they scroll into view", async ({
   page,
 }) => {

--- a/frontend/e2e/browse-the-database.spec.ts
+++ b/frontend/e2e/browse-the-database.spec.ts
@@ -221,6 +221,30 @@ test("a reader narrows a search with operators, in either language", async ({
   await expect(rows.filter({ hasText: "Barren Lives" })).toHaveCount(0);
 });
 
+test("a reader can find out how to search, without losing the search", async ({
+  page,
+}) => {
+  await seedCorpus(page);
+  await page.goto("/?search=Machado");
+
+  await page.getByRole("button", { name: "How to search" }).click();
+
+  const help = page.getByRole("dialog", { name: "How to search" });
+  await expect(help).toBeVisible();
+  // The things a text box cannot advertise, and the operators it takes.
+  await expect(help).toContainText("Accents may be omitted");
+  await expect(help).toContainText("title:iracema");
+  await expect(help).toContainText("autor:");
+
+  // Reading the help does not throw away what was being searched.
+  await page.keyboard.press("Escape");
+  await expect(help).toHaveCount(0);
+  await expect(page).toHaveURL(/\?search=Machado/);
+  await expect(
+    indexTable(page).getByRole("row").filter({ hasText: "Machado de Assis" }),
+  ).toHaveCount(3);
+});
+
 test("a large index virtualizes: far rows render as they scroll into view", async ({
   page,
 }) => {


### PR DESCRIPTION
A term could only be thrown at the whole record, so narrowing meant hoping the word appeared nowhere else — asking for a translator named Machado found every book he wrote instead. A term can now name the field it means.

    title:casmurro            the title alone
    autor:machado             the writer, in Portuguese
    editora:penguin           the publisher
    year:1950-1960            a span of years, open at either end
    -country:US               everything but
    title:"dom casmurro"      the phrase, in that order

Operators answer to three vocabularies — the labels the interface shows, the names the database uses, and Portuguese — so a reader of a database of Brazilian literature need not know which language it was built in. A prefix that names no field is not an operator at all but ordinary text, which keeps a colon someone typed in a title from turning into a failed query.

Each alternative `:or` separates carries its own operators, and is satisfied by its words and its operators together. Values match as free text does: from the start of a word, and fuzzily when nothing matches as typed.

A year is the one thing full-text search could not express at all — the year was only ever a word in the document, so `1950` matched but a span was impossible.

Based on #432, which introduces `:or` and which this builds the parser on top of. Retarget to `main` once that lands.