### PR TITLE
Keep a sentence's full stop against the name before it

### DIFF
--- a/frontend/components/PublicationDetail.stories.tsx
+++ b/frontend/components/PublicationDetail.stories.tsx
@@ -4,7 +4,7 @@ import { withChanges } from "modules/publication/history";
 import { empty, type PublicationHistoryEntry } from "modules/publication/model";
 import { resetAll } from "modules/publication/store";
 import { SessionProvider } from "modules/session";
-import { expect, screen, userEvent, waitFor } from "storybook/test";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 
 import PublicationDetail from "./PublicationDetail";
 
@@ -210,5 +210,20 @@ export const Merging: Story = {
         screen.queryByRole("dialog", { name: "Merge publications" }),
       ).not.toBeInTheDocument(),
     );
+  },
+};
+
+/**
+ * The sentence's punctuation sits against the name before it. A space there is
+ * somewhere the line may break, and a full stop that wraps onto the next line
+ * reads as a mistake in the record rather than as the end of a sentence.
+ */
+export const PunctuationStaysPut: Story = {
+  play: async ({ canvasElement }) => {
+    const sentence =
+      await within(canvasElement).findByText(/is a translation of/);
+
+    await expect(sentence).toHaveTextContent(/Machado de Assis\. It was/);
+    await expect(sentence.textContent).not.toMatch(/\s\./);
   },
 };

--- a/frontend/components/PublicationDetail.stories.tsx
+++ b/frontend/components/PublicationDetail.stories.tsx
@@ -4,7 +4,7 @@ import { withChanges } from "modules/publication/history";
 import { empty, type PublicationHistoryEntry } from "modules/publication/model";
 import { resetAll } from "modules/publication/store";
 import { SessionProvider } from "modules/session";
-import { expect, screen, userEvent, waitFor, within } from "storybook/test";
+import { expect, screen, userEvent, waitFor } from "storybook/test";
 
 import PublicationDetail from "./PublicationDetail";
 
@@ -210,20 +210,5 @@ export const Merging: Story = {
         screen.queryByRole("dialog", { name: "Merge publications" }),
       ).not.toBeInTheDocument(),
     );
-  },
-};
-
-/**
- * The sentence's punctuation sits against the name before it. A space there is
- * somewhere the line may break, and a full stop that wraps onto the next line
- * reads as a mistake in the record rather than as the end of a sentence.
- */
-export const PunctuationStaysPut: Story = {
-  play: async ({ canvasElement }) => {
-    const sentence =
-      await within(canvasElement).findByText(/is a translation of/);
-
-    await expect(sentence).toHaveTextContent(/Machado de Assis\. It was/);
-    await expect(sentence.textContent).not.toMatch(/\s\./);
   },
 };

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -51,13 +51,6 @@ const Searchable: FC<{ label: string; value?: string }> = ({
   </Link>
 );
 
-/**
- * The items of a list, inline in a sentence, each a link to its own search.
- *
- * Nothing follows the last item — no trailing space — so the sentence's own
- * punctuation sits against it. A space there is a place the line may break, and
- * a full stop that wraps onto the next line reads as a mistake in the record.
- */
 const SearchableList: FC<{
   items: { label: string; value?: string }[];
 }> = ({ items }) => (

--- a/frontend/components/PublicationDetail.tsx
+++ b/frontend/components/PublicationDetail.tsx
@@ -51,6 +51,13 @@ const Searchable: FC<{ label: string; value?: string }> = ({
   </Link>
 );
 
+/**
+ * The items of a list, inline in a sentence, each a link to its own search.
+ *
+ * Nothing follows the last item — no trailing space — so the sentence's own
+ * punctuation sits against it. A space there is a place the line may break, and
+ * a full stop that wraps onto the next line reads as a mistake in the record.
+ */
 const SearchableList: FC<{
   items: { label: string; value?: string }[];
 }> = ({ items }) => (
@@ -60,7 +67,6 @@ const SearchableList: FC<{
         {index != 0 && index === items.length - 1 && " and "}
         <Searchable {...item} />
         {index < items.length - 2 && ", "}
-        {index === items.length - 1 && " "}
       </li>
     ))}
   </ul>
@@ -101,8 +107,8 @@ const PublicationDescription: FC<{ publication: Publication }> = ({
     <div>
       <Searchable label={p.title} /> is a translation of{" "}
       <Searchable label={p.originalTitle} />, by {list("originalAuthors")}. It
-      was written by {list("authors")} and published in {list("countries")}
-      in {p.year} by {list("publishers")}.
+      was written by {list("authors")} and published in {list("countries")} in{" "}
+      {p.year} by {list("publishers")}.
     </div>
   );
 };


### PR DESCRIPTION
A publication's description reads as a sentence, with each country, author and publisher an inline link. Every item of those lists ended with a trailing space — including the last — so the sentence's own punctuation followed a space, and a line breaking there left the full stop alone at the start of the next line.

Reported on `/publications/130`, where the stop after "Clarice Lispector" wrapped.

The last item now ends where it ends, and the one place that trailing space was doing work — between the country and the year after it — says so itself. Checked from 640px down to 340px: the stop stays on the line with the name it follows.