### PR TITLE
Group the dependencies that are only correct together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,20 +29,46 @@ updates:
           - "@types/react"
           - "@types/react-dom"
         update-types: ["minor", "patch"]
+      # `eslint-config-next` carries Next's version, not ESLint's, and is
+      # released from the same repository. It has to follow `next` — grouped
+      # with ESLint it would be offered a Next the application is not on.
+      next:
+        patterns:
+          - "next"
+          - "eslint-config-next"
+        update-types: ["minor", "patch"]
       vitest:
         patterns:
           - "vitest"
           - "@vitest/*"
         update-types: ["minor", "patch"]
+      # The Vite plugins name a Vite major as their peer, so they are only ever
+      # correct against the Vite beside them.
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"
+        update-types: ["minor", "patch"]
       tailwind:
         patterns:
           - "tailwindcss"
           - "@tailwindcss/*"
+          - "tailwind-scrollbar"
         update-types: ["minor", "patch"]
       playwright:
         patterns:
           - "playwright"
           - "@playwright/*"
+        update-types: ["minor", "patch"]
+      jotai:
+        patterns:
+          - "jotai"
+          - "jotai-*"
+        update-types: ["minor", "patch"]
+      stylelint:
+        patterns:
+          - "stylelint"
+          - "stylelint-config-*"
         update-types: ["minor", "patch"]
       eslint:
         patterns:
@@ -50,6 +76,8 @@ updates:
           - "eslint-*"
           - "@eslint/*"
           - "typescript-eslint"
+        exclude-patterns:
+          - "eslint-config-next"
         update-types: ["minor", "patch"]
     # The Node types describe the runtime this project pins, so their major is
     # not ours to choose: it follows `.tool-versions`, and a major ahead of it
@@ -76,6 +104,19 @@ updates:
           - "ecto"
           - "ecto_*"
           - "postgrex"
+        update-types: ["minor", "patch"]
+      # Both halves of the Plug stack, and both telemetry collectors, are
+      # released from one repository each and are only tested against their
+      # own sibling.
+      plug:
+        patterns:
+          - "plug"
+          - "plug_cowboy"
+        update-types: ["minor", "patch"]
+      telemetry:
+        patterns:
+          - "telemetry"
+          - "telemetry_*"
         update-types: ["minor", "patch"]
 
   # The workflows pin their actions, and those pins go stale silently — checkout


### PR DESCRIPTION
Some dependencies are only correct against the version of the one beside them, and Dependabot was offering several of those one at a time.

`eslint-config-next` was the one actually wrong. It matched the ESLint group's `eslint-*` pattern, but it carries Next's version and ships from Next's repository — grouped there it could be offered a Next the application is not on. It follows `next` now, and the ESLint group says explicitly that it does not want it.

The rest follow the rule the file already states: a peer that names a version is not satisfied by a sibling left behind. Vite and its plugins, Jotai and its companion, Stylelint and its config, Tailwind and its scrollbar plugin, Plug and its adapter, and both telemetry collectors each arrive as one pull request now.

Every pairing was checked against the peer range the installed package actually declares rather than assumed from the name — which is also why `cors_plug` stays out of the Plug group.
